### PR TITLE
Make Fireblocks asset registration idempotent on 409

### DIFF
--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -1,4 +1,5 @@
 import { FireblocksSDK } from 'fireblocks-sdk';
+import axios from 'axios';
 import { createFireblocksEthersProvider, FireblocksAppConfig } from './config';
 import { createVaultManagementFunctions } from '../../vaults';
 import { CustodyProvider, CustodyWallet, GasStation } from '../../services/direct';
@@ -125,12 +126,11 @@ export class FireblocksCustodyProvider implements CustodyProvider {
 
   async onAssetRegistered(tokenAddress: string, symbol?: string): Promise<void> {
     if (this.config.localSubmit) return;
-    const responseRegister = await this.fireblocksSdk.registerNewAsset(
-      'ETH_TEST5', tokenAddress, symbol
-    );
-    const vaultId = this.config.assetIssuerVaultId ?? this.config.omnibusVaultId;
-    if (vaultId) {
-      await this.fireblocksSdk.createVaultAsset(vaultId, responseRegister.legacyId);
+    try {
+      await this.fireblocksSdk.registerNewAsset('ETH_TEST5', tokenAddress, symbol);
+    } catch (e) {
+      if (axios.isAxiosError(e) && e.response?.status === 409) return; // already registered — idempotent
+      throw e;
     }
   }
 }

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -295,11 +295,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
 
     const tokenAddress = assetBind.tokenIdentifier.tokenId;
     await this.assetStore.saveAsset({ contract_address: tokenAddress, decimals, token_standard: tokenStandard, id: assetId });
-    try {
-      await this.custodyProvider.onAssetRegistered?.(tokenAddress);
-    } catch (e) {
-      this.logger.warn(`Asset registration failed (may already exist): ${e}`);
-    }
+    await this.custodyProvider.onAssetRegistered?.(tokenAddress);
     return { ledgerIdentifier: makeLedgerIdentifier(tokenAddress, tokenStandard), reference: undefined };
   }
 }

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -111,11 +111,7 @@ export class DirectTokenService implements TokenService, EscrowService {
         id: assetId,
       });
 
-      try {
-        await this.custodyProvider.onAssetRegistered?.(tokenAddress);
-      } catch (e) {
-        this.logger.warn(`Asset registration failed (may already exist): ${e}`);
-      }
+      await this.custodyProvider.onAssetRegistered?.(tokenAddress);
 
       return {
         operation: "createAsset",


### PR DESCRIPTION
## Summary
Fixes the noisy `Asset registration failed (may already exist): AxiosError: Request failed with status code 409` warning seen on asset creation — and, more importantly, the silent partial failure it was masking.

- [src/integrations/fireblocks/provider.ts](src/integrations/fireblocks/provider.ts): `onAssetRegistered` now only calls `registerNewAsset` and catches a 409 as success (asset already registered globally). Dropped the in-line `createVaultAsset` call — attaching an asset to a specific vault is a mint/deposit-time concern, not a global-registration concern.
- [src/services/direct/token-service.ts](src/services/direct/token-service.ts) and [src/services/direct/omnibus-delegate.ts](src/services/direct/omnibus-delegate.ts): dropped the outer try/catch + "may already exist" warning. Any remaining error from `onAssetRegistered` is now a genuine failure that should propagate.

## Why this is a bug, not just noise
Before the fix: if `registerNewAsset` 409'd, we lost `responseRegister.legacyId`, so the subsequent `createVaultAsset` call was skipped. The outer try/catch swallowed the error and logged a warning. Net effect: the asset may have been globally registered but **not attached to the issuer/omnibus vault**, and nobody knew.

After the fix: registration is idempotent, and vault attachment happens at the appropriate step (mint/deposit) where the failure mode is clear and surfaced.

## Not a regression from #213
Master never had the idempotent handling — this is a pre-existing bug that became visible now.

## Test plan
- [ ] CI green
- [ ] Create an asset whose contract address is already registered in Fireblocks — expect no warning, no failure
- [ ] Create an asset that isn't registered — expect a successful `registerNewAsset` call
- [ ] Confirm no regression on Fireblocks LOCAL_SUBMIT mode (early return unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)