### PR TITLE
Revert 0.28 signature template changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ node_modules
 /finp2p-contracts/typechain-types/
 /finp2p-contracts/dist/
 /finp2p-contracts/cache/
-/finp2p-contracts/contracts/scratch/
-/finp2p-contracts/test/scratch/
 /bin/
 .env.fireblocks
 .env.dfns

--- a/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
+++ b/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
@@ -26,7 +26,7 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
     using StringUtils for uint256;
     using FinIdUtils for string;
 
-    string public constant VERSION = "0.28.4";
+    string public constant VERSION = "0.28.0";
 
     bytes32 private constant ASSET_MANAGER = keccak256("ASSET_MANAGER");
     bytes32 private constant TRANSACTION_MANAGER = keccak256("TRANSACTION_MANAGER");
@@ -68,15 +68,11 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
     }
 
     address private escrowWalletAddress;
+    mapping(string => Asset) private assets;
     mapping(string => Lock) private locks;
 
     // Credentials: finId -> wallet address
     mapping(string => address) private credentials;
-
-    // assetId → ERC20 fallback registry. Operational resolution prefers the
-    // CAIP-encoded tokenAddress carried inline in the assetId; this map is
-    // only consulted when the parser returns address(0) (legacy signers).
-    mapping(string => Asset) private assets;
 
     constructor(address admin) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
@@ -132,13 +128,11 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
         return credentials[finId];
     }
 
-    // ---- Asset registry (fallback) ----
-    // Operational resolution prefers the CAIP-encoded tokenAddress carried inline
-    // in the EIP712 Term.assetId (e.g. "name: <net>, chainId: <id>/<standard>:0x<40-hex>").
-    // The registry below is consulted only when `_extractTokenAddress` returns
-    // address(0) — i.e. for legacy signers that emit plain resourceIds.
+    // ---- Asset management ----
 
-    /// @notice Register an assetId → ERC20 fallback mapping.
+    /// @notice Associate an asset with a token address
+    /// @param assetId The asset id
+    /// @param tokenAddress The token address
     function associateAsset(string calldata assetId, address tokenAddress) external {
         require(hasRole(ASSET_MANAGER, _msgSender()), "FINP2POperator: must have asset manager role to associate asset");
         require(!_haveAsset(assetId), "Asset already exists");
@@ -146,33 +140,35 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
         assets[assetId] = Asset(assetId, tokenAddress);
     }
 
-    /// @notice Remove an asset from the fallback registry.
+    /// @notice Remove an asset
+    /// @param assetId The asset id
     function removeAsset(string calldata assetId) external {
         require(hasRole(ASSET_MANAGER, _msgSender()), "FINP2POperator: must have asset manager role to remove asset");
         require(_haveAsset(assetId), "Asset not found");
         delete assets[assetId];
     }
 
-    /// @notice Look up the ERC20 address registered for `assetId`.
-    /// @dev Only reflects the fallback registry; does NOT parse CAIP-encoded
-    ///      assetIds. Use _resolveToken(assetId) inside the contract to honor
-    ///      the parser-first / registry-fallback resolution order.
+    /// @notice Get the token address of an asset
+    /// @param assetId The asset id
+    /// @return The token address
     function getAssetAddress(string calldata assetId) external view returns (address) {
         require(_haveAsset(assetId), "Asset not found");
         return assets[assetId].tokenAddress;
     }
 
-    /// @notice Get the balance of an asset for a FinID.
-    /// @return The balance as a decimal string, or "0" if the asset is off-chain.
+    /// @notice Get the balance of an asset for a FinID
+    /// @param assetId The asset id
+    /// @param finId The FinID
+    /// @return The balance of the asset
     function getBalance(
         string calldata assetId,
         string calldata finId
     ) external view returns (string memory) {
-        address tokenAddress = _resolveToken(assetId);
-        if (tokenAddress == address(0)) return "0";
+        require(_haveAsset(assetId), "Asset not found");
         address addr = _resolveAddress(finId);
-        uint8 tokenDecimals = IERC20Metadata(tokenAddress).decimals();
-        uint256 tokenBalance = IERC20(tokenAddress).balanceOf(addr);
+        Asset memory asset = assets[assetId];
+        uint8 tokenDecimals = IERC20Metadata(asset.tokenAddress).decimals();
+        uint256 tokenBalance = IERC20(asset.tokenAddress).balanceOf(addr);
         return tokenBalance.uintToString(tokenDecimals);
     }
 
@@ -331,16 +327,16 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
 
     // ------------------------------------------------------------------------------------------
 
+    function _haveAsset(string memory assetId) internal view returns (bool exists) {
+        exists = (assets[assetId].tokenAddress != address(0));
+    }
+
     function _haveContract(string memory operationId) internal view returns (bool exists) {
         exists = (bytes(locks[operationId].amount).length > 0);
     }
 
     function _haveCredential(string memory finId) internal view returns (bool) {
         return credentials[finId] != address(0);
-    }
-
-    function _haveAsset(string memory assetId) internal view returns (bool) {
-        return assets[assetId].tokenAddress != address(0);
     }
 
     /// @notice Resolve finId to wallet address via credentials mapping
@@ -350,66 +346,32 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
         return addr;
     }
 
