### PR TITLE
Strip empty executionContext from receipt tradeDetails

### DIFF
--- a/src/services/finp2p-contract/mapping.ts
+++ b/src/services/finp2p-contract/mapping.ts
@@ -11,9 +11,21 @@ function mapAccount(acc: { finId: string; account?: string } | undefined) {
  * Map a contracts ReceiptOperation to the skeleton's shape.
  * Optionally overrides the receipt's asset with the caller's full asset
  * (which carries ledgerIdentifier the on-chain contract doesn't know about).
+ *
+ * Strips an empty `tradeDetails.executionContext` — finp2p-contracts
+ * seeds it with `{ planId: "", sequence: 0 }` when there's no real plan,
+ * and the router rejects empty `executionPlanId` strings.
  */
 export function mapReceiptOperation(op: ContractReceiptOperation, asset?: Asset): ReceiptOperation {
   if (op.type !== 'success') return op as any;
+  const rawTradeDetails = (op.receipt as any).tradeDetails;
+  const exCtx = rawTradeDetails?.executionContext;
+  const hasRealExCtx = exCtx && typeof exCtx.planId === 'string' && exCtx.planId.trim().length > 0;
+  const tradeDetails = hasRealExCtx
+    ? rawTradeDetails
+    : rawTradeDetails
+      ? { ...rawTradeDetails, executionContext: undefined }
+      : undefined;
   return {
     ...op,
     receipt: {
@@ -21,6 +33,7 @@ export function mapReceiptOperation(op: ContractReceiptOperation, asset?: Asset)
       asset: asset ?? op.receipt.asset,
       source: mapAccount(op.receipt.source as any),
       destination: mapAccount(op.receipt.destination as any),
+      tradeDetails,
     },
   } as any;
 }


### PR DESCRIPTION
## Problem

Router rejects adapter callbacks for finp2p-contract receipts with:

> Invalid format for field: \"response.tradeDetails.executionContext.executionPlanId\", The required format is: .*\\S.*

## Root cause

[finp2p-contracts' parseTransactionReceipt](https://github.com/owneraio/finp2p-ethereum-adapter/blob/master/finp2p-contracts/src/utils.ts) seeds every receipt with `tradeDetails: { executionContext: { planId: \"\", sequence: 0 } }` and our adapter's [mapReceiptOperation](src/services/finp2p-contract/mapping.ts) passes it through unchanged.

The skeleton's `executionContextOptToAPI` treats only `undefined` as absent, so it emits `{ executionPlanId: \"\", instructionSequenceNumber: 0 }` — which violates the router schema's non-whitespace regex on `executionPlanId`.

## Fix

At the boundary `mapReceiptOperation`, drop `executionContext` when `planId` is missing or whitespace-only. `receiptTradeDetails.executionContext` is optional in the API schema, so omission is valid. When a real execution context is present, pass it through unchanged.

## Out of scope

The second router error — _\"input does not contain the discriminator property 'type'\"_ — couldn't be pinpointed from the OpenAPI schemas. It may be a cascade from the malformed `executionContext` or a separate validator difference; will revisit if it persists after this fix.

## Test plan
- [ ] CI green (existing signature + receipt tests cover the mapping path)
- [ ] Manually verify a failed transfer now produces a callback the router accepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)