### PR TITLE
CI: build on release/** branches + allow manual workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - 'master'
+      - 'release/**'
     tags:
       - 'v0.**'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -77,7 +79,7 @@ jobs:
         run: |
           set -euxo pipefail
           case $GITHUB_EVENT_NAME in
-            push)
+            push|workflow_dispatch)
               IMAGE_TAG=$GITHUB_REF_NAME
               ;;
             pull_request)


### PR DESCRIPTION
## Summary
Two additions to the CI triggers so we can build images from release branches without having to tag:

- **\`release/**\` push trigger** — pushing to \`release/v0.28\`, \`release/v0.29\`, etc. produces images like \`ghcr.io/owneraio/finp2p-ethereum-adapter:release-v0.28\`.
- **\`workflow_dispatch\`** — adds a \"Run workflow\" button in the Actions UI so the pipeline can be triggered manually against any branch/ref.

Also updates the \`Set Docker tags\` step to handle \`workflow_dispatch\` (same as \`push\` — uses \`GITHUB_REF_NAME\`).

## Why
Release branches are intentionally divergent from master and shouldn't be merged back, so a PR-based CI trigger doesn't fit. A real release tag (\`v0.28.0\`) should stay aligned with \`package.json\` — can't bump it prematurely just to force a build.

## Test plan
- [ ] CI runs on this PR (validates the YAML + existing test suite)
- [ ] After merge: push a nop commit to \`release/v0.28\` to confirm the image builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)