### PR TITLE
[Bug] Ensure that a `reuse-existing-token` policy responds back with a unique `tokenId`

### DIFF
--- a/src/services/mapping.ts
+++ b/src/services/mapping.ts
@@ -103,3 +103,7 @@ export const assetCreationResult = (cid: string, tokenId: string, tokenAddress: 
     } as AssetCreateResponse
   } as CreateAssetResponse;
 }
+
+export function getRandomNumber(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}


### PR DESCRIPTION
FinP2P router won't accept the result and fail on asset creation, because of the new tokenId uniqueness constraint being introduced