### PR TITLE
Add admin fund endpoint for E2E test setup

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,9 @@ import {
   CommonServiceImpl as DirectCommonServiceImpl,
   HealthServiceImpl as DirectHealthServiceImpl,
 } from "./services/direct"
+import { ERC20Contract, finIdToAddress } from "@owneraio/finp2p-contracts";
+import { parseUnits, parseEther } from "ethers";
+import { createFireblocksEthersProvider } from "./config";
 
 async function createApp(
   workflowsConfig: workflows.Config | undefined,
@@ -55,6 +58,67 @@ async function createApp(
       const healthService = new DirectHealthServiceImpl(custodyProvider.healthCheckProvider);
 
       register(app, tokenService, tokenService, commonService, healthService, paymentsService, planApprovalService, pluginManager, workflowsConfig);
+
+      // Admin endpoint: fund an investor's wallet with ERC20 tokens or native ETH
+      app.post('/api/admin/fund', async (req, res) => {
+        try {
+          const { finId, amount, tokenAddress, sourceVaultId, native, assetId } = req.body as {
+            finId: string; amount: string; tokenAddress?: string; sourceVaultId?: string;
+            native?: boolean; assetId?: string;
+          };
+          const address = finIdToAddress(finId);
+
+          // Native ETH via Fireblocks vault-to-vault transfer (reliable, polls for completion)
+          if (native && appConfig.type === 'fireblocks' && sourceVaultId) {
+            const fb = custodyProvider as FireblocksCustodyProvider;
+            const targetVaultId = await fb.getVaultIdForAddress(address);
+            if (!targetVaultId) throw new Error(`No Fireblocks vault found for address ${address}`);
+            const fbAssetId = assetId ?? 'ETH_TEST5';
+            await fb.transferBetweenVaults(sourceVaultId, targetVaultId, fbAssetId, amount);
+            logger.info(`Vault-to-vault funded ${amount} ${fbAssetId} to vault ${targetVaultId} (${address}) from vault ${sourceVaultId}`);
+            res.json({ success: true, to: address, amount, native: true, fromVault: sourceVaultId, toVault: targetVaultId });
+            return;
+          }
+
+          // Use explicit source vault or fall back to escrow
+          let wallet;
+          if (sourceVaultId && appConfig.type === 'fireblocks') {
+            wallet = await createFireblocksEthersProvider({
+              apiKey: appConfig.apiKey,
+              privateKey: appConfig.apiPrivateKey,
+              chainId: appConfig.chainId,
+              apiBaseUrl: appConfig.apiBaseUrl,
+              vaultAccountIds: [sourceVaultId],
+            });
+          } else {
+            wallet = custodyProvider.escrow;
+          }
+
+          if (native) {
+            // Fallback: Web3 sendTransaction
+            const tx = await wallet.signer.sendTransaction({
+              to: address,
+              value: parseEther(amount),
+            });
+            const receipt = await tx.wait();
+            logger.info(`Funded ${amount} ETH to ${address} (finId: ${finId}) from vault ${sourceVaultId ?? 'escrow'}, tx: ${receipt?.hash}`);
+            res.json({ success: true, txHash: receipt?.hash, to: address, amount, native: true });
+          } else {
+            // Send ERC20 tokens
+            const c = new ERC20Contract(wallet.provider, wallet.signer, tokenAddress!, logger);
+            const decimals = await c.decimals();
+            const rawAmount = parseUnits(amount, decimals);
+            const tx = await c.transfer(address, rawAmount);
+            const receipt = await tx.wait();
+            logger.info(`Funded ${amount} tokens to ${address} (finId: ${finId}) from vault ${sourceVaultId ?? 'escrow'}, tx: ${receipt?.hash}`);
+            res.json({ success: true, txHash: receipt?.hash, to: address, amount });
+          }
+        } catch (e: any) {
+          logger.error(`Fund failed: ${e.message ?? e}`);
+          res.status(500).json({ error: String(e) });
+        }
+      });
+
       break
     }
     case 'finp2p-contract': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ const init = async () => {
 
   const level = process.env.LOG_LEVEL || "info";
   const logger = winston.createLogger({
+    levels: winston.config.syslog.levels,
     level,
     transports: [new transports.Console()],
     format: format.combine(

--- a/src/services/direct/fireblocks-provider.ts
+++ b/src/services/direct/fireblocks-provider.ts
@@ -68,6 +68,14 @@ export class FireblocksCustodyProvider implements CustodyProvider {
     });
   }
 
+  async transferBetweenVaults(fromVaultId: string, toVaultId: string, assetId: string, amount: string): Promise<void> {
+    await this.vaultManagement.transferAssetFromVaultToVault(this.fireblocksSdk, fromVaultId, toVaultId, assetId, amount);
+  }
+
+  async getVaultIdForAddress(address: string): Promise<string | undefined> {
+    return this.vaultManagement.getVaultIdForAddress(address);
+  }
+
   async onAssetRegistered(tokenAddress: string, symbol?: string): Promise<void> {
     const responseRegister = await this.fireblocksSdk.registerNewAsset(
       'ETH_TEST5', tokenAddress, symbol


### PR DESCRIPTION
## Summary
- Add `POST /api/admin/fund` endpoint (Fireblocks/DFNS mode only) for E2E test setup — funds investor wallets with ERC20 tokens or native ETH
- For Fireblocks native ETH transfers, use SDK vault-to-vault transfer (`transferAssetFromVaultToVault`) which polls for completion, instead of Web3 `sendTransaction`
- Expose `transferBetweenVaults()` and `getVaultIdForAddress()` on `FireblocksCustodyProvider`
- Fix winston logger levels to use syslog config

## Test plan
- [x] Built adapter image and deployed to local k3d cluster
- [x] E2E dvp-cross flow with real Fireblocks Sepolia USDC passed (3 investors funded with gas ETH + USDC via this endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)