-    /// @notice Resolve an assetId to an ERC20 contract address.
-    ///         First tries to parse it inline (CAIP-style); falls back to the
-    ///         associateAsset registry; returns address(0) if neither yields a token.
-    function _resolveToken(string memory assetId) internal view returns (address) {
-        address parsed = _extractTokenAddress(assetId);
-        if (parsed != address(0)) return parsed;
-        return assets[assetId].tokenAddress;
-    }
-
-    /// @notice Extracts the ERC20 contract address from a CAIP-style assetId
-    ///         of the form: "...<prefix>/<standard>:0x<40-hex>"
-    /// Returns address(0) if the assetId doesn't end with that pattern (e.g.
-    /// "vanilla/high:<uuid>") — caller should treat as an off-chain asset.
-    function _extractTokenAddress(string memory assetId) internal pure returns (address) {
-        bytes memory b = bytes(assetId);
-        // Minimum length for ":0x<40 hex>" suffix is 43 chars.
-        if (b.length < 43) return address(0);
-        uint256 xPos = b.length - 42;
-        // Expect ':' at xPos-1, then '0' 'x' at xPos, xPos+1
-        if (xPos == 0) return address(0);
-        if (b[xPos - 1] != ':' || b[xPos] != '0' || (b[xPos + 1] != 'x' && b[xPos + 1] != 'X')) return address(0);
-        uint160 addr = 0;
-        for (uint256 i = b.length - 40; i < b.length; i++) {
-            uint8 c = uint8(b[i]);
-            uint8 v;
-            if (c >= 0x30 && c <= 0x39) v = c - 0x30;            // '0'-'9'
-            else if (c >= 0x61 && c <= 0x66) v = c - 0x61 + 10;  // 'a'-'f'
-            else if (c >= 0x41 && c <= 0x46) v = c - 0x41 + 10;  // 'A'-'F'
-            else return address(0);
-            addr = (addr << 4) | v;
-        }
-        return address(addr);
-    }
-
     function _mint(address to, string memory assetId, string memory quantity) internal {
-        address tokenAddress = _resolveToken(assetId);
-        require(tokenAddress != address(0), "Cannot mint an off-chain asset");
-        uint8 tokenDecimals = IERC20Metadata(tokenAddress).decimals();
+        require(_haveAsset(assetId), "Asset not found");
+        Asset memory asset = assets[assetId];
+        uint8 tokenDecimals = IERC20Metadata(asset.tokenAddress).decimals();
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
-        Mintable(tokenAddress).mint(to, tokenAmount);
+        Mintable(asset.tokenAddress).mint(to, tokenAmount);
     }
 
     function _transfer(address from, address to, string memory assetId, string memory quantity) internal {
-        address tokenAddress = _resolveToken(assetId);
-        if (tokenAddress == address(0)) return; // off-chain asset — event-only leg
-        uint8 tokenDecimals = IERC20Metadata(tokenAddress).decimals();
+        require(_haveAsset(assetId), "Asset not found");
+        Asset memory asset = assets[assetId];
+        uint8 tokenDecimals = IERC20Metadata(asset.tokenAddress).decimals();
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
-        uint256 balance = IERC20(tokenAddress).balanceOf(from);
+        uint256 balance = IERC20(asset.tokenAddress).balanceOf(from);
         require(balance >= tokenAmount, "Not sufficient balance to transfer");
-        IERC20(tokenAddress).transferFrom(from, to, tokenAmount);
+        IERC20(asset.tokenAddress).transferFrom(from, to, tokenAmount);
     }
 
     function _burn(address from, string memory assetId, string memory quantity) internal {
-        address tokenAddress = _resolveToken(assetId);
-        require(tokenAddress != address(0), "Cannot burn an off-chain asset");
-        uint8 tokenDecimals = IERC20Metadata(tokenAddress).decimals();
+        require(_haveAsset(assetId), "Asset not found");
+        Asset memory asset = assets[assetId];
+        uint8 tokenDecimals = IERC20Metadata(asset.tokenAddress).decimals();
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
-        uint256 balance = IERC20(tokenAddress).balanceOf(from);
+        uint256 balance = IERC20(asset.tokenAddress).balanceOf(from);
         require(balance >= tokenAmount, "Not sufficient balance to burn");
-        Burnable(tokenAddress).burn(from, tokenAmount);
+        Burnable(asset.tokenAddress).burn(from, tokenAmount);
     }
 
     function _extractDetails(

--- a/finp2p-contracts/contracts/finp2p/FINP2POperatorWithRegistry.sol
+++ b/finp2p-contracts/contracts/finp2p/FINP2POperatorWithRegistry.sol
@@ -23,7 +23,7 @@ contract FINP2POperatorWithRegistry is AccessControl, FinP2PSignatureVerifier {
     using FinIdUtils for string;
 
 
-    string public constant VERSION = "0.28.1";
+    string public constant VERSION = "0.28.0";
 
     bytes32 private constant ASSET_MANAGER = keccak256("ASSET_MANAGER");
     bytes32 private constant TRANSACTION_MANAGER = keccak256("TRANSACTION_MANAGER");

--- a/finp2p-contracts/contracts/utils/finp2p/FinP2PSignatureVerifier.sol
+++ b/finp2p-contracts/contracts/utils/finp2p/FinP2PSignatureVerifier.sol
@@ -30,36 +30,33 @@ contract FinP2PSignatureVerifier is EIP712 {
         "FinId(string idkey)"
     );
 
-    // 0.28: assetType removed from the EIP712 hash input to align with the new
-    // on-the-wire Term format. The struct still carries assetType for ABI stability
-    // and for use in events; only the signed-digest excludes it.
     bytes32 private constant TERM_TYPE_HASH = keccak256(
-        "Term(string assetId,string amount)"
+        "Term(string assetId,string assetType,string amount)"
     );
 
 
     bytes32 private constant PRIMARY_SALE_TYPE_HASH = keccak256(
-        "PrimarySale(string nonce,FinId buyer,FinId issuer,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string amount)"
+        "PrimarySale(string nonce,FinId buyer,FinId issuer,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string assetType,string amount)"
     );
 
     bytes32 private constant BUYING_TYPE_HASH = keccak256(
-        "Buying(string nonce,FinId buyer,FinId seller,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string amount)"
+        "Buying(string nonce,FinId buyer,FinId seller,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string assetType,string amount)"
     );
 
     bytes32 private constant SELLING_TYPE_HASH = keccak256(
-        "Selling(string nonce,FinId buyer,FinId seller,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string amount)"
+        "Selling(string nonce,FinId buyer,FinId seller,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string assetType,string amount)"
     );
 
     bytes32 private constant REDEMPTION_TYPE_HASH = keccak256(
-        "Redemption(string nonce,FinId seller,FinId issuer,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string amount)"
+        "Redemption(string nonce,FinId seller,FinId issuer,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string assetType,string amount)"
     );
 
     bytes32 private constant TRANSFER_TYPE_HASH = keccak256(
-        "Transfer(string nonce,FinId buyer,FinId seller,Term asset)FinId(string idkey)Term(string assetId,string amount)"
+        "Transfer(string nonce,FinId buyer,FinId seller,Term asset)FinId(string idkey)Term(string assetId,string assetType,string amount)"
     );
 
     bytes32 private constant PRIVATE_OFFER_TYPE_HASH = keccak256(
-        "PrivateOffer(string nonce,FinId buyer,FinId seller,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string amount)"
+        "PrivateOffer(string nonce,FinId buyer,FinId seller,Term asset,Term settlement)FinId(string idkey)Term(string assetId,string assetType,string amount)"
     );
 
     bytes32 private constant LOAN_TERMS_TYPE_HASH = keccak256(
@@ -67,7 +64,7 @@ contract FinP2PSignatureVerifier is EIP712 {
     );
 
     bytes32 private constant LOAN_TYPE_HASH = keccak256(
-        "Loan(string nonce,FinId borrower,FinId lender,Term asset,Term settlement,LoanTerms loanTerms)FinId(string idkey)LoanTerms(string openTime,string closeTime,string borrowedMoneyAmount,string returnedMoneyAmount)Term(string assetId,string amount)"
+        "Loan(string nonce,FinId borrower,FinId lender,Term asset,Term settlement,LoanTerms loanTerms)FinId(string idkey)LoanTerms(string openTime,string closeTime,string borrowedMoneyAmount,string returnedMoneyAmount)Term(string assetId,string assetType,string amount)"
     );
 
     struct Term {
@@ -123,6 +120,7 @@ contract FinP2PSignatureVerifier is EIP712 {
         return keccak256(abi.encode(
             TERM_TYPE_HASH,
             keccak256(bytes(term.assetId)),
+            hashAssetType(term.assetType),
             keccak256(bytes(term.amount))
         ));
     }

--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.9",
+  "version": "0.28.4",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",
@@ -15,6 +15,7 @@
   "bin": {
     "deploy-contract": "./dist/scripts/deploy.js",
     "grant-operator-roles": "./dist/scripts/grant.js",
+    "associate-asset": "./dist/scripts/associate.js",
     "generate-wallet": "./dist/scripts/generate-wallet.js",
     "erc20-approve": "./dist/scripts/erc20-approve.js",
     "eip712-domain-params": "./dist/scripts/eip712-domain-params.js",
@@ -29,6 +30,7 @@
     "postbuild": "cpx \"contracts/**/*\" dist/contracts && shx chmod +x dist/scripts/*.js",
     "deploy-contract": "ts-node scripts/deploy.ts",
     "grant-operator-roles": "ts-node scripts/grant.ts",
+    "associate-asset": "ts-node scripts/associate.ts",
     "generate-wallet": "ts-node scripts/generate-wallet.ts",
     "erc20-approve": "ts-node scripts/erc20-approve.ts",
     "eip712-domain-params": "ts-node scripts/eip712-domain-params.ts",

--- a/finp2p-contracts/scripts/associate.ts
+++ b/finp2p-contracts/scripts/associate.ts
@@ -1,0 +1,58 @@
+import { FinP2PContract } from "../src";
+import { createJsonProvider, parseConfig } from "./config";
+import { Logger, ConsoleLogger } from "../src/adapter-types";
+
+const logger: Logger = new ConsoleLogger("info");
+
+const associateAsset = async (
+  operatorPrivateKey: string,
+  ethereumRPCUrl: string,
+  finp2pContractAddress: string,
+  assetId: string,
+  erc20Address: string,
+) => {
+  logger.info(`Associating asset ${assetId} with token ${erc20Address} on finP2P contract ${finp2pContractAddress}`);
+
+  const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
+
+  const finP2P = new FinP2PContract(provider, signer, finp2pContractAddress, logger);
+  await finP2P.associateAsset(assetId, erc20Address);
+  logger.info("Asset associated successfully");
+};
+
+const config = parseConfig([
+  {
+    name: "operator_pk",
+    envVar: "OPERATOR_PRIVATE_KEY",
+    required: true,
+    description: "Operator private key"
+  },
+  {
+    name: "rpc_url",
+    envVar: "RPC_URL",
+    required: true,
+    description: "Ethereum RPC URL"
+  },
+  {
+    name: "finp2p_contract_address",
+    envVar: "FINP2P_CONTRACT_ADDRESS",
+    description: "FinP2P contract address",
+    required: true
+  },
+  {
+    name: "asset_id",
+    envVar: "ASSET_ID",
+    description: "Asset ID to associate",
+    required: true
+  },
+  {
+    name: "token_address",
+    envVar: "TOKEN_ADDRESS",
+    description: "Token address to associate",
+    required: true
+  }
+]);
+
+associateAsset(config.operator_pk!, config.rpc_url!, config.finp2p_contract_address!, config.asset_id!, config.token_address!)
+  .then(() => {
+  }).catch(console.error);

--- a/finp2p-contracts/scripts/deploy.ts
+++ b/finp2p-contracts/scripts/deploy.ts
@@ -8,12 +8,13 @@ const logger: Logger = new ConsoleLogger("info");
 const deploy = async (
   deployerPrivateKey: string,
   ethereumRPCUrl: string,
-  operatorAddress: string
+  operatorAddress: string,
+  paymentAssetCode: string | undefined
 ) => {
   const { provider, signer } = await createJsonProvider(deployerPrivateKey, ethereumRPCUrl);
   const contractManger = new ContractsManager(provider, signer, logger);
   logger.info("Deploying from env variables...");
-  const finP2PContractAddress = await contractManger.deployFinP2PContract(operatorAddress);
+  const finP2PContractAddress = await contractManger.deployFinP2PContract(operatorAddress, paymentAssetCode);
   logger.info(`FINP2P Contract deployed at address: ${finP2PContractAddress}`);
   const finP2P = new FinP2PContract(provider, signer, finP2PContractAddress, logger);
 
@@ -43,9 +44,14 @@ const config = parseConfig([
     envVar: "OPERATOR_ADDRESS",
     description: "Operator address",
     required: true
+  },
+  {
+    name: "payment_asset_code",
+    envVar: "PAYMENT_ASSET_CODE",
+    description: "Payment asset code"
   }
 ]);
 
-deploy(config.deployer_pk!, config.rpc_url!, config.operator!)
+deploy(config.deployer_pk!, config.rpc_url!, config.operator!, config.payment_asset_code)
   .then(() => {
   }).catch(console.error);

--- a/finp2p-contracts/scripts/erc20-approve.ts
+++ b/finp2p-contracts/scripts/erc20-approve.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { formatUnits, parseUnits } from "ethers";
 import { Logger, ConsoleLogger } from "../src/adapter-types";
-import { ERC20Contract } from "../src";
+import { FinP2PContract, ERC20Contract } from "../src";
 import { createJsonProvider, parseConfig } from "./config";
 
 const logger: Logger = new ConsoleLogger("info");
@@ -10,7 +10,8 @@ const logger: Logger = new ConsoleLogger("info");
 const erc20Approve = async (
   operatorPrivateKey: string,
   ethereumRPCUrl: string,
-  tokenAddress: string,
+  finp2pContractAddress: string,
+  assetId: string,
   spender: string,
   amount: string
 ) => {
@@ -19,25 +20,29 @@ const erc20Approve = async (
   const network = await provider.getNetwork();
   logger.info("Network name: ", network.name);
   logger.info("Network chainId: ", network.chainId);
-  const signerAddress = await signer.getAddress();
+  const singerAddress = await signer.getAddress();
+
+  const finp2p = new FinP2PContract(provider, signer, finp2pContractAddress, logger);
+  const tokenAddress = await finp2p.getAssetAddress(assetId);
+  logger.info(`ERC20 token associated with ${assetId} is: ${tokenAddress}`);
 
   const erc20 = new ERC20Contract(provider, signer, tokenAddress, logger);
   logger.info("ERC20 token details: ");
   logger.info(`\tname: ${await erc20.name()}`);
   const decimals = await erc20.decimals();
 
-  const allowanceBefore = await erc20.allowance(signerAddress, spender);
+  const allowanceBefore = await erc20.allowance(singerAddress, spender);
   logger.info(`\tallowance before: ${formatUnits(allowanceBefore, decimals)}`);
 
   const txResp = await erc20.approve(spender, parseUnits(amount, decimals));
   logger.info(`\terc20 approve tx-hash: ${txResp.hash}`);
   await txResp.wait();
 
-  const allowanceAfter = await erc20.allowance(signerAddress, spender);
+  const allowanceAfter = await erc20.allowance(singerAddress, spender);
   logger.info(`\tallowance after: ${formatUnits(allowanceAfter, decimals)}`);
 
 
-  logger.info(`Approved ${amount} tokens for ${spender}`);
+  logger.info(`Approved ${amount} tokens for ${spender} (${spender})`);
 };
 
 const config = parseConfig([
@@ -54,9 +59,15 @@ const config = parseConfig([
     description: "Ethereum RPC URL"
   },
   {
-    name: "token_address",
-    envVar: "TOKEN_ADDRESS",
-    description: "ERC20 token address to approve",
+    name: "finp2p_contract_address",
+    envVar: "FINP2P_CONTRACT_ADDRESS",
+    description: "FinP2P contract address",
+    required: true
+  },
+  {
+    name: "asset_id",
+    envVar: "ASSET_ID",
+    description: "Asset ID to approve",
     required: true
   },
   {
@@ -73,6 +84,6 @@ const config = parseConfig([
   }
 ]);
 
-erc20Approve(config.operator_pk!, config.rpc_url!, config.token_address!, config.spender!, config.amount!)
+erc20Approve(config.operator_pk!, config.rpc_url!, config.finp2p_contract_address!, config.asset_id!, config.spender!, config.amount!)
   .then(() => {
   }).catch(console.error);

--- a/finp2p-contracts/src/adapter-types.ts
+++ b/finp2p-contracts/src/adapter-types.ts
@@ -96,8 +96,7 @@ export type EIP712Domain = {
 
 export interface EIP712Term {
   assetId: string;
-  // 0.28: removed from EIP712 hash. Kept optional so pre-0.28 messages still parse.
-  assetType?: string;
+  assetType: string;
   amount: string;
 }
 
@@ -193,11 +192,10 @@ export const FINID_TYPE: EIP712Types = {
   FinId: [{ name: 'idkey', type: 'string' }],
 };
 
-// 0.28: assetType removed from EIP712 Term hash. Matches Solidity
-// TERM_TYPE_HASH in FinP2PSignatureVerifier.sol.
 export const TERM_TYPE: EIP712Types = {
   Term: [
     { name: 'assetId', type: 'string' },
+    { name: 'assetType', type: 'string' },
     { name: 'amount', type: 'string' },
   ],
 };

--- a/finp2p-contracts/src/finp2p.ts
+++ b/finp2p-contracts/src/finp2p.ts
@@ -58,20 +58,14 @@ export class FinP2PContract extends ContractsManager {
     return { name, version, chainId, verifyingContract };
   }
 
+  async getAssetAddress(assetId: string) {
+    return this.finP2P.getAssetAddress(assetId);
+  }
+
   async associateAsset(assetId: string, tokenAddress: string) {
     return this.safeExecuteTransaction(this.finP2P, async (finP2P: FINP2POperator, txParams: PayableOverrides) => {
       return finP2P.associateAsset(assetId, tokenAddress, txParams);
     });
-  }
-
-  async removeAsset(assetId: string) {
-    return this.safeExecuteTransaction(this.finP2P, async (finP2P: FINP2POperator, txParams: PayableOverrides) => {
-      return finP2P.removeAsset(assetId, txParams);
-    });
-  }
-
-  async getAssetAddress(assetId: string) {
-    return this.finP2P.getAssetAddress(assetId);
   }
 
   async addCredential(finId: string, address: string) {

--- a/finp2p-contracts/src/manager.ts
+++ b/finp2p-contracts/src/manager.ts
@@ -53,7 +53,7 @@ export class ContractsManager {
     return await this.provider.getTransactionCount(this.signer.getAddress(), "latest");
   }
 
-  async deployFinP2PContract(operatorAddress: string | undefined) {
+  async deployFinP2PContract(operatorAddress: string | undefined, paymentAssetCode: string | undefined = undefined) {
     this.logger.info("Deploying FinP2P contract...");
     const factory = new ContractFactory<any[], FINP2POperator>(
       FINP2P.abi, FINP2P.bytecode, this.signer
@@ -70,8 +70,9 @@ export class ContractsManager {
       await this.grantTransactionManagerRole(address, operatorAddress);
     }
 
-    // 0.28.2: on-chain asset registry removed. Payment-asset pre-creation is no
-    // longer needed — asset tokenAddress is carried inline in EIP712 Term.assetId.
+    if (paymentAssetCode) {
+      await this.preCreatePaymentAsset(factory, address, paymentAssetCode, DefaultDecimalsCurrencies);
+    }
 
     return address;
   }
@@ -82,12 +83,28 @@ export class ContractsManager {
     );
     const contract = factory.attach(finP2PContractAddress);
     try {
-      // 0.28.2: on-chain asset registry was removed. Health-check via VERSION() instead.
-      const version = await contract.VERSION();
-      return typeof version === 'string' && version.length > 0;
-    } catch {
+      await contract.getAssetAddress("test-asset-id");
+    } catch (err) {
+      if (err instanceof Error) {
+        if (err.message.includes("Asset not found")) {
+          return true;
+        }
+      }
       return false;
     }
+    return true;
+  }
+
+  async preCreatePaymentAsset(factory: ContractFactory<any[], FINP2POperator>, finP2PContractAddress: string, assetId: string, decimals: number): Promise<void> {
+    this.logger.info(`Pre-creating payment asset ${assetId}...`);
+    const finP2PAddress = await factory.attach(finP2PContractAddress).getAddress();
+    const tokenAddress = await this.deployERC20(assetId, assetId, decimals, finP2PAddress);
+
+    const contract = factory.attach(finP2PContractAddress) as FINP2POperator;
+    this.logger.info(`Associating asset ${assetId} with token ${tokenAddress}...`);
+    await this.safeExecuteTransaction(contract, async (finP2P: FINP2POperator, txParams: PayableOverrides) => {
+      return finP2P.associateAsset(assetId, tokenAddress, txParams);
+    });
   }
 
   async grantAssetManagerRole(finP2PContractAddress: string, to: string) {

--- a/finp2p-contracts/src/mappers.ts
+++ b/finp2p-contracts/src/mappers.ts
@@ -52,22 +52,17 @@ export const assetTypeFromString = (assetType: string): AssetType => {
 
 
 export const termToEIP712 = (term: Term): EIP712Term => {
-  // 0.28: assetType is no longer part of the EIP712 hash. Emit only the fields
-  // that participate in hashing so consumers (ethers signTypedData / tests /
-  // verify-signature scripts) produce a digest that matches the on-chain hash.
   return {
     assetId: term.assetId,
+    assetType: assetTypeToEIP712(term.assetType),
     amount: term.amount
   };
 };
 
 export const termFromEIP712 = (eip712Term: EIP712Term): Term => {
-  // 0.28 dropped `assetType` from the on-the-wire Term payload; default to FinP2P
-  // so adapter parsing still works against new-format messages. Pre-0.28 messages
-  // still carry assetType and take the explicit path.
   return {
     assetId: eip712Term.assetId,
-    assetType: eip712Term.assetType ? assetTypeFromString(eip712Term.assetType) : AssetType.FinP2P,
+    assetType: assetTypeFromString(eip712Term.assetType),
     amount: eip712Term.amount
   };
 }

--- a/finp2p-contracts/test/finp2p-contract.ts
+++ b/finp2p-contracts/test/finp2p-contract.ts
@@ -48,13 +48,6 @@ describe("FinP2P proxy contract test", function() {
     return `bank-us:102:${uuid()}`;
   }
 
-  // 0.28.2: the on-chain verifier extracts the ERC20 address from the assetId
-  // string suffix. Tests build assetIds in the form the platform produces:
-  //   "<original-id>/ERC20:0x<40-hex>"
-  function buildCaipAssetId(originalId: string, tokenAddress: string): string {
-    return `${originalId}/ERC20:${tokenAddress.toLowerCase()}`;
-  }
-
   function generateInvestor(): {
     signer: Signer, finId: string, address: string
   } {
@@ -189,34 +182,21 @@ describe("FinP2P proxy contract test", function() {
       [operator] = await ethers.getSigners();
       ({ contract, finP2PAddress } = await loadFixture(deployFinP2PProxyFixture));
       ({ chainId, verifyingContract } = await contract.eip712Domain());
-      // 0.28.2: tokenAddress is carried inline in the EIP712 Term.assetId.
-      // Deploy ERC20 first, then rewrite each test case's assetId/settlement.assetId
-      // to the CAIP-style form the contract parses.
       for (const tc of testCases) {
+        // Deploy ERC20 tokens with finP2P contract as operator (minter + transferFrom bypasser)
         const assetToken = await deployERC20(tc.asset.assetId, tc.asset.assetId, tc.decimals, finP2PAddress);
-        tc.asset = term(buildCaipAssetId(tc.asset.assetId, assetToken), tc.asset.assetType, tc.asset.amount);
+        await contract.associateAsset(tc.asset.assetId, assetToken, { from: operator });
 
-        if (tc.settlement !== emptyTerm()) {
-          // Fiat/FinP2P settlement: deploy a backing ERC20 so the on-chain flow has something to transfer.
-          const settlementToken = await deployERC20(tc.settlement.assetId, tc.settlement.assetId, tc.decimals, finP2PAddress);
-          tc.settlement = term(buildCaipAssetId(tc.settlement.assetId, settlementToken), tc.settlement.assetType, tc.settlement.amount);
-        }
+        const settlementToken = await deployERC20(tc.settlement.assetId, tc.settlement.assetId, tc.decimals, finP2PAddress);
+        await contract.associateAsset(tc.settlement.assetId, settlementToken, { from: operator });
       }
     });
 
-    testCases.forEach((tc) => {
-      const { decimals, loan, primaryTypes, legs, phases } = tc;
-      // `tc.asset` / `tc.settlement` are rewritten by `before()` with the deployed
-      // ERC20 address inline. Read through getters so every `it()` picks up the
-      // post-rewrite values rather than describe-time snapshots.
-      const getAssetTerm = () => tc.asset;
-      const getSettlementTerm = () => tc.settlement;
+    testCases.forEach(({ decimals, asset, settlement, loan, primaryTypes, legs, phases }) => {
       primaryTypes.forEach((primaryType) => {
         legs.forEach((leg) => {
           phases.forEach((phase) => {
-            it(`issue/transfer/redeem operations (primaryType: ${primaryType}, leg: ${leg}, phase: ${phase}, decimals: ${decimals})`, async () => {
-              const asset = getAssetTerm();
-              const settlement = getSettlementTerm();
+            it(`issue/transfer/redeem operations (asset: ${asset}, settlement ${settlement}, primaryType: ${primaryType}, leg: ${leg}, phase: ${phase}, decimals: ${decimals}`, async () => {
               const buyer = generateInvestor();
               const seller = generateInvestor();
               // Register credentials for both investors
@@ -247,9 +227,7 @@ describe("FinP2P proxy contract test", function() {
               expect(await contract.getBalance(assetId, to)).to.equal(`${(0).toFixed(decimals)}`);
             });
 
-            it(`hold/release operations (primaryType: ${primaryType}, leg: ${leg}, phase: ${phase}, decimals: ${decimals})`, async () => {
-              const asset = getAssetTerm();
-              const settlement = getSettlementTerm();
+            it(`hold/release operations (asset: ${asset}, settlement ${settlement}, primaryType: ${primaryType}, leg: ${leg}, phase: ${phase},decimals: ${decimals})`, async () => {
               const buyer = generateInvestor();
               const seller = generateInvestor();
               await registerCredential(contract, buyer.finId);
@@ -290,9 +268,7 @@ describe("FinP2P proxy contract test", function() {
 
             });
 
-            it(`hold/rollback operations (primaryType: ${primaryType}, leg: ${leg}, phase: ${phase}, decimals: ${decimals})`, async () => {
-              const asset = getAssetTerm();
-              const settlement = getSettlementTerm();
+            it(`hold/rollback operations (asset: ${asset}, settlement ${settlement}, primaryType: ${primaryType}, leg: ${leg}, phase: ${phase},decimals: ${decimals})`, async () => {
               const buyer = Wallet.createRandom();
               const buyerFinId = getFinId(buyer);
               const seller = Wallet.createRandom();
@@ -363,12 +339,10 @@ describe("FinP2P proxy contract test", function() {
               await expect(contract.getLockInfo(operationId)).to.be.revertedWith("Contract not found");
             });
 
-            it(`hold/redeem operations (leg: ${leg}, phase: ${phase}, decimals: ${decimals})`, async () => {
+            it(`hold/redeem operations (asset: ${asset}, settlement ${settlement}, leg: ${leg}, phase: ${phase}, decimals: ${decimals})`, async () => {
               if (primaryType !== PrimaryType.Redemption) {
                 return;
               }
-              const asset = getAssetTerm();
-              const settlement = getSettlementTerm();
               const issuer = Wallet.createRandom();
               const issuerFinId = getFinId(issuer);
 

--- a/finp2p-contracts/test/signatures.ts
+++ b/finp2p-contracts/test/signatures.ts
@@ -129,6 +129,28 @@ describe("Signing test", function() {
     });
   });
 
+  it("Transfer signature from platform", async function() {
+    // Real captured payload — verifies that the v0.27 Term shape
+    // (assetId, assetType, amount) reproduces the platform's EIP712 hash and
+    // that the signature recovers the seller's finId-derived address.
+    const chainId = 1;
+    const verifyingContract = "0x0000000000000000000000000000000000000000";
+    const nonce = "866c6baf0e2a1856bc25ba00436de5e0";
+    const buyerFinId  = "0341bf2178bc4e047f5782f3a25ed4ffd742edf4604ba22ae2f771036d3e4a6710";
+    const sellerFinId = "0376339d3cd3c44d704d27cfba39e13234732f47f2d10927c4f3a7b5032daa3649";
+    const asset = term("org-a:102:bb4dfc13-fa75-4387-82eb-2efaeabad499", AssetType.FinP2P, "1");
+    const { types, message } = newInvestmentMessage(
+      PrimaryType.Transfer, nonce, buyerFinId, sellerFinId,
+      termToEIP712(asset), termToEIP712(asset) /* unused for Transfer */,
+    );
+
+    const platformHash = "0xf86f07b52453bb32d98f8aa392bde5deb71c8e60176454883bc2c8a80cd59a49";
+    const platformSignature = "0x2add321a53b6bdb70c337040bf065f3dd0b549239afe7f33fcf955bca07d0efd2c6e254ff6936db1113075ea64993e6374d32c98959194e2305a591eeb6af32d1c";
+
+    expect(hashEIP712(chainId, verifyingContract, types, message)).to.equal(platformHash);
+    expect(verifyEIP712(chainId, verifyingContract, types, message, sellerFinId, platformSignature)).to.equal(true);
+  });
+
   it.skip("Investor signature from platform", async function() {
     const { contract: verifier } = await loadFixture(deployFinP2PSignatureVerifier);
     const chainId = 1337;

--- a/finp2p-contracts/test/signatures.ts
+++ b/finp2p-contracts/test/signatures.ts
@@ -129,26 +129,34 @@ describe("Signing test", function() {
     });
   });
 
-  it("Selling signature from platform (0.28 wire format)", async function() {
-    // Real captured payload from the platform. Exercises:
-    //  - off-chain EIP712 hash matches the platform-computed hash byte-for-byte
-    //    (validates new 0.28 Term shape: { assetId, amount } — no assetType)
-    //  - off-chain signer recovery returns the seller's derived EVM address
-    const chainId = 1;
-    const verifyingContract = "0x0000000000000000000000000000000000000000";
-    const nonce = "75dbdf185a9ca33c5c1ef14d4cf1342c";
-    const buyerFinId  = "03897e68c1dc647ccb03875b1267c12ec7bcaaea7084b262b131d5fccef714433b";
-    const sellerFinId = "03f38f6b90efab51ed88e12e919e4975027c4cde5309bf4a82d89039f774b70446";
-    const asset      = term("name: sepolia, chainId: 11155111/ERC20:0x9f9bd18b402ee53dab974defd5ff1be2a3f2aaea", AssetType.FinP2P, "5");
-    const settlement = term("vanilla/high:12d019fc-4e4f-49aa-9121-4968c54240ba",                                AssetType.FinP2P, "50");
-    const primaryType = PrimaryType.Selling;
-    const { message, types } = newInvestmentMessage(primaryType, nonce, buyerFinId, sellerFinId, termToEIP712(asset), termToEIP712(settlement));
+  it.skip("Investor signature from platform", async function() {
+    const { contract: verifier } = await loadFixture(deployFinP2PSignatureVerifier);
+    const chainId = 1337;
+    const verifyingContract = "0x5FbDB2315678afecb367f032d93F642f64180aa3";
+    const nonce = "e78c3a7f564c19667a7d90285e7fe443eca8403d45a2eea80000000067d1907d";
+    // borrower
+    const sellerFinId = "03da4a23d6385d7f591350f55d98176902580b8ed0412fe54de28a59d5fd5d1af7";
+    // lender
+    const buyerFinId = "02d34fde92bcd3baef081118e1e5fe9154ff47176a4118cc27b10f5347a56bec23";
+    const asset = term("bank-us:102:66fe5a05-ffc6-4754-8d46-68e8abd0e083", AssetType.FinP2P, "1");
+    const settlement = term("USD", AssetType.Fiat, "900");
+    const loan = loanTerms("1741787256", "1741787271", "900", "900.25");
+    const primaryType = PrimaryType.Loan;
+    const {
+      message,
+      types
+    } = newInvestmentMessage(primaryType, nonce, buyerFinId, sellerFinId, termToEIP712(asset), termToEIP712(settlement), loan);
+    const offChainHash = hashEIP712(chainId, verifyingContract, types, message);
+    const onChainHash = await verifier.hashInvestment(primaryType, nonce, buyerFinId, sellerFinId, asset, settlement, loan);
 
-    const platformHash = "0xb728c7c6dc6f42d61979bb5095a4c1ec97b29250681eb36ae215e25cff8700d1";
-    const platformSignature = "0x05bba94ca10eef6c6485374146d82c5e166a9a8460c019796552c22f50394ee90409fb56f35af7b5c7abbc5371fd7fd121bcf6a1833acce1929549c8dda9a96d1c";
+    const platformHash = "0x28fc646eb6470c62252c9d4c2092bf34d86e590983429580b04578a8ff37e171";
+    const platformSignature = "0xd9c145d6f0f020276f268a83178ba08767eaab8fb71475a14f0a5c13275675885f6e89270cfca55cd9e9da29a9412564a2840af5680782f61cb7646181efbe941c";
+    expect(offChainHash).to.equal(platformHash);
+    expect(offChainHash).to.equal(onChainHash);
 
-    expect(hashEIP712(chainId, verifyingContract, types, message)).to.equal(platformHash);
-    expect(verifyEIP712(chainId, verifyingContract, types, message, sellerFinId, platformSignature)).to.equal(true);
+    // const signerAddress = finIdToEthereumAddress(sellerFinId);
+    // expect(verify(chainId, verifyingContract, types, message, signerAddress, platformSignature)).to.equal(true);
+    expect(await verifier.verifyInvestmentSignature(primaryType, nonce, buyerFinId, sellerFinId, asset, settlement, loan, sellerFinId, platformSignature)).to.equal(true);
   });
 
   it("Receipt proof signature", async function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,11 @@
         "@dfns/sdk": "^0.8.11",
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
-        "@owneraio/finp2p-client": "^0.28.6",
-        "@owneraio/finp2p-contracts": "^0.28.8",
+        "@owneraio/finp2p-client": "^0.28.0",
+        "@owneraio/finp2p-contracts": "^0.28.4",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.6",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.5",
         "@owneraio/finp2p-vanilla-service": "^0.28.1",
         "@types/node": "^24.10.1",
         "axios": "^1.1.3",
@@ -30,10 +30,12 @@
         "uuid": "^9.0.0"
       },
       "bin": {
-        "mass-approve": "dist/scripts/mass-approve.js"
+        "mass-approve": "dist/scripts/mass-approve.js",
+        "migration": "dist/scripts/migration.js",
+        "sync-balances": "dist/scripts/sync-balances.js"
       },
       "devDependencies": {
-        "@owneraio/adapter-tests": "^0.28.1",
+        "@owneraio/adapter-tests": "^0.28.0",
         "@testcontainers/postgresql": "^11.8.1",
         "@types/express": "^5.0.3",
         "@types/jest": "^29.2.0",
@@ -1676,13 +1678,13 @@
       }
     },
     "node_modules/@owneraio/adapter-tests": {
-      "version": "0.28.1",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/adapter-tests/0.28.1/79dab4224e8ecc1886c3a548a1fa8c89c8833a2f",
-      "integrity": "sha512-GILyzKXQOoWWfC72gmyHj66Q2Mps4WoQs+YLwp6Ffvb81KXk+raNk1bsAR8QNJuSDK0RZ2PNHfmpIVO1bNo6Vw==",
+      "version": "0.28.0",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/adapter-tests/0.28.0/2e6f932d1f943b2ece6d1b8e6cd48fa983e96753",
+      "integrity": "sha512-8wtRBg9Ywjfb/o2hpO6tWe6iQVSvrNhbNWQ/I27gQr58DZOQG4Tgca0vM+f52RxPAAFscQPg/czIiFXl8c4Ntw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.6",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.0",
         "axios": "^1.12.2",
         "secp256k1": "^3.7.1",
         "yaml": "^2.8.1",
@@ -1693,9 +1695,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.6",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.6/0b66643c9727a464e52dbb6bde237f09168cc60d",
-      "integrity": "sha512-4CsT8BHRx7XOuuLbS+yDmqnufCaRNP58K/UXllpQCbJrBmFjsxPPJTMr9DCeqI0W3ZA1H2xtNJ890I+rJdeLbQ==",
+      "version": "0.28.0",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.0/46c459b00027a7500e8ac2f572880c69f4208490",
+      "integrity": "sha512-EWKjfNwhCGoLy6ehLGXNX+XzqBCikZMOxY7F28q48b4tClCAv7Vx2MhuHSsFa6lLC46NirwGgCPG3N0VJQ/nHg==",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
@@ -1705,15 +1707,16 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.8",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.8/7e80eb58c7d34d67859f9512e9fedb2b2a16926f",
-      "integrity": "sha512-vW61h0idGyzsOqbQKZSlcRDHO4SXmbq+i9tXSzHw60C4qpbjvX9eUcJa5fYCgrOVFDB7wcuqapkCgy+lqWMEyg==",
+      "version": "0.28.4",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.4/7e0afb251571e4e2568ad0582b089ac447ebf85b",
+      "integrity": "sha512-t9PlcAEkEPudesmN4+d7Ns8GzVHHHjL658cQOqtmKx2bhKGxar1itzaPrQ89o9UWzqp0e/onOTBYCBbWVB/9aA==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "0.28.0",
         "ethers": "^6.11.1"
       },
       "bin": {
+        "associate-asset": "dist/scripts/associate.js",
         "deploy-contract": "dist/scripts/deploy.js",
         "eip712-domain-params": "dist/scripts/eip712-domain-params.js",
         "erc20-approve": "dist/scripts/erc20-approve.js",
@@ -1761,9 +1764,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.6",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.6/4939b821be296ade442cc755423fd0f7e82ba0ed",
-      "integrity": "sha512-ukQdnKfbOdbUoWa++AO6W1hc4gb8uUgHtHZ1O3fUwC8k+Izt+gBs+nma5+JDWyZeEqsEOWh+N09vrnWB+EHIWQ==",
+      "version": "0.28.5",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.5/4429bdab4e2e6baf1abedf36c6b59d1cfc56e1e2",
+      "integrity": "sha512-75O1+p4EOUAFoURBCRHoWyGI6h54bUJczDFetauksUOo/ZcvUIuKWnqovod+13JV1x9Mf2v3btVKs5Ej8rtnhg==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",
@@ -1777,7 +1780,7 @@
         "winston": "^3.18.3"
       },
       "peerDependencies": {
-        "@owneraio/finp2p-client": "^0.28.6",
+        "@owneraio/finp2p-client": "^0.28.0",
         "pg": "^8.15.6"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@dfns/sdk": "^0.8.11",
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
-        "@owneraio/finp2p-client": "^0.28.0",
+        "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.4",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
@@ -1695,9 +1695,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.0/46c459b00027a7500e8ac2f572880c69f4208490",
-      "integrity": "sha512-EWKjfNwhCGoLy6ehLGXNX+XzqBCikZMOxY7F28q48b4tClCAv7Vx2MhuHSsFa6lLC46NirwGgCPG3N0VJQ/nHg==",
+      "version": "0.28.7",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.7/55adcf40750476d6542eba321e1ffdde355c1411",
+      "integrity": "sha512-VeuXp5A0VLx+UHQCrrzszdnUU9yytkm7Oym1zViaLRIumlPSBEpZ9V6vJD5CO2PScwrDHgisANGPZGJfsuMlRg==",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dfns/sdk": "^0.8.11",
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
-    "@owneraio/finp2p-client": "^0.28.0",
+    "@owneraio/finp2p-client": "^0.28.6",
     "@owneraio/finp2p-contracts": "^0.28.4",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "",
   "main": "dist/src/index.js",
   "homepage": "https://ownera.io/",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "node": ">=20"
   },
   "bin": {
+    "migration": "./dist/scripts/migration.js",
+    "sync-balances": "./dist/scripts/sync-balances.js",
     "mass-approve": "./dist/scripts/mass-approve.js"
   },
   "scripts": {
@@ -21,6 +23,8 @@
     "test:account-mapping": "jest --config jest.account-mapping.config.js",
     "test:omnibus": "jest --config jest.omnibus.config.js",
     "test-server": "ts-node ./scripts/test-server.ts",
+    "migration": "ts-node ./scripts/migration.ts",
+    "sync-balances": "ts-node ./scripts/sync-balances.ts",
     "mass-approve": "ts-node ./scripts/mass-approve.ts",
     "verify-signature": "ts-node ./scripts/verify-signature.ts",
     "start-debug": "ts-node ./src/index.ts",
@@ -37,11 +41,11 @@
     "@dfns/sdk": "^0.8.11",
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
-    "@owneraio/finp2p-client": "^0.28.6",
-    "@owneraio/finp2p-contracts": "^0.28.8",
+    "@owneraio/finp2p-client": "^0.28.0",
+    "@owneraio/finp2p-contracts": "^0.28.4",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.6",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.5",
     "@owneraio/finp2p-vanilla-service": "^0.28.1",
     "@types/node": "^24.10.1",
     "axios": "^1.1.3",
@@ -53,7 +57,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@owneraio/adapter-tests": "^0.28.1",
+    "@owneraio/adapter-tests": "^0.28.0",
     "@testcontainers/postgresql": "^11.8.1",
     "@types/express": "^5.0.3",
     "@types/jest": "^29.2.0",

--- a/scripts/mass-approve.ts
+++ b/scripts/mass-approve.ts
@@ -29,12 +29,7 @@ const massApprove = async (
 
   const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
   const signerAddress = await signer.getAddress();
-  for (const { id: assetId, ledgerAssetInfo } of assets) {
-    const tokenAddress = ledgerAssetInfo.ledgerReference?.address ?? ledgerAssetInfo.ledgerIdentifier?.tokenId;
-    if (!tokenAddress) {
-      logger.warn(`asset ${assetId}: no tokenAddress in ledgerAssetInfo, skipping`);
-      continue;
-    }
+  for (const { id: assetId, ledgerAssetInfo: { tokenId: tokenAddress } } of assets) {
     try {
       const erc20 = new ERC20Contract(provider, signer, tokenAddress, logger);
       const decimals = await erc20.decimals();

--- a/scripts/mass-approve.ts
+++ b/scripts/mass-approve.ts
@@ -29,7 +29,12 @@ const massApprove = async (
 
   const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
   const signerAddress = await signer.getAddress();
-  for (const { id: assetId, ledgerAssetInfo: { tokenId: tokenAddress } } of assets) {
+  for (const { id: assetId, ledgerAssetInfo } of assets) {
+    const tokenAddress = ledgerAssetInfo.ledgerReference?.address ?? ledgerAssetInfo.ledgerIdentifier?.tokenId;
+    if (!tokenAddress) {
+      logger.warn(`asset ${assetId}: no tokenAddress in ledgerAssetInfo, skipping`);
+      continue;
+    }
     try {
       const erc20 = new ERC20Contract(provider, signer, tokenAddress, logger);
       const decimals = await erc20.decimals();

--- a/scripts/migration.ts
+++ b/scripts/migration.ts
@@ -21,11 +21,10 @@ const logger = winston.createLogger({
 });
 
 const getTokenAddress = (ledgerAssetInfo: LedgerAssetInfo): string => {
-  const { tokenId, ledgerReference } = ledgerAssetInfo;
-  if (ledgerReference) {
-    return ledgerReference.address;
+  if (ledgerAssetInfo.ledgerReference) {
+    return ledgerAssetInfo.ledgerReference.address;
   }
-  return tokenId;
+  return ledgerAssetInfo.ledgerIdentifier?.tokenId ?? '';
 };
 
 const whitelistERC20 = async (
@@ -123,27 +122,10 @@ const startMigration = async (
     }
   }
 
+  // Payment-asset migration removed when FinP2PClient.getPaymentAssets was dropped in 0.28.6.
+  // Re-implement via getAssets({ key: 'type', operator: 'equals', value: 'payment' }) if needed.
   if (oldFinp2pAddress) {
-    const oldFinP2PContract = new FinP2PContract(provider, signer, oldFinp2pAddress, logger);
-    const paymentAssets = await finp2p.getPaymentAssets();
-    logger.info(`Got a list of ${paymentAssets.length} assets to migrate`);
-    for (const { orgId: assetOrg, assets } of paymentAssets) {
-      if (assets.length > 0 && assetOrg === orgId) {
-        for (const { code } of assets) {
-          let tokenAddress: string;
-          try {
-            tokenAddress = await oldFinP2PContract.getAssetAddress(code);
-          } catch (e) {
-            if (!`${e}`.includes("Asset not found")) {
-              logger.error(e);
-            }
-            continue;
-          }
-          logger.info(`Migrating payment asset ${code} with token address ${tokenAddress}`);
-          await finP2PContract.associateAsset(code, tokenAddress);
-        }
-      }
-    }
+    logger.warn(`oldFinp2pAddress=${oldFinp2pAddress} provided, but payment-asset migration is not implemented for finp2p-client ^0.28.6`);
   }
 
   logger.info("Migration complete");

--- a/scripts/migration.ts
+++ b/scripts/migration.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+import winston, { format, transports } from "winston";
+import console from "console";
+import { FinP2PClient, LedgerAssetInfo } from "@owneraio/finp2p-client";
+import {
+  FinP2PContract,
+  ERC20Contract,
+  EthereumTransactionError,
+  MINTER_ROLE,
+  OPERATOR_ROLE,
+  isEthereumAddress
+} from "@owneraio/finp2p-contracts";
+import { createJsonProvider, parseConfig } from "../src/config";
+import { Provider, Signer } from "ethers";
+import { Logger } from "@owneraio/finp2p-nodejs-skeleton-adapter";
+
+const logger = winston.createLogger({
+  level: "info",
+  transports: [new transports.Console()],
+  format: format.json()
+});
+
+const getTokenAddress = (ledgerAssetInfo: LedgerAssetInfo): string => {
+  const { tokenId, ledgerReference } = ledgerAssetInfo;
+  if (ledgerReference) {
+    return ledgerReference.address;
+  }
+  return tokenId;
+};
+
+const whitelistERC20 = async (
+  provider: Provider,
+  signer: Signer,
+  tokenAddress: string,
+  logger: Logger,
+  operator: string
+) => {
+  logger.info(`Token standard is ERC20 with operator, checking roles`);
+  const erc20 = new ERC20Contract(provider, signer, tokenAddress, logger);
+  if (!await erc20.hasRole(OPERATOR_ROLE, operator)) {
+    await erc20.grantOperatorTo(operator);
+    logger.info("       granting new operator [done]");
+  } else {
+    logger.info(`       operator already granted for ${tokenAddress}`);
+  }
+  if (!await erc20.hasRole(MINTER_ROLE, operator)) {
+    await erc20.grantMinterTo(operator);
+    logger.info("       granting new minter [done]");
+  } else {
+    logger.info(`       minter already granted for ${tokenAddress}`);
+  }
+};
+
+
+const startMigration = async (
+  operatorPrivateKey: string,
+  ethereumRPCUrl: string,
+  orgId: string,
+  ossUrl: string,
+  finp2pContractAddress: string,
+  oldFinp2pAddress: string | undefined) => {
+  const finp2p = new FinP2PClient("", ossUrl);
+  const assets = await finp2p.getAssets();
+  logger.info(`Got a list of ${assets.length} assets to migrate`);
+
+  if (assets.length === 0) {
+    logger.info("No assets to migrate");
+    return;
+  }
+
+  const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
+  const finP2PContract = new FinP2PContract(provider, signer, finp2pContractAddress, logger);
+
+  let migrated = 0;
+  let skipped = 0;
+  for (const { organizationId, id: assetId, ledgerAssetInfo } of assets) {
+    if (organizationId !== orgId) {
+      continue;
+    }
+    if (!ledgerAssetInfo) {
+      continue;
+    }
+    const tokenAddress = getTokenAddress(ledgerAssetInfo);
+    if (!isEthereumAddress(tokenAddress)) {
+      continue
+    }
+
+    try {
+      const foundAddress = await finP2PContract.getAssetAddress(assetId);
+      if (foundAddress === tokenAddress) {
+        logger.info(`Asset ${assetId} already associated with token ${tokenAddress}`);
+        await whitelistERC20(provider, signer, tokenAddress, logger, finp2pContractAddress);
+        skipped++;
+        continue;
+      }
+    } catch (e) {
+      if (!`${e}`.includes("Asset not found")) {
+        throw e;
+      }
+    }
+
+    try {
+      logger.info(`Migrating asset ${assetId} with token address ${tokenAddress}`);
+      await finP2PContract.associateAsset(assetId, tokenAddress);
+      logger.info("       asset association [done]");
+      await whitelistERC20(provider, signer, tokenAddress, logger, finp2pContractAddress);
+      migrated++;
+    } catch (e) {
+      if (`${e}`.includes("Asset not found")) {
+        logger.info(`Asset ${assetId} not found on old contract`);
+        skipped++;
+        continue;
+      } else if (e instanceof EthereumTransactionError) {
+        if (e.reason.includes("Asset already exists")) {
+          skipped++;
+          continue;
+        }
+      } else if (`${e}`.includes("must have admin role to grant")) {
+        logger.info(`not an admin to grant roles for ${assetId}`);
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  if (oldFinp2pAddress) {
+    const oldFinP2PContract = new FinP2PContract(provider, signer, oldFinp2pAddress, logger);
+    const paymentAssets = await finp2p.getPaymentAssets();
+    logger.info(`Got a list of ${paymentAssets.length} assets to migrate`);
+    for (const { orgId: assetOrg, assets } of paymentAssets) {
+      if (assets.length > 0 && assetOrg === orgId) {
+        for (const { code } of assets) {
+          let tokenAddress: string;
+          try {
+            tokenAddress = await oldFinP2PContract.getAssetAddress(code);
+          } catch (e) {
+            if (!`${e}`.includes("Asset not found")) {
+              logger.error(e);
+            }
+            continue;
+          }
+          logger.info(`Migrating payment asset ${code} with token address ${tokenAddress}`);
+          await finP2PContract.associateAsset(code, tokenAddress);
+        }
+      }
+    }
+  }
+
+  logger.info("Migration complete");
+  logger.info(`Migrated ${migrated} of ${assets.length} assets`);
+  logger.info(`Skipped ${skipped} assets`);
+};
+
+
+const config = parseConfig([
+  {
+    name: "operator_pk",
+    envVar: "OPERATOR_PRIVATE_KEY",
+    required: true,
+    description: "Operator private key"
+  },
+  {
+    name: "rpc_url",
+    envVar: "RPC_URL",
+    required: true,
+    description: "Ethereum RPC URL"
+  },
+  {
+    name: "organization_id",
+    envVar: "ORGANIZATION_ID",
+    required: true,
+    description: "Organization ID"
+  },
+  {
+    name: "oss_url",
+    envVar: "OSS_URL",
+    required: true,
+    description: "OSS URL"
+  },
+  {
+    name: "finp2p_contract_address",
+    envVar: "FINP2P_CONTRACT_ADDRESS",
+    required: true,
+    description: "FINP2P Contract Address"
+  },
+  {
+    name: "old_finp2p_contract_address",
+    envVar: "OLD_FINP2P_CONTRACT_ADDRESS",
+    description: "Old FINP2P Contract Address"
+  }
+]);
+
+
+startMigration(
+  config.operator_pk!,
+  config.rpc_url!,
+  config.organization_id!,
+  config.oss_url!,
+  config.finp2p_contract_address!,
+  config.old_finp2p_contract_address
+).catch(console.error);

--- a/scripts/sync-balances.ts
+++ b/scripts/sync-balances.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import console from "console";
+import winston, { format, transports } from "winston";
+import { FinP2PClient } from "@owneraio/finp2p-client";
+import { FinP2PContract, AssetType, term } from "@owneraio/finp2p-contracts";
+import { emptyOperationParams } from "../src/services/finp2p-contract/helpers";
+import { createJsonProvider, parseConfig } from "../src/config";
+
+
+const logger = winston.createLogger({
+  level: "info",
+  transports: [new transports.Console()],
+  format: format.json()
+});
+
+const syncBalanceFromOssToEthereum = async (
+  operatorPrivateKey: string,
+  ethereumRPCUrl: string,
+  ossUrl: string,
+  finp2pContractAddress: string
+) => {
+  const finp2p = new FinP2PClient("", ossUrl);
+  const assets = await finp2p.getAssets();
+  logger.info(`Got a list of ${assets.length} assets to migrate`);
+
+  if (assets.length === 0) {
+    logger.info("No assets to migrate");
+    return;
+  }
+
+  const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
+  const contract = new FinP2PContract(provider, signer, finp2pContractAddress, logger);
+
+  for (const { id: assetId } of assets) {
+    try {
+      const erc20Address = await contract.getAssetAddress(assetId);
+      logger.info(`Found asset ${assetId} with token address ${erc20Address}`);
+    } catch (e) {
+      if (`${e}`.includes("Asset not found")) {
+        logger.info(`Deploying new token for asset ${assetId}`);
+        const erc20Address = await contract.deployERC20(assetId, assetId, 0, finp2pContractAddress);
+        logger.info(`Associating asset ${assetId} with token ${erc20Address}`);
+        await contract.associateAsset(assetId, erc20Address);
+      } else {
+        logger.error(`Error migrating asset ${assetId}: ${e}`);
+      }
+    }
+
+    const owners = await finp2p.getOwnerBalances(assetId);
+    for (const { finId, balance: expectedBalance } of owners) {
+      const actualBalance = await contract.balance(assetId, finId);
+      const balance = parseFloat(expectedBalance) - parseFloat(actualBalance);
+      if (balance > 0) {
+
+        logger.info(`Issuing ${balance} asset ${assetId} for finId ${finId}`);
+        await contract.issue(finId, term(assetId, AssetType.FinP2P, `${balance}`), emptyOperationParams());
+      } else if (balance < 0) {
+
+        logger.info(`Redeeming ${-balance} asset ${assetId} for finId ${finId}`);
+        await contract.redeem(finId, term(assetId, AssetType.FinP2P, `${-balance}`), emptyOperationParams());
+      } else {
+        logger.info(`FinId ${finId} already has enough balance for asset ${assetId}: ${balance}`);
+      }
+    }
+
+  }
+
+  logger.info("Migration complete");
+};
+
+const config = parseConfig([
+  {
+    name: "operator_pk",
+    envVar: "OPERATOR_PRIVATE_KEY",
+    required: true,
+    description: "Operator private key"
+  },
+  {
+    name: "rpc_url",
+    envVar: "RPC_URL",
+    required: true,
+    description: "Ethereum RPC URL"
+  },
+  {
+    name: "oss_url",
+    envVar: "OSS_URL",
+    description: "FinP2P OSS URL",
+    required: true
+  },
+  {
+    name: "finp2p_contract_address",
+    envVar: "FINP2P_CONTRACT_ADDRESS",
+    description: "FinP2P contract address",
+    required: true
+  }
+]);
+
+syncBalanceFromOssToEthereum(
+  config.operator_pk!,
+  config.rpc_url!,
+  config.oss_url!,
+  config.finp2p_contract_address!
+).then(() => {
+}).catch(console.error);

--- a/scripts/test-server.ts
+++ b/scripts/test-server.ts
@@ -114,10 +114,11 @@ const startHardhatContainer = async () => {
 const deployContract = async (
   provider: Provider,
   signer: Signer,
-  operatorAddress: string | undefined
+  operatorAddress: string | undefined,
+  paymentAssetCode: string | undefined = undefined
 ) => {
   const contractManger = new ContractsManager(provider, signer, logger);
-  return contractManger.deployFinP2PContract(operatorAddress);
+  return contractManger.deployFinP2PContract(operatorAddress, paymentAssetCode);
 };
 
 const deployERC20Contract = async (

--- a/src/app.ts
+++ b/src/app.ts
@@ -106,7 +106,6 @@ function registerFinP2PContractServices(
   app: express.Application, contractConfig: FinP2PContractAppConfig,
   paymentsService: PaymentsServiceImpl, pluginManager: PluginManager,
   dbPool: any, finP2PClient: FinP2PClient | undefined,
-  assetStore: AssetStore | undefined,
 ) {
   if (contractConfig.accountModel === 'omnibus') {
     throw new Error('Omnibus account model is not supported with finp2p-contract provider');
@@ -114,7 +113,7 @@ function registerFinP2PContractServices(
   const workflowStorage = dbPool ? new workflows.WorkflowStorage(dbPool) : undefined;
   let planApprovalService = new PlanApprovalServiceImpl(contractConfig.orgId, pluginManager, contractConfig.finP2PClient);
   const escrowService = new EscrowServiceImpl(contractConfig.finP2PContract, contractConfig.finP2PClient, contractConfig.execDetailsStore, contractConfig.proofProvider, pluginManager);
-  const tokenService = new TokenServiceImpl(contractConfig.finP2PContract, contractConfig.finP2PClient, contractConfig.execDetailsStore, contractConfig.proofProvider, pluginManager, assetStore);
+  const tokenService = new TokenServiceImpl(contractConfig.finP2PContract, contractConfig.finP2PClient, contractConfig.execDetailsStore, contractConfig.proofProvider, pluginManager);
   const mappingService = new CredentialsMappingService(contractConfig.finP2PContract);
   const mappingConfig = buildMappingConfig();
 
@@ -177,7 +176,7 @@ async function createApp(
   if (custodyProvider) {
     registerDirectServices(app, logger, custodyProvider, appConfig, paymentsService, pluginManager, dbPool, finP2PClient, accountMappingStore, assetStore);
   } else if (appConfig.type === 'finp2p-contract') {
-    registerFinP2PContractServices(app, appConfig as FinP2PContractAppConfig, paymentsService, pluginManager, dbPool, finP2PClient, assetStore);
+    registerFinP2PContractServices(app, appConfig as FinP2PContractAppConfig, paymentsService, pluginManager, dbPool, finP2PClient);
   } else {
     throw new Error(`Unknown provider type: '${appConfig.type}'. Available custody providers: ${custodyRegistry.availableProviders.join(', ')}`);
   }

--- a/src/services/finp2p-contract/helpers.ts
+++ b/src/services/finp2p-contract/helpers.ts
@@ -195,25 +195,13 @@ export const eip712PrimaryTypeFromTemplate = (template: EIP712Template): Primary
 };
 
 const compareAssets = (asset: Asset, eipAsset: EIP712Term): boolean => {
-  // 1) Direct FinP2P-id match (settlement, non-bound assets, pre-0.28 messages).
-  if (eipAsset.assetId === asset.assetId) return true;
-
-  // 2) 0.28 bound-ERC20 assetId encodes the on-chain contract address inline, e.g.
-  //    "name: sepolia, chainId: 11155111/ERC20:0x9f9b..aea". Match on the contract address.
-  const tokenId = asset.ledgerIdentifier?.tokenId?.toLowerCase();
-  if (tokenId) {
-    const m = eipAsset.assetId.toLowerCase().match(/0x[a-f0-9]{40}/);
-    if (m && m[0] === tokenId) return true;
-  }
-
-  // 3) Legacy fallback: assetFromAPI returns assetType='finp2p' for all assets,
-  //    but pre-0.28 EIP712 settlement terms used 'fiat'/'cryptocurrency' for USD/USDC.
+  // Settlement fallback: skeleton's assetFromAPI returns assetType='finp2p' for all assets,
+  // but EIP712 settlement terms use 'fiat'/'cryptocurrency'. Match well-known symbols across types.
   if (isIn(eipAsset.assetType as string, "fiat", "cryptocurrency") && isIn(eipAsset.assetId as string, "USD", "USDC") &&
     isIn(asset.assetType as string, "fiat", "cryptocurrency", "finp2p") && isIn(asset.assetId, "USD", "USDC")) {
     return true;
   }
-
-  return false;
+  return (eipAsset.assetId === asset.assetId && eipAsset.assetType === asset.assetType);
 };
 
 const isIn = (str: string, ...args: string[]): boolean => args.includes(str);

--- a/src/services/finp2p-contract/tokens.ts
+++ b/src/services/finp2p-contract/tokens.ts
@@ -4,7 +4,6 @@ import {
   failedReceiptOperation, successfulReceiptOperation, pendingReceiptOperation,
   AssetBind, AssetDenomination, AssetCreationResult, Destination, ExecutionContext,
   ReceiptOperation, Source, Signature, logger, ProofProvider, PluginManager,
-  storage,
 } from "@owneraio/finp2p-nodejs-skeleton-adapter";
 import { ValidationError } from "@owneraio/finp2p-contracts";
 import { FinP2PClient } from "@owneraio/finp2p-client";
@@ -20,88 +19,43 @@ import { mapReceiptOperation } from "./mapping";
 import { emptyOperationParams, extractBusinessDetails } from "./helpers";
 import { validateRequest } from "./validator";
 
-type AssetStore = InstanceType<typeof storage.PgAssetStore>;
 
 const DefaultDecimals = 2;
-
-/**
- * 0.28.2+ FINP2POperator extracts the ERC20 contract address from the trailing
- * ":0x<40-hex>" of each assetId. EIP712-signed flows carry the CAIP-style id
- * natively (e.g. "name: sepolia, chainId: .../ERC20:0x..."). Unsigned paths
- * (`issue`, balance reads) receive a plain resourceId from the API; the adapter
- * resolves the tokenAddress from its local AssetStore (populated during
- * `createAsset`) and appends the CAIP suffix.
- */
-const toContractAssetId = async (asset: Asset, assetStore: AssetStore | undefined): Promise<string> => {
-  // Already CAIP-encoded with a token-address suffix — pass through.
-  if (/:0x[a-fA-F0-9]{40}$/.test(asset.assetId)) return asset.assetId;
-  // Prefer an explicit ledgerIdentifier.tokenId iff it's a real EVM address.
-  const tokenFromLi = asset.ledgerIdentifier?.tokenId;
-  if (tokenFromLi && isEthereumAddress(tokenFromLi)) {
-    return `${asset.assetId}/${asset.ledgerIdentifier?.standard ?? 'ERC20'}:${tokenFromLi}`;
-  }
-  // Fall back to the adapter's local asset store.
-  if (assetStore) {
-    const record = await assetStore.getAsset(asset.assetId);
-    if (record?.contract_address) {
-      return `${asset.assetId}/${record.token_standard ?? 'ERC20'}:${record.contract_address}`;
-    }
-  }
-  return asset.assetId;
-};
 
 export class TokenServiceImpl extends CommonServiceImpl implements TokenService {
 
 
-  private readonly assetStore: AssetStore | undefined;
-
   constructor(finP2PContract: FinP2PContract, finP2PClient: FinP2PClient | undefined,
               execDetailsStore: ExecDetailsStore | undefined,
               proofProvider: ProofProvider | undefined,
-              pluginManager: PluginManager | undefined,
-              assetStore: AssetStore | undefined = undefined) {
+              pluginManager: PluginManager | undefined) {
     super(finP2PContract, finP2PClient, execDetailsStore, proofProvider, pluginManager);
-    this.assetStore = assetStore;
   }
 
   public async createAsset(idempotencyKey: string, assetId: string,
                            assetBind: AssetBind | undefined, assetMetadata: any | undefined, assetName: string | undefined, issuerId: string | undefined,
                            assetDenomination: AssetDenomination | undefined): Promise<AssetCreationStatus> {
     let tokenAddress: string;
-    let allowanceRequired: boolean;
-    const operatorAddress = this.finP2PContract.finP2PContractAddress;
+    let allowanceRequired: boolean
     if (assetBind?.tokenIdentifier?.tokenId && isEthereumAddress(assetBind.tokenIdentifier.tokenId)) {
       tokenAddress = assetBind.tokenIdentifier.tokenId;
       allowanceRequired = true; // TODO: parse from metadata
-      logger.info(`createAsset(${assetId}): binding to existing ERC20 at ${tokenAddress}`);
+      logger.debug(`Associating existing token ${tokenAddress} to asset ${assetId}`);
     } else {
-      logger.info(`createAsset(${assetId}): deploying new ERC20 (decimals=${DefaultDecimals}, operator=${operatorAddress})`);
-      try {
-        tokenAddress = await this.finP2PContract.deployERC20(assetId, assetId, DefaultDecimals, operatorAddress);
-      } catch (e) {
-        logger.error(`createAsset(${assetId}): deployERC20 failed: ${e}`);
-        if (e instanceof EthereumTransactionError) return failedAssetCreation(1, e.message);
+      tokenAddress = await this.finP2PContract.deployERC20(assetId, assetId, DefaultDecimals, this.finP2PContract.finP2PContractAddress);
+      allowanceRequired = false;
+      logger.debug(`Deployed new token ${tokenAddress} for asset ${assetId}`);
+    }
+
+    try {
+      const txHash = await this.finP2PContract.associateAsset(assetId, tokenAddress);
+    } catch (e) {
+      logger.error(`Error creating asset: ${e}`);
+      if (e instanceof EthereumTransactionError) {
+        return failedAssetCreation(1, e.message);
+      } else {
         return failedAssetCreation(1, `${e}`);
       }
-      allowanceRequired = false;
-      logger.info(`createAsset(${assetId}): deployed ERC20 at ${tokenAddress}`);
-    }
-    // 0.28.3: the on-chain contract parses tokenAddress inline from CAIP-style
-    // assetIds (primary). For legacy signers that still emit plain resourceIds
-    // (e.g. adapter-tests 0.28.x), the contract also supports a fallback lookup
-    // populated by associateAsset. Register both so either signer shape works.
-    if (this.assetStore) {
-      await this.assetStore.saveAsset({
-        id: assetId,
-        token_standard: 'ERC20',
-        contract_address: tokenAddress,
-        decimals: DefaultDecimals,
-      });
-    }
-    try {
-      await this.finP2PContract.associateAsset(assetId, tokenAddress);
-    } catch (e) {
-      logger.warning(`createAsset(${assetId}): associateAsset fallback registration failed (may already exist): ${e}`);
     }
 
     // TODO: parse assetMetadata to determine token standard and other details
@@ -129,8 +83,7 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
     const issuerFinId = destinationFinId;
     try {
       await this.ensureCredential(issuerFinId);
-      const contractAssetId = await toContractAssetId(asset, this.assetStore);
-      const transactionReceipt = await this.finP2PContract.issue(issuerFinId, term(contractAssetId, assetTypeFromString(asset.assetType), quantity), emptyOperationParams())
+      const transactionReceipt = await this.finP2PContract.issue(issuerFinId, term(asset.assetId, assetTypeFromString(asset.assetType), quantity), emptyOperationParams())
       if (exCtx) {
         this.execDetailsStore?.addExecutionContext(transactionReceipt.hash, exCtx.planId, exCtx.sequence);
       }
@@ -206,12 +159,12 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
 
   public async getBalance(asset: Asset, finId: string): Promise<string> {
     await this.ensureCredential(finId);
-    return await this.finP2PContract.balance(await toContractAssetId(asset, this.assetStore), finId);
+    return await this.finP2PContract.balance(asset.assetId, finId);
   }
 
   public async balance(asset: Asset, finId: string): Promise<Balance> {
     await this.ensureCredential(finId);
-    const balance = await this.finP2PContract.balance(await toContractAssetId(asset, this.assetStore), finId);
+    const balance = await this.finP2PContract.balance(asset.assetId, finId);
     return {
       current: balance,
       available: balance,


### PR DESCRIPTION
## Summary

The platform-side rollback ([finp2p-core PR #2266](https://github.com/owneraio/finp2p-core/pull/2266)) reverted the 0.28 wire-format change that dropped \`assetType\` from the EIP712 \`Term\` hash. This PR puts the adapter back where it was before that effort started.

## Reverts (back to pre-PR #218 state, commit \`c7bb354\`)
- **Solidity** — \`Term\` hash includes \`assetType\` again ([FINP2POperator.sol](finp2p-contracts/contracts/finp2p/FINP2POperator.sol), [FinP2PSignatureVerifier.sol](finp2p-contracts/contracts/utils/finp2p/FinP2PSignatureVerifier.sol)); VERSION back to \`0.28.0\`. \`FINP2POperatorWithRegistry.sol\` likewise.
- **finp2p-contracts TS** — \`TERM_TYPE\` has \`assetType\`, \`EIP712Term.assetType\` required, \`termFromEIP712\` strict, \`termToEIP712\` emits \`assetType\`. Package version pinned back to \`0.28.4\`.
- **Adapter** — \`helpers.ts::compareAssets\` requires \`assetType\` match again; \`tokens.ts\` drops the \`toContractAssetId\` helper + AssetStore plumbing; \`createAsset\` calls \`associateAsset\` (no DB save); \`app.ts\` wiring restored.
- **Manager / scripts** — \`preCreatePaymentAsset\` back; \`deploy.ts\` takes \`paymentAssetCode\` again; \`associate.ts\`, \`migration.ts\`, \`sync-balances.ts\` restored; \`test-server.ts\` and contract test fixtures back to associate-then-issue.
- **Deps floors** restored: \`finp2p-client ^0.28.0\`, \`finp2p-contracts ^0.28.4\`, \`skeleton ^0.28.5\`, \`adapter-tests ^0.28.0\`.
- **.gitignore** drops the scratch entries.

## Kept (unrelated to signature template)
- PR #220's \`mapReceiptOperation\` strip of empty \`executionContext\` (router-callback fix — orthogonal to the EIP712 change).
- PR #222's CI workflow (\`release/**\` + \`workflow_dispatch\` triggers).

## Verification
- 128/128 hardhat contract tests pass locally.
- Adapter \`tsc --noEmit\` clean.

## Note on published packages
\`@owneraio/finp2p-contracts@0.28.5\`–\`0.28.9\` remain on npm but are no longer referenced from this branch. Future work goes back to the \`0.28.4\` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)