### PR TITLE
[Task] Bump finp2p-client to 0.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "TBD",
       "dependencies": {
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
-        "@owneraio/finp2p-client": "^0.26.0",
-        "@owneraio/finp2p-contracts": "file:finp2p-contracts",
+        "@owneraio/finp2p-client": "^0.27.0",
+        "@owneraio/finp2p-contracts": "^0.27.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.27.1",
         "@types/node": "^24.10.1",
         "axios": "^1.1.3",
@@ -1553,9 +1553,9 @@
       "license": "ISC"
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.26.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.26.0/b76ca1c4eab14c8c6bdcf5eddf0e0366334bd226",
-      "integrity": "sha512-fHm6d5pMslOFVO4Jb02T8VQYmNg0OaUPQ+i0Eao3UxEECSe1/81p7TVWVj/h0aEKNVfm0Sc4DsBaYOmvpohAqw==",
+      "version": "0.27.0",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.27.0/8a457688c53d70fd2a67dc417c2684f83200e5af",
+      "integrity": "sha512-TtWdQQvL3z1/Aoh3DDr/s9g9lxaDUFcKxHhNacMSwzv/t/SzcEe9lvcLpVXeuN4lUU+0Mh9OslQI6gVxjJTJ+Q==",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
@@ -1603,28 +1603,6 @@
         "pg": "^8.15.6",
         "secp256k1": "^3.7.1",
         "winston": "^3.18.3"
-      }
-    },
-    "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter/node_modules/@owneraio/finp2p-client": {
-      "version": "0.27.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.27.0/8a457688c53d70fd2a67dc417c2684f83200e5af",
-      "integrity": "sha512-TtWdQQvL3z1/Aoh3DDr/s9g9lxaDUFcKxHhNacMSwzv/t/SzcEe9lvcLpVXeuN4lUU+0Mh9OslQI6gVxjJTJ+Q==",
-      "license": "ISC",
-      "dependencies": {
-        "axios": "^1.12.2",
-        "graphql": "^16.8.1",
-        "graphql-import-node": "^0.0.5",
-        "openapi-fetch": "0.14.0"
-      }
-    },
-    "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter/node_modules/@owneraio/finp2p-client/node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter/node_modules/axios": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "TBD",
   "dependencies": {
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
-    "@owneraio/finp2p-client": "^0.26.0",
+    "@owneraio/finp2p-client": "^0.27.0",
     "@owneraio/finp2p-contracts": "^0.27.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.27.1",
     "@types/node": "^24.10.1",


### PR DESCRIPTION
## Summary
- Bump `@owneraio/finp2p-client` from `^0.26.0` to `^0.27.0`
- Aligns all `@owneraio` dependencies to 0.27.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)