### PR TITLE
Fix asset-create callback: use real ledger network + on-chain decimals

### DIFF
--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -10,7 +10,8 @@ import { parseUnits, id as keccak256 } from 'ethers';
 import winston from 'winston';
 import { CustodyProvider, CustodyWallet } from './custody-provider';
 import { tokenStandardRegistry } from "./token-standards/registry";
-import { ERC20_TOKEN_STANDARD } from "./token-standards/erc20";
+import { ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from "./token-standards/erc20";
+import { ERC20Contract } from "@owneraio/finp2p-contracts";
 import { AccountMappingService, AssetStore } from './account-mapping';
 import { getAssetFromDb } from './helpers';
 
@@ -271,31 +272,35 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     assetMetadata: any | undefined, assetName: string | undefined, issuerId: string | undefined,
     assetDenomination: AssetDenomination | undefined,
   ): Promise<AssetCreationResult> {
-    const decimals = 6;
-
     const tokenStandard = assetBind?.tokenIdentifier?.standard
       ? (tokenStandardRegistry.has(assetBind.tokenIdentifier.standard) ? assetBind.tokenIdentifier.standard : ERC20_TOKEN_STANDARD)
       : ERC20_TOKEN_STANDARD;
     const standard = tokenStandardRegistry.resolve(tokenStandard);
 
-    const makeLedgerIdentifier = (tokenId: string, std: string): LedgerAssetIdentifier => ({
+    const { chainId } = await this.custodyProvider.rpcProvider.getNetwork();
+    const defaultNetwork = `eip155:${chainId}`;
+
+    const makeLedgerIdentifier = (tokenId: string, std: string, network: string): LedgerAssetIdentifier => ({
       assetIdentifierType: 'CAIP-19',
-      network: '',
+      network,
       tokenId,
       standard: std,
     });
 
     if (assetBind === undefined || assetBind.tokenIdentifier === undefined) {
       const symbol = 'OWNERA';
-      const result = await standard.deploy(this.omnibusWallet, assetName ?? 'OWNERACOIN', symbol, decimals, this.logger);
+      const result = await standard.deploy(this.omnibusWallet, assetName ?? 'OWNERACOIN', symbol, DEFAULT_NEW_ERC20_DECIMALS, this.logger);
       await this.assetStore.saveAsset({ contract_address: result.contractAddress, decimals: result.decimals, token_standard: result.tokenStandard, id: assetId });
       await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);
-      return { ledgerIdentifier: makeLedgerIdentifier(result.contractAddress, result.tokenStandard), reference: undefined };
+      return { ledgerIdentifier: makeLedgerIdentifier(result.contractAddress, result.tokenStandard, defaultNetwork), reference: undefined };
     }
 
     const tokenAddress = assetBind.tokenIdentifier.tokenId;
+    const network = assetBind.tokenIdentifier.network || defaultNetwork;
+    const erc20 = new ERC20Contract(this.omnibusWallet.provider, this.omnibusWallet.signer, tokenAddress, this.logger);
+    const decimals = Number(await erc20.decimals());
     await this.assetStore.saveAsset({ contract_address: tokenAddress, decimals, token_standard: tokenStandard, id: assetId });
     await this.custodyProvider.onAssetRegistered?.(tokenAddress);
-    return { ledgerIdentifier: makeLedgerIdentifier(tokenAddress, tokenStandard), reference: undefined };
+    return { ledgerIdentifier: makeLedgerIdentifier(tokenAddress, tokenStandard, network), reference: undefined };
   }
 }

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -11,7 +11,8 @@ import { CustodyProvider, CustodyWallet } from './custody-provider';
 import { AccountMappingService, AssetStore } from './account-mapping';
 import { getAssetFromDb, fundGasIfNeeded } from './helpers';
 import { tokenStandardRegistry } from './token-standards/registry';
