### PR TITLE
Update dtcc-plugin to 0.27.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.27.12",
+  "version": "0.27.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-ethereum-adapter",
-      "version": "0.27.12",
+      "version": "0.27.13",
       "hasInstallScript": true,
       "license": "TBD",
       "dependencies": {
@@ -16,7 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.27.7",
         "@owneraio/finp2p-contracts": "^0.27.10",
-        "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.27.43",
+        "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.27.44",
         "@owneraio/finp2p-ethereum-token-standard": "^0.27.10",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.27.17",
         "@owneraio/finp2p-vanilla-service": "^0.27.7",
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-dtcc-plugin": {
-      "version": "0.27.43",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-dtcc-plugin/0.27.43/bf15d154b375ee5baa6024364f477d9954558afd",
-      "integrity": "sha512-QeaTUqrnqBvczM4UhhuciUv94oYEwf9VzTXpzqPHWFtGZKg/pxgX5S5/S63vZQcZni4znqjky/vNPZJ6/2uv+Q==",
+      "version": "0.27.44",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-dtcc-plugin/0.27.44/6e75bafe7dc22f9029668ff907ce13eca6bc85a0",
+      "integrity": "sha512-F4Fw5zXritn+F3EFvC0rN9RC6ex0gtPxtDkDWetrigaJn7vLs9Gb1rkDdBbWUTvAewRiy/8B4Yzfp2TRWmVF4w==",
       "license": "ISC",
       "peerDependencies": {
         "@owneraio/finp2p-client": "^0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.27.13",
+  "version": "0.27.14",
   "description": "",
   "main": "dist/src/index.js",
   "homepage": "https://ownera.io/",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.27.7",
     "@owneraio/finp2p-contracts": "^0.27.10",
-    "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.27.43",
+    "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.27.44",
     "@owneraio/finp2p-ethereum-token-standard": "^0.27.10",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.27.17",
     "@owneraio/finp2p-vanilla-service": "^0.27.7",


### PR DESCRIPTION
## Summary
- Update `@owneraio/finp2p-ethereum-dtcc-plugin` to `0.27.44`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)