### PR TITLE
FINP2POperator 0.28.4: restore full asset association API

### DIFF
--- a/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
+++ b/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
@@ -26,7 +26,7 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
     using StringUtils for uint256;
     using FinIdUtils for string;
 
-    string public constant VERSION = "0.28.3";
+    string public constant VERSION = "0.28.4";
 
     bytes32 private constant ASSET_MANAGER = keccak256("ASSET_MANAGER");
     bytes32 private constant TRANSACTION_MANAGER = keccak256("TRANSACTION_MANAGER");
@@ -54,6 +54,11 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
     /// @notice Redeem event
     event Redeem(string assetId, AssetType assetType, string ownerFinId, string quantity, string operationId);
 
+    struct Asset {
+        string id;
+        address tokenAddress;
+    }
+
     struct Lock {
         string assetId;
         AssetType assetType;
@@ -68,10 +73,10 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
     // Credentials: finId -> wallet address
     mapping(string => address) private credentials;
 
-    // Fallback assetId → ERC20 mapping for signers that don't yet emit CAIP-style
-    // assetIds inline. `_extractTokenAddress(assetId)` is tried first; this map is
-    // only consulted when the parser returns address(0).
-    mapping(string => address) private assetTokens;
+    // assetId → ERC20 fallback registry. Operational resolution prefers the
+    // CAIP-encoded tokenAddress carried inline in the assetId; this map is
+    // only consulted when the parser returns address(0) (legacy signers).
+    mapping(string => Asset) private assets;
 
     constructor(address admin) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
@@ -127,20 +132,34 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
         return credentials[finId];
     }
 
-    // ---- Asset resolution ----
-    // Primary: the assetId in each EIP712 Term carries the ERC20 contract address
-    // inline — "name: <net>, chainId: <id>/<standard>:0x<40-hex>" — and
-    // _extractTokenAddress(assetId) parses it out.
-    // Fallback: for signers that still emit plain resourceIds (e.g. adapter-tests
-    // legacy builders), `associateAsset(assetId, tokenAddress)` registers a
-    // lookup so the operator can still resolve the token address.
+    // ---- Asset registry (fallback) ----
+    // Operational resolution prefers the CAIP-encoded tokenAddress carried inline
+    // in the EIP712 Term.assetId (e.g. "name: <net>, chainId: <id>/<standard>:0x<40-hex>").
+    // The registry below is consulted only when `_extractTokenAddress` returns
+    // address(0) — i.e. for legacy signers that emit plain resourceIds.
 
-    /// @notice Register an assetId → ERC20 fallback mapping. Only consulted when
-    /// the assetId doesn't carry the tokenAddress inline.
+    /// @notice Register an assetId → ERC20 fallback mapping.
     function associateAsset(string calldata assetId, address tokenAddress) external {
         require(hasRole(ASSET_MANAGER, _msgSender()), "FINP2POperator: must have asset manager role to associate asset");
+        require(!_haveAsset(assetId), "Asset already exists");
         require(tokenAddress != address(0), "Token address cannot be zero");
-        assetTokens[assetId] = tokenAddress;
+        assets[assetId] = Asset(assetId, tokenAddress);
+    }
+
+    /// @notice Remove an asset from the fallback registry.
+    function removeAsset(string calldata assetId) external {
+        require(hasRole(ASSET_MANAGER, _msgSender()), "FINP2POperator: must have asset manager role to remove asset");
+        require(_haveAsset(assetId), "Asset not found");
+        delete assets[assetId];
+    }
+
+    /// @notice Look up the ERC20 address registered for `assetId`.
+    /// @dev Only reflects the fallback registry; does NOT parse CAIP-encoded
+    ///      assetIds. Use _resolveToken(assetId) inside the contract to honor
+    ///      the parser-first / registry-fallback resolution order.
+    function getAssetAddress(string calldata assetId) external view returns (address) {
+        require(_haveAsset(assetId), "Asset not found");
+        return assets[assetId].tokenAddress;
     }
 
     /// @notice Get the balance of an asset for a FinID.
@@ -320,6 +339,10 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
         return credentials[finId] != address(0);
     }
 
+    function _haveAsset(string memory assetId) internal view returns (bool) {
+        return assets[assetId].tokenAddress != address(0);
+    }
+
     /// @notice Resolve finId to wallet address via credentials mapping
     function _resolveAddress(string memory finId) internal view returns (address) {
         address addr = credentials[finId];
@@ -333,7 +356,7 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
     function _resolveToken(string memory assetId) internal view returns (address) {
         address parsed = _extractTokenAddress(assetId);
         if (parsed != address(0)) return parsed;
-        return assetTokens[assetId];
+        return assets[assetId].tokenAddress;
     }
 
     /// @notice Extracts the ERC20 contract address from a CAIP-style assetId

--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.8",
+  "version": "0.28.9",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-contracts/src/finp2p.ts
+++ b/finp2p-contracts/src/finp2p.ts
@@ -64,6 +64,16 @@ export class FinP2PContract extends ContractsManager {
     });
   }
 
+  async removeAsset(assetId: string) {
+    return this.safeExecuteTransaction(this.finP2P, async (finP2P: FINP2POperator, txParams: PayableOverrides) => {
+      return finP2P.removeAsset(assetId, txParams);
+    });
+  }
+
+  async getAssetAddress(assetId: string) {
+    return this.finP2P.getAssetAddress(assetId);
+  }
+
   async addCredential(finId: string, address: string) {
     return this.safeExecuteTransaction(this.finP2P, async (finP2P: FINP2POperator, txParams: PayableOverrides) => {
       return finP2P.addCredential(finId, address, txParams);


### PR DESCRIPTION
## Summary
PR #218 (Solidity 0.28.3) introduced a minimal `associateAsset` so legacy plain-resourceId signers (adapter-tests builders, etc.) can still resolve a tokenAddress through a fallback registry. This PR fleshes the registry surface back to its pre-0.28.2 shape so operator tooling that depends on the older API keeps working.

### Solidity (FINP2POperator.sol, VERSION 0.28.3 → 0.28.4)
- Restore `struct Asset { id, tokenAddress }`; rename storage `assetTokens` → `assets`
- `associateAsset` regains its `require(!_haveAsset(assetId))` guard; writes the struct
- Restore `removeAsset(assetId)` and `getAssetAddress(assetId)`
- Restore internal `_haveAsset(assetId)` helper
- `_resolveToken` keeps parser-first / registry-fallback resolution unchanged

### TS wrapper (`finp2p-contracts` 0.28.8 → 0.28.9)
- Restore `FinP2PContract.removeAsset` and `FinP2PContract.getAssetAddress`

### Not changed
- `FINP2POperatorWithRegistry` — explicitly out of scope per prior decisions
- `_resolveToken` order (CAIP parse → registry fallback) — same as 0.28.3

### Test plan
- [x] All 133 hardhat tests pass locally
- [ ] CI green
- [ ] Adapter integration suite still green (uses `associateAsset` for legacy fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)