-import { ERC20_TOKEN_STANDARD } from './token-standards/erc20';
+import { ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from './token-standards/erc20';
+import { ERC20Contract } from '@owneraio/finp2p-contracts';
 import { buildOperationContext } from './operation-context';
 
 function resultToReceipt(
@@ -85,10 +86,13 @@ export class DirectTokenService implements TokenService, EscrowService {
     const tokenStandard = ERC20_TOKEN_STANDARD;
     const standard = tokenStandardRegistry.resolve(tokenStandard);
 
+    const { chainId } = await this.custodyProvider.rpcProvider.getNetwork();
+    const defaultNetwork = `eip155:${chainId}`;
+
     if (assetBind === undefined || assetBind.tokenIdentifier === undefined) {
       const wallet = this.custodyProvider.issuer;
       const symbol = "OWNERA"; // TODO: align with product team which metadata fields to use for token name/symbol/decimals
-      const result = await standard.deploy(wallet, assetName ?? "OWNERACOIN", symbol, 6, this.logger);
+      const result = await standard.deploy(wallet, assetName ?? "OWNERACOIN", symbol, DEFAULT_NEW_ERC20_DECIMALS, this.logger);
       await this.assetStore.saveAsset({
         contract_address: result.contractAddress,
         decimals: result.decimals,
@@ -100,13 +104,16 @@ export class DirectTokenService implements TokenService, EscrowService {
       return {
         operation: "createAsset",
         type: "success",
-        result: { ledgerIdentifier: { assetIdentifierType: 'CAIP-19', network: '', tokenId: result.contractAddress, standard: tokenStandard }, reference: undefined }
+        result: { ledgerIdentifier: { assetIdentifierType: 'CAIP-19', network: defaultNetwork, tokenId: result.contractAddress, standard: tokenStandard }, reference: undefined }
       };
     } else {
       const tokenAddress = assetBind.tokenIdentifier.tokenId;
+      const wallet = this.custodyProvider.issuer;
+      const erc20 = new ERC20Contract(wallet.provider, wallet.signer, tokenAddress, this.logger);
+      const decimals = Number(await erc20.decimals());
       await this.assetStore.saveAsset({
         contract_address: tokenAddress,
-        decimals: 6,
+        decimals,
         token_standard: tokenStandard,
         id: assetId,
       });
@@ -116,7 +123,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       return {
         operation: "createAsset",
         type: "success",
-        result: { ledgerIdentifier: { assetIdentifierType: 'CAIP-19', network: assetBind.tokenIdentifier.network ?? '', tokenId: tokenAddress, standard: tokenStandard }, reference: undefined }
+        result: { ledgerIdentifier: { assetIdentifierType: 'CAIP-19', network: assetBind.tokenIdentifier.network || defaultNetwork, tokenId: tokenAddress, standard: tokenStandard }, reference: undefined }
       };
     }
   }

--- a/src/services/direct/token-standards/erc20.ts
+++ b/src/services/direct/token-standards/erc20.ts
@@ -8,6 +8,12 @@ import {
 
 export const ERC20_TOKEN_STANDARD = 'ERC20';
 
+/**
+ * Decimals used when the adapter deploys a brand-new ERC20. For bind-to-existing
+ * we always read the on-chain `decimals()` instead — never assume.
+ */
+export const DEFAULT_NEW_ERC20_DECIMALS = 2;
+
 export class ERC20TokenStandard implements TokenStandard {
 
   async deploy(wallet: TokenWallet, name: string, symbol: string, decimals: number, logger: winston.Logger): Promise<DeployResult> {

--- a/tests/omnibus-delegate.test.ts
+++ b/tests/omnibus-delegate.test.ts
@@ -9,11 +9,13 @@ tokenStandardRegistry.register(ERC20_TOKEN_STANDARD, new ERC20TokenStandard());
 // Mock @owneraio/finp2p-contracts
 const mockBalanceOf = jest.fn();
 const mockTransfer = jest.fn();
+const mockDecimals = jest.fn();
 const mockDeployERC20Detached = jest.fn();
 jest.mock('@owneraio/finp2p-contracts', () => ({
   ERC20Contract: jest.fn().mockImplementation(() => ({
     balanceOf: mockBalanceOf,
     transfer: mockTransfer,
+    decimals: mockDecimals,
   })),
   ContractsManager: jest.fn().mockImplementation(() => ({
     deployERC20: mockDeployERC20Detached,
@@ -45,6 +47,7 @@ function createMockCustodyProvider(overrides: Partial<CustodyProvider> = {}): Cu
     rpcProvider: {
       waitForTransaction: jest.fn(),
       getBlock: jest.fn(),
+      getNetwork: jest.fn().mockResolvedValue({ chainId: 11155111n, name: 'sepolia' }),
     } as any,
     resolveWallet: jest.fn(),
     ...overrides,
@@ -247,26 +250,42 @@ describe('OmnibusDelegate', () => {
       );
 
       expect(result.ledgerIdentifier.tokenId).toBe(deployedAddress);
+      expect(result.ledgerIdentifier.network).toBe('eip155:11155111');
       expect(mockSaveAsset).toHaveBeenCalledWith(expect.objectContaining({
         contract_address: deployedAddress,
         id: TEST_ASSET.assetId,
       }));
     });
 
-    it('should use provided tokenIdentifier address', async () => {
+    it('should use provided tokenIdentifier address and read decimals on-chain', async () => {
       const existingAddress = '0xEXISTING_TOKEN';
+      mockDecimals.mockResolvedValue(8n);
 
       const result = await delegate.createAsset(
         'idem-create-2', TEST_ASSET.assetId,
-        { tokenIdentifier: { tokenId: existingAddress } } as any,
+        { tokenIdentifier: { tokenId: existingAddress, network: 'eip155:42161' } } as any,
         undefined, 'TestCoin', undefined, undefined,
       );
 
       expect(result.ledgerIdentifier.tokenId).toBe(existingAddress);
+      expect(result.ledgerIdentifier.network).toBe('eip155:42161');
       expect(mockDeployERC20Detached).not.toHaveBeenCalled();
       expect(mockSaveAsset).toHaveBeenCalledWith(expect.objectContaining({
         contract_address: existingAddress,
+        decimals: 8,
       }));
+    });
+
+    it('should fall back to chain-derived network when bind omits it', async () => {
+      mockDecimals.mockResolvedValue(6n);
+
+      const result = await delegate.createAsset(
+        'idem-create-3', TEST_ASSET.assetId,
+        { tokenIdentifier: { tokenId: '0xANY' } } as any,
+        undefined, undefined, undefined, undefined,
+      );
+
+      expect(result.ledgerIdentifier.network).toBe('eip155:11155111');
     });
   });
 });


### PR DESCRIPTION
## Summary
Asset-create requests at org-c/k3d-local6 looked stuck — adapter returned 200 with a pending cid, asset got registered on-chain, then nothing. Tracked it down to the workflow callback: skeleton 0.28.5's proxy silently swallowed FinAPI's 400 (only catches throws, not openapi-fetch's \`result.error\`).

Reproduced end-to-end:

| Replayed callback to router | Response |
|---|---|
| Adapter's actual stored payload (\`network: \"\"\`) | **HTTP 400** |
| Same payload with \`network: \"eip155:11155111\"\` | **HTTP 200** |

### Fixes
- **omnibus-delegate.createAsset** — bind path: preserve \`assetBind.tokenIdentifier.network\`. Deploy path: derive \`eip155:\${chainId}\` from \`rpcProvider.getNetwork()\`.
- **token-service.createAsset** — same fix to both paths (deploy was hardcoded to \`''\`, bind already had partial fallback to \`''\`).
- **decimals** — bind path now reads the ERC20 contract's \`decimals()\` instead of hardcoding 6 (USDC happens to be 6; most tokens aren't). New deploys use a new \`DEFAULT_NEW_ERC20_DECIMALS = 2\` constant.

The skeleton-side gap (silent callback errors in 0.28.5) is also worth fixing upstream so this kind of mismatch surfaces in adapter logs without forensic DB queries — see separate skeleton task.

## Test plan
- [x] \`tsc --noEmit\` passes
- [ ] CI green on PR
- [ ] Verify create-asset flow on k3d-local6 / org-c with USDC bind (decimals=6 read from contract, network=eip155:11155111 in callback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)