### PR TITLE
Cherry-pick #233 (release cross-org destination) into release/v0.28

### DIFF
--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -183,11 +183,23 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const escrowWallet = this.custodyProvider.escrow;
     const amount = parseUnits(quantity, dbAsset.decimals);
 
+    // Local destination (mapped in our DB → our investor): funds stay pooled in our
+    // omnibus and per-finId accounting happens via vanilla's `accounts` table.
+    // External destination (counterparty in another org): the router supplies the
+    // counterparty's on-chain address via `destination.account.address`; deliver
+    // there directly so funds physically leave this org.
+    const localAddress = await this.accountMapping.resolveAccount(destination.finId);
+    const externalAddress = destination.account?.address;
+    if (!localAddress && !externalAddress) {
+      return { success: false, error: `Cannot resolve release destination for finId: ${destination.finId}` };
+    }
+    const onChainTarget = localAddress ? omnibusAddress : externalAddress!;
+
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
-    const result = await standard.release(escrowWallet, dbAsset, omnibusAddress, amount, this.logger);
+    const result = await standard.release(escrowWallet, dbAsset, onChainTarget, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
-    this.logger.info(`Release: ${quantity} of ${asset.assetId} from escrow to omnibus, tx: ${result.transactionId}`);
+    this.logger.info(`Release: ${quantity} of ${asset.assetId} from escrow to ${onChainTarget} (${localAddress ? 'local omnibus' : 'external'}), tx: ${result.transactionId}`);
     return { success: true, transactionId: result.transactionId ?? '' };
   }
 

--- a/tests/omnibus-delegate.test.ts
+++ b/tests/omnibus-delegate.test.ts
@@ -207,19 +207,50 @@ describe('OmnibusDelegate', () => {
   });
 
   describe('release', () => {
-    it('should transfer from escrow to omnibus', async () => {
+    it('should transfer from escrow to omnibus when destination is locally mapped', async () => {
       const mockReceipt = { hash: '0xRELEASE_TX', status: 1, getBlock: jest.fn().mockResolvedValue({ timestamp: 1700000000 }) };
       mockTransfer.mockResolvedValue({ wait: jest.fn().mockResolvedValue(mockReceipt) });
+      (accountMapping.resolveAccount as jest.Mock).mockResolvedValue('0xLOCAL_INVESTOR');
 
       const result = await delegate.release(
         'idem-release',
         {} as any,
-        {} as any,
+        { finId: 'local-investor-finId' } as any,
         TEST_ASSET, '5.0', 'op-2', undefined,
       );
 
       expect(result.success).toBe(true);
       expect(mockTransfer).toHaveBeenCalledWith('0xOMNIBUS', 5000000n);
+    });
+
+    it('should transfer from escrow to external counterparty address when destination is unmapped', async () => {
+      const mockReceipt = { hash: '0xCROSS_ORG_TX', status: 1, getBlock: jest.fn().mockResolvedValue({ timestamp: 1700000000 }) };
+      mockTransfer.mockResolvedValue({ wait: jest.fn().mockResolvedValue(mockReceipt) });
+      (accountMapping.resolveAccount as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await delegate.release(
+        'idem-release-cross-org',
+        {} as any,
+        { finId: 'remote-org-finId', account: { type: 'crypto', address: '0xREMOTE_ORG_OMNIBUS' } } as any,
+        TEST_ASSET, '7.0', 'op-cross', undefined,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockTransfer).toHaveBeenCalledWith('0xREMOTE_ORG_OMNIBUS', 7000000n);
+    });
+
+    it('should fail cleanly when neither local mapping nor external address is provided', async () => {
+      (accountMapping.resolveAccount as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await delegate.release(
+        'idem-release-bad',
+        {} as any,
+        { finId: 'unknown-finId' } as any,
+        TEST_ASSET, '1.0', 'op-bad', undefined,
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('Cannot resolve release destination');
     });
   });
 


### PR DESCRIPTION
Cherry-pick of #233 (`bf3e18c`) — `omnibus-delegate.release` now routes funds to the counterparty's `destination.account.address` when the destination finId isn't locally mapped, instead of always sending to local omnibus. Fixes the org-c → org-b cross-org settlement bug.

Test plan:
- [x] tsc clean
- [x] omnibus tests 16/16
- [ ] CI green
- [ ] Live: redeploy on org-b/k3d-local6, run cross-org Selling plan, verify on-chain Transfer goes to org-c's omnibus address (not org-b's).