### PR TITLE
Fix: wrap payments service with workflow proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.27.16",
+  "version": "0.27.17",
   "description": "",
   "main": "dist/src/index.js",
   "homepage": "https://ownera.io/",

--- a/src/app.ts
+++ b/src/app.ts
@@ -81,7 +81,8 @@ function registerDirectServices(
     const proxiedPlanService = wrapWithWorkflowProxy(planApprovalService, workflowStorage, finP2PClient, 'approvePlan', 'proposeCancelPlan', 'proposeResetPlan', 'proposeInstructionApproval');
     const proxiedTokenService = wrapWithWorkflowProxy(tokenService, workflowStorage, finP2PClient, 'createAsset', 'issue', 'transfer', 'redeem');
     const proxiedEscrowService = wrapWithWorkflowProxy(escrowService, workflowStorage, finP2PClient, 'hold', 'release', 'rollback');
-    register(app, proxiedTokenService, proxiedEscrowService, commonService, commonService, delegate, proxiedPlanService, mappingConfig, mappingService);
+    const proxiedPaymentService = wrapWithWorkflowProxy(delegate, workflowStorage, finP2PClient, 'getDepositInstruction', 'payout');
+    register(app, proxiedTokenService, proxiedEscrowService, commonService, commonService, proxiedPaymentService, proxiedPlanService, mappingConfig, mappingService);
     if (distributionService) {
       registerDistributionRoutes(app, distributionService);
     }
@@ -97,7 +98,8 @@ function registerDirectServices(
   const proxiedTokenService = wrapWithWorkflowProxy(tokenService, workflowStorage, finP2PClient, 'createAsset', 'issue', 'transfer', 'redeem');
   const proxiedEscrowService = wrapWithWorkflowProxy(tokenService, workflowStorage, finP2PClient, 'hold', 'release', 'rollback');
   const proxiedPlanService = wrapWithWorkflowProxy(planApprovalService, workflowStorage, finP2PClient, 'approvePlan', 'proposeCancelPlan', 'proposeResetPlan', 'proposeInstructionApproval');
-  register(app, proxiedTokenService, proxiedEscrowService, commonService, healthService, paymentsService, proxiedPlanService, mappingConfig, accountMappingService);
+  const proxiedPaymentsService = wrapWithWorkflowProxy(paymentsService, workflowStorage, finP2PClient, 'getDepositInstruction', 'payout');
+  register(app, proxiedTokenService, proxiedEscrowService, commonService, healthService, proxiedPaymentsService, proxiedPlanService, mappingConfig, accountMappingService);
 }
 
 function registerFinP2PContractServices(


### PR DESCRIPTION
## Summary
- PaymentsService (`getDepositInstruction`, `payout`) was not wrapped with the workflow proxy
- Deposit operations ran synchronously within the HTTP request, causing 90s timeouts for long-running flows (e.g. DTCC collateral with multiple on-chain txs)
- Now proxied in both direct and omnibus paths — returns CID immediately, executes async

## Test plan
- [ ] CI passes
- [ ] DTCC deposit returns CID immediately instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)