### PR TITLE
Bump finp2p-vanilla-service 0.28.1 → 0.28.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.11",
-        "@owneraio/finp2p-vanilla-service": "^0.28.1",
+        "@owneraio/finp2p-vanilla-service": "^0.28.2",
         "@types/node": "^24.10.1",
         "axios": "^1.1.3",
         "express": "^5.1.0",
@@ -1911,12 +1911,12 @@
       }
     },
     "node_modules/@owneraio/finp2p-vanilla-service": {
-      "version": "0.28.1",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-vanilla-service/0.28.1/3bb72da55d15c057cb17cbce758a6991e16605e1",
-      "integrity": "sha512-VfTkdbubKFnv1GuSRO/YaR4h3/bSYHODyQa/+fLSxCCNbs9EI5Fgo9Nor0Jj2xh+nunfU3xDXnm7zGnoz4ni9g==",
+      "version": "0.28.2",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-vanilla-service/0.28.2/4a488f8725266af379d0f6f534683ac7e98d4630",
+      "integrity": "sha512-M25RQJN4/eK8PAGCRBT2o6GHC6MR5NQHT9zO6/MPJSzYWL32Rm3Ni/G6NXpNgejD3FXOzjbiYC4LcDUmhKTqoA==",
       "license": "TBD",
       "dependencies": {
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.4",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.9",
         "bs58": "^6.0.0",
         "pg": "^8.15.6",
         "winston": "^3.18.3"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.11",
-    "@owneraio/finp2p-vanilla-service": "^0.28.1",
+    "@owneraio/finp2p-vanilla-service": "^0.28.2",
     "@types/node": "^24.10.1",
     "axios": "^1.1.3",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
Routine bump of `@owneraio/finp2p-vanilla-service` from 0.28.1 → 0.28.2. The new version's peer on `@owneraio/finp2p-nodejs-skeleton-adapter` widens to `^0.28.9`; root pin remains `^0.28.11` so resolution stays on 0.28.11 (single hoisted copy, no nested duplicates).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run test:account-mapping` — 14/14 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)