### PR TITLE
Pin vanilla LedgerStorage to LEDGER_SCHEMA (omnibus prod-incident fix)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ import {
   storage as storageModule,
 } from "@owneraio/finp2p-nodejs-skeleton-adapter";
 import { FinP2PClient } from "@owneraio/finp2p-client";
-import { createVanillaServices, registerDistributionRoutes } from "@owneraio/finp2p-vanilla-service";
+import { LedgerStorage, VanillaServiceImpl, registerDistributionRoutes } from "@owneraio/finp2p-vanilla-service";
 import {
   CredentialsMappingService,
   EscrowServiceImpl,
@@ -79,11 +79,19 @@ function registerDirectServices(
   if (appConfig.accountModel === 'omnibus') {
     if (!dbPool || !assetStore) throw new Error('DB connection is required for omnibus account model');
     const delegate = new OmnibusDelegate(logger, custodyProvider, accountMapping, assetStore);
-    const { tokenService, escrowService, commonService, mappingService, distributionService, inboundTransferHook } = createVanillaServices(
-      { transfer: delegate, asset: delegate, escrow: delegate, omnibus: delegate },
-      { connectionString: dbPool.options?.connectionString ?? '' },
-      logger,
-    );
+    // vanilla 0.28.2's createVanillaServices doesn't forward schemaName to its
+    // LedgerStorage, so its account_mappings/accounts/transactions queries hit
+    // the default `ledger_adapter` schema even when migrations placed those
+    // tables in `ethereum_adapter`. Build the storage + service ourselves to
+    // pin the schema. (LedgerStorage + VanillaServiceImpl are public exports.)
+    const ledgerStorage = new LedgerStorage(dbPool, ledgerSchema);
+    const vanillaService = new VanillaServiceImpl(ledgerStorage, delegate, delegate, delegate, delegate);
+    const tokenService = vanillaService;
+    const escrowService = vanillaService;
+    const commonService = vanillaService;
+    const mappingService = vanillaService;
+    const distributionService = vanillaService;
+    const inboundTransferHook = vanillaService;
     const planApprovalService = new PlanApprovalServiceImpl(appConfig.orgId, pluginManager, finP2PClient, inboundTransferHook);
     const proxiedPlanService = wrapWithWorkflowProxy(planApprovalService, workflowStorage, finP2PClient, 'approvePlan', 'proposeCancelPlan', 'proposeResetPlan', 'proposeInstructionApproval');
     const proxiedTokenService = wrapWithWorkflowProxy(tokenService, workflowStorage, finP2PClient, 'createAsset', 'issue', 'transfer', 'redeem');


### PR DESCRIPTION
## Summary
release-v0.28 omnibus deploy on org-c surfaced a build-side mismatch:

> migrations create the new `ethereum_adapter` schema (we see account_mappings, assets, operations there), but the runtime code still hard-codes queries against `ledger_adapter.account_mappings`.

Root cause: vanilla 0.28.2's [\`createVanillaServices()\`](node_modules/@owneraio/finp2p-vanilla-service/dist/index.js) builds `new LedgerStorage(pool)` with no schema arg → falls back to `storage.DEFAULT_SCHEMA_NAME` (`ledger_adapter`). That LedgerStorage backs vanilla's `account_mappings`/`accounts`/`transactions` queries used by the omnibus mappingService and ledger ops.

Adapter-side stores (`PgAccountStore`, `PgAssetStore`, `WorkflowStorage`) already received `ledgerSchema`; only vanilla's was missing.

## Fix
`LedgerStorage` and `VanillaServiceImpl` are both public exports — construct them ourselves and pass `ledgerSchema`. No vanilla bump or skeleton change needed.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run test:account-mapping` 14/14 pass
- [ ] CI green
- [ ] After merge: cherry-pick to release/v0.28, redeploy org-c, verify asset-create lands and omnibus credit/debit hit `ethereum_adapter.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)