### PR TITLE
omnibus-delegate: cover gas-funding gap on all signing paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",
-        "@owneraio/finp2p-vanilla-service": "^0.28.5",
+        "@owneraio/finp2p-vanilla-service": "^0.28.6",
         "@types/node": "^24.10.1",
         "axios": "^1.1.3",
         "express": "^5.1.0",
@@ -1911,9 +1911,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-vanilla-service": {
-      "version": "0.28.5",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-vanilla-service/0.28.5/c518523deac2f57551bf28ad02baccf671406cf9",
-      "integrity": "sha512-XvzO51ocXdJysFUIVAt3vMIrjUzuGnXZYeUkSvhiv1Nbien8bbcrDcfcp1C0sMkEhlrhBUKMGLQF942Oslh95w==",
+      "version": "0.28.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-vanilla-service/0.28.6/83388880b1d6f35a0f7d29af2128e6e243018e96",
+      "integrity": "sha512-1JgL0XKpsUyiD0V+IwNEHRZhNqqPNgEsj1bt6WCUPfdTJ/Vo6QaNByrKH/SWoFxq4/22TnraTmeGF7toqZ84ZA==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-client": "^0.28.12",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",
-    "@owneraio/finp2p-vanilla-service": "^0.28.5",
+    "@owneraio/finp2p-vanilla-service": "^0.28.6",
     "@types/node": "^24.10.1",
     "axios": "^1.1.3",
     "express": "^5.1.0",

--- a/src/integrations/dfns/provider.ts
+++ b/src/integrations/dfns/provider.ts
@@ -1,9 +1,9 @@
 import { DfnsApiClient } from '@dfns/sdk';
 import { AsymmetricKeySigner } from '@dfns/sdk-keysigner';
 import { DfnsWallet } from '@dfns/lib-ethersjs6';
-import { JsonRpcProvider, parseEther } from 'ethers';
+import { JsonRpcProvider } from 'ethers';
 import { DfnsAppConfig } from './config';
-import { CustodyProvider, CustodyWallet, GasStation, GAS_FUNDING_TIMEOUT_MS, GAS_FUNDING_POLL_INTERVAL_MS } from '../../services/direct';
+import { CustodyProvider, CustodyWallet, GasStation } from '../../services/direct';
 
 export class DfnsCustodyProvider implements CustodyProvider {
   readonly issuer: CustodyWallet;
@@ -63,7 +63,7 @@ export class DfnsCustodyProvider implements CustodyProvider {
     let gasStation: GasStation | undefined;
     if (config.gasFunding) {
       const gasWallet = await DfnsCustodyProvider.createWalletProvider(dfnsClient, config.gasFunding.walletId, config.rpcUrl);
-      gasStation = { wallet: gasWallet, amount: config.gasFunding.amount };
+      gasStation = new GasStation(gasWallet, config.gasFunding.amount);
     }
 
     let omnibusWallet: CustodyWallet | undefined;
@@ -92,30 +92,4 @@ export class DfnsCustodyProvider implements CustodyProvider {
     return wallet.address;
   }
 
-  /**
-   * Pre-fund only when below threshold; block until the target's on-chain
-   * balance actually reflects the funding before returning. DFNS resolves
-   * sendTransaction once the broadcast is queued, not when mined; polling
-   * the target balance is the strongest signal that the funding is usable
-   * by the next op.
-   */
-  async ensureGas(walletAddress: string): Promise<void> {
-    if (!this.gasStation) return;
-    const threshold = parseEther(this.gasStation.amount);
-    let balance = await this.rpcProvider.getBalance(walletAddress);
-    if (balance >= threshold) return;
-
-    await this.gasStation.wallet.signer.sendTransaction({
-      to: walletAddress,
-      value: threshold,
-    });
-
-    const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
-    while (Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
-      balance = await this.rpcProvider.getBalance(walletAddress);
-      if (balance >= threshold) return;
-    }
-    throw new Error(`Gas top-up to ${walletAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
-  }
 }

--- a/src/integrations/dfns/provider.ts
+++ b/src/integrations/dfns/provider.ts
@@ -93,20 +93,31 @@ export class DfnsCustodyProvider implements CustodyProvider {
   }
 
   /**
-   * Pre-fund only when below threshold; await the funding tx receipt before
-   * returning so the dependent op sees the new on-chain balance. DFNS'
-   * sendTransaction returns once the broadcast is accepted, not when mined.
+   * Pre-fund only when below threshold; block until the target's on-chain
+   * balance actually reflects the funding before returning. DFNS resolves
+   * sendTransaction once the broadcast is queued, not when mined; polling
+   * the target balance is the strongest signal that the funding is usable
+   * by the next op.
    */
   async ensureGas(wallet: CustodyWallet): Promise<void> {
     if (!this.gasStation) return;
     const targetAddress = await wallet.signer.getAddress();
     const threshold = parseEther(this.gasStation.amount);
-    const balance = await wallet.provider.getBalance(targetAddress);
+    let balance = await wallet.provider.getBalance(targetAddress);
     if (balance >= threshold) return;
-    const tx = await this.gasStation.wallet.signer.sendTransaction({
+
+    await this.gasStation.wallet.signer.sendTransaction({
       to: targetAddress,
       value: threshold,
     });
-    await tx.wait();
+
+    const deadline = Date.now() + 60_000;
+    const intervalMs = 1_000;
+    while (Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, intervalMs));
+      balance = await wallet.provider.getBalance(targetAddress);
+      if (balance >= threshold) return;
+    }
+    throw new Error(`Gas top-up to ${targetAddress} did not reflect on-chain after 60s (last balance: ${balance})`);
   }
 }

--- a/src/integrations/dfns/provider.ts
+++ b/src/integrations/dfns/provider.ts
@@ -99,24 +99,23 @@ export class DfnsCustodyProvider implements CustodyProvider {
    * the target balance is the strongest signal that the funding is usable
    * by the next op.
    */
-  async ensureGas(wallet: CustodyWallet): Promise<void> {
+  async ensureGas(walletAddress: string): Promise<void> {
     if (!this.gasStation) return;
-    const targetAddress = await wallet.signer.getAddress();
     const threshold = parseEther(this.gasStation.amount);
-    let balance = await wallet.provider.getBalance(targetAddress);
+    let balance = await this.rpcProvider.getBalance(walletAddress);
     if (balance >= threshold) return;
 
     await this.gasStation.wallet.signer.sendTransaction({
-      to: targetAddress,
+      to: walletAddress,
       value: threshold,
     });
 
     const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
-      balance = await wallet.provider.getBalance(targetAddress);
+      balance = await this.rpcProvider.getBalance(walletAddress);
       if (balance >= threshold) return;
     }
-    throw new Error(`Gas top-up to ${targetAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
+    throw new Error(`Gas top-up to ${walletAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
   }
 }

--- a/src/integrations/dfns/provider.ts
+++ b/src/integrations/dfns/provider.ts
@@ -1,7 +1,7 @@
 import { DfnsApiClient } from '@dfns/sdk';
 import { AsymmetricKeySigner } from '@dfns/sdk-keysigner';
 import { DfnsWallet } from '@dfns/lib-ethersjs6';
-import { JsonRpcProvider } from 'ethers';
+import { JsonRpcProvider, parseEther } from 'ethers';
 import { DfnsAppConfig } from './config';
 import { CustodyProvider, CustodyWallet, GasStation } from '../../services/direct';
 
@@ -90,5 +90,23 @@ export class DfnsCustodyProvider implements CustodyProvider {
       throw new Error(`No address found for DFNS wallet ${walletId}`);
     }
     return wallet.address;
+  }
+
+  /**
+   * Pre-fund only when below threshold; await the funding tx receipt before
+   * returning so the dependent op sees the new on-chain balance. DFNS'
+   * sendTransaction returns once the broadcast is accepted, not when mined.
+   */
+  async ensureGas(wallet: CustodyWallet): Promise<void> {
+    if (!this.gasStation) return;
+    const targetAddress = await wallet.signer.getAddress();
+    const threshold = parseEther(this.gasStation.amount);
+    const balance = await wallet.provider.getBalance(targetAddress);
+    if (balance >= threshold) return;
+    const tx = await this.gasStation.wallet.signer.sendTransaction({
+      to: targetAddress,
+      value: threshold,
+    });
+    await tx.wait();
   }
 }

--- a/src/integrations/dfns/provider.ts
+++ b/src/integrations/dfns/provider.ts
@@ -3,7 +3,7 @@ import { AsymmetricKeySigner } from '@dfns/sdk-keysigner';
 import { DfnsWallet } from '@dfns/lib-ethersjs6';
 import { JsonRpcProvider, parseEther } from 'ethers';
 import { DfnsAppConfig } from './config';
-import { CustodyProvider, CustodyWallet, GasStation } from '../../services/direct';
+import { CustodyProvider, CustodyWallet, GasStation, GAS_FUNDING_TIMEOUT_MS, GAS_FUNDING_POLL_INTERVAL_MS } from '../../services/direct';
 
 export class DfnsCustodyProvider implements CustodyProvider {
   readonly issuer: CustodyWallet;
@@ -111,13 +111,12 @@ export class DfnsCustodyProvider implements CustodyProvider {
       value: threshold,
     });
 
-    const deadline = Date.now() + 60_000;
-    const intervalMs = 1_000;
+    const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
     while (Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, intervalMs));
+      await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
       balance = await wallet.provider.getBalance(targetAddress);
       if (balance >= threshold) return;
     }
-    throw new Error(`Gas top-up to ${targetAddress} did not reflect on-chain after 60s (last balance: ${balance})`);
+    throw new Error(`Gas top-up to ${targetAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
   }
 }

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { parseEther } from 'ethers';
 import { createFireblocksEthersProvider, FireblocksAppConfig } from './config';
 import { createVaultManagementFunctions } from '../../vaults';
-import { CustodyProvider, CustodyWallet, GasStation } from '../../services/direct';
+import { CustodyProvider, CustodyWallet, GasStation, GAS_FUNDING_TIMEOUT_MS, GAS_FUNDING_POLL_INTERVAL_MS } from '../../services/direct';
 import { FireblocksRawSigner } from './raw-signer';
 
 export class FireblocksCustodyProvider implements CustodyProvider {
@@ -157,13 +157,12 @@ export class FireblocksCustodyProvider implements CustodyProvider {
       value: threshold,
     });
 
-    const deadline = Date.now() + 60_000;
-    const intervalMs = 1_000;
+    const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
     while (Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, intervalMs));
+      await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
       balance = await wallet.provider.getBalance(targetAddress);
       if (balance >= threshold) return;
     }
-    throw new Error(`Gas top-up to ${targetAddress} did not reflect on-chain after 60s (last balance: ${balance})`);
+    throw new Error(`Gas top-up to ${targetAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
   }
 }

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -1,5 +1,6 @@
 import { FireblocksSDK } from 'fireblocks-sdk';
 import axios from 'axios';
+import { parseEther } from 'ethers';
 import { createFireblocksEthersProvider, FireblocksAppConfig } from './config';
 import { createVaultManagementFunctions } from '../../vaults';
 import { CustodyProvider, CustodyWallet, GasStation } from '../../services/direct';
@@ -132,5 +133,26 @@ export class FireblocksCustodyProvider implements CustodyProvider {
       if (axios.isAxiosError(e) && e.response?.status === 409) return; // already registered — idempotent
       throw e;
     }
+  }
+
+  /**
+   * Pre-fund only when below threshold; await the funding tx receipt before
+   * returning. Fireblocks' raw signer (and the Fireblocks Web3 provider) both
+   * resolve sendTransaction() once Fireblocks accepts the request and a tx
+   * hash is known — not when the tx is mined. Without the .wait() the next
+   * dependent operation racing through Fireblocks sees on-chain balance still
+   * zero and fails with INSUFFICIENT_FUNDS_FOR_FEE.
+   */
+  async ensureGas(wallet: CustodyWallet): Promise<void> {
+    if (!this.gasStation) return;
+    const targetAddress = await wallet.signer.getAddress();
+    const threshold = parseEther(this.gasStation.amount);
+    const balance = await wallet.provider.getBalance(targetAddress);
+    if (balance >= threshold) return;
+    const tx = await this.gasStation.wallet.signer.sendTransaction({
+      to: targetAddress,
+      value: threshold,
+    });
+    await tx.wait();
   }
 }

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -136,23 +136,34 @@ export class FireblocksCustodyProvider implements CustodyProvider {
   }
 
   /**
-   * Pre-fund only when below threshold; await the funding tx receipt before
-   * returning. Fireblocks' raw signer (and the Fireblocks Web3 provider) both
-   * resolve sendTransaction() once Fireblocks accepts the request and a tx
-   * hash is known — not when the tx is mined. Without the .wait() the next
-   * dependent operation racing through Fireblocks sees on-chain balance still
-   * zero and fails with INSUFFICIENT_FUNDS_FOR_FEE.
+   * Pre-fund only when below threshold; block until the target's on-chain
+   * balance actually reflects the funding before returning. Fireblocks'
+   * sendTransaction may resolve once Fireblocks accepts the request — not
+   * when the tx is broadcast/mined; tx.wait() additionally requires the tx
+   * to be observable through our local RPC. Polling the target balance is
+   * the strongest signal: it covers broadcast, mining, and our RPC seeing
+   * it, in one check. Without this guard the dependent op races and fails
+   * with INSUFFICIENT_FUNDS_FOR_FEE.
    */
   async ensureGas(wallet: CustodyWallet): Promise<void> {
     if (!this.gasStation) return;
     const targetAddress = await wallet.signer.getAddress();
     const threshold = parseEther(this.gasStation.amount);
-    const balance = await wallet.provider.getBalance(targetAddress);
+    let balance = await wallet.provider.getBalance(targetAddress);
     if (balance >= threshold) return;
-    const tx = await this.gasStation.wallet.signer.sendTransaction({
+
+    await this.gasStation.wallet.signer.sendTransaction({
       to: targetAddress,
       value: threshold,
     });
-    await tx.wait();
+
+    const deadline = Date.now() + 60_000;
+    const intervalMs = 1_000;
+    while (Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, intervalMs));
+      balance = await wallet.provider.getBalance(targetAddress);
+      if (balance >= threshold) return;
+    }
+    throw new Error(`Gas top-up to ${targetAddress} did not reflect on-chain after 60s (last balance: ${balance})`);
   }
 }

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -145,24 +145,23 @@ export class FireblocksCustodyProvider implements CustodyProvider {
    * it, in one check. Without this guard the dependent op races and fails
    * with INSUFFICIENT_FUNDS_FOR_FEE.
    */
-  async ensureGas(wallet: CustodyWallet): Promise<void> {
+  async ensureGas(walletAddress: string): Promise<void> {
     if (!this.gasStation) return;
-    const targetAddress = await wallet.signer.getAddress();
     const threshold = parseEther(this.gasStation.amount);
-    let balance = await wallet.provider.getBalance(targetAddress);
+    let balance = await this.rpcProvider.getBalance(walletAddress);
     if (balance >= threshold) return;
 
     await this.gasStation.wallet.signer.sendTransaction({
-      to: targetAddress,
+      to: walletAddress,
       value: threshold,
     });
 
     const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
-      balance = await wallet.provider.getBalance(targetAddress);
+      balance = await this.rpcProvider.getBalance(walletAddress);
       if (balance >= threshold) return;
     }
-    throw new Error(`Gas top-up to ${targetAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
+    throw new Error(`Gas top-up to ${walletAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
   }
 }

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -1,9 +1,8 @@
 import { FireblocksSDK } from 'fireblocks-sdk';
 import axios from 'axios';
-import { parseEther } from 'ethers';
 import { createFireblocksEthersProvider, FireblocksAppConfig } from './config';
 import { createVaultManagementFunctions } from '../../vaults';
-import { CustodyProvider, CustodyWallet, GasStation, GAS_FUNDING_TIMEOUT_MS, GAS_FUNDING_POLL_INTERVAL_MS } from '../../services/direct';
+import { CustodyProvider, CustodyWallet, GasStation } from '../../services/direct';
 import { FireblocksRawSigner } from './raw-signer';
 
 export class FireblocksCustodyProvider implements CustodyProvider {
@@ -73,7 +72,7 @@ export class FireblocksCustodyProvider implements CustodyProvider {
     let gasStation: GasStation | undefined;
     if (config.gasFunding) {
       const gasWallet = await createWallet(config.gasFunding.vaultId);
-      gasStation = { wallet: gasWallet, amount: config.gasFunding.amount };
+      gasStation = new GasStation(gasWallet, config.gasFunding.amount);
     }
 
     let omnibusWallet: CustodyWallet | undefined;
@@ -133,35 +132,5 @@ export class FireblocksCustodyProvider implements CustodyProvider {
       if (axios.isAxiosError(e) && e.response?.status === 409) return; // already registered — idempotent
       throw e;
     }
-  }
-
-  /**
-   * Pre-fund only when below threshold; block until the target's on-chain
-   * balance actually reflects the funding before returning. Fireblocks'
-   * sendTransaction may resolve once Fireblocks accepts the request — not
-   * when the tx is broadcast/mined; tx.wait() additionally requires the tx
-   * to be observable through our local RPC. Polling the target balance is
-   * the strongest signal: it covers broadcast, mining, and our RPC seeing
-   * it, in one check. Without this guard the dependent op races and fails
-   * with INSUFFICIENT_FUNDS_FOR_FEE.
-   */
-  async ensureGas(walletAddress: string): Promise<void> {
-    if (!this.gasStation) return;
-    const threshold = parseEther(this.gasStation.amount);
-    let balance = await this.rpcProvider.getBalance(walletAddress);
-    if (balance >= threshold) return;
-
-    await this.gasStation.wallet.signer.sendTransaction({
-      to: walletAddress,
-      value: threshold,
-    });
-
-    const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
-    while (Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
-      balance = await this.rpcProvider.getBalance(walletAddress);
-      if (balance >= threshold) return;
-    }
-    throw new Error(`Gas top-up to ${walletAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
   }
 }

--- a/src/services/direct/custody-provider.ts
+++ b/src/services/direct/custody-provider.ts
@@ -28,12 +28,11 @@ export interface CustodyProvider {
   resolveAddressFromCustodyId?(custodyAccountId: string): Promise<string>;
   onAssetRegistered?(tokenAddress: string, symbol?: string): Promise<void>;
   /**
-   * Ensure `wallet` has at least the configured gas-station threshold available
-   * for the next on-chain tx. Pre-funds only when below threshold; the provider
-   * is responsible for awaiting the funding tx as needed (e.g. Fireblocks' raw
-   * signer returns after broadcast, not mining — needs tx.wait() before the
-   * dependent operation can use the new balance, otherwise the next signed tx
-   * fails with INSUFFICIENT_FUNDS_FOR_FEE).
+   * Ensure `walletAddress` has at least the configured gas-station threshold
+   * available for the next on-chain tx. Pre-funds only when below threshold;
+   * the provider is responsible for waiting until the new balance is reflected
+   * on-chain before returning, so the dependent op doesn't fail with
+   * INSUFFICIENT_FUNDS_FOR_FEE.
    */
-  ensureGas?(wallet: CustodyWallet): Promise<void>;
+  ensureGas?(walletAddress: string): Promise<void>;
 }

--- a/src/services/direct/custody-provider.ts
+++ b/src/services/direct/custody-provider.ts
@@ -1,19 +1,10 @@
 import { Provider, Signer } from "ethers";
+import { GasStation } from "./gas-station";
 
 export interface CustodyWallet {
   provider: Provider;
   signer: Signer;
 }
-
-export interface GasStation {
-  wallet: CustodyWallet;
-  amount: string;
-}
-
-/** How long ensureGas waits for the target wallet's balance to reflect the funding tx. */
-export const GAS_FUNDING_TIMEOUT_MS = 60_000;
-/** Poll interval for target balance during ensureGas. */
-export const GAS_FUNDING_POLL_INTERVAL_MS = 1_000;
 
 export interface CustodyProvider {
   readonly issuer: CustodyWallet;
@@ -27,12 +18,4 @@ export interface CustodyProvider {
   createWalletForCustodyId?(custodyAccountId: string): Promise<CustodyWallet>;
   resolveAddressFromCustodyId?(custodyAccountId: string): Promise<string>;
   onAssetRegistered?(tokenAddress: string, symbol?: string): Promise<void>;
-  /**
-   * Ensure `walletAddress` has at least the configured gas-station threshold
-   * available for the next on-chain tx. Pre-funds only when below threshold;
-   * the provider is responsible for waiting until the new balance is reflected
-   * on-chain before returning, so the dependent op doesn't fail with
-   * INSUFFICIENT_FUNDS_FOR_FEE.
-   */
-  ensureGas?(walletAddress: string): Promise<void>;
 }

--- a/src/services/direct/custody-provider.ts
+++ b/src/services/direct/custody-provider.ts
@@ -10,6 +10,11 @@ export interface GasStation {
   amount: string;
 }
 
+/** How long ensureGas waits for the target wallet's balance to reflect the funding tx. */
+export const GAS_FUNDING_TIMEOUT_MS = 60_000;
+/** Poll interval for target balance during ensureGas. */
+export const GAS_FUNDING_POLL_INTERVAL_MS = 1_000;
+
 export interface CustodyProvider {
   readonly issuer: CustodyWallet;
   readonly escrow: CustodyWallet;

--- a/src/services/direct/custody-provider.ts
+++ b/src/services/direct/custody-provider.ts
@@ -22,4 +22,13 @@ export interface CustodyProvider {
   createWalletForCustodyId?(custodyAccountId: string): Promise<CustodyWallet>;
   resolveAddressFromCustodyId?(custodyAccountId: string): Promise<string>;
   onAssetRegistered?(tokenAddress: string, symbol?: string): Promise<void>;
+  /**
+   * Ensure `wallet` has at least the configured gas-station threshold available
+   * for the next on-chain tx. Pre-funds only when below threshold; the provider
+   * is responsible for awaiting the funding tx as needed (e.g. Fireblocks' raw
+   * signer returns after broadcast, not mining — needs tx.wait() before the
+   * dependent operation can use the new balance, otherwise the next signed tx
+   * fails with INSUFFICIENT_FUNDS_FOR_FEE).
+   */
+  ensureGas?(wallet: CustodyWallet): Promise<void>;
 }

--- a/src/services/direct/gas-station.ts
+++ b/src/services/direct/gas-station.ts
@@ -1,0 +1,42 @@
+import { parseEther } from 'ethers';
+import { CustodyWallet } from './custody-provider';
+
+/** How long GasStation.ensureGas waits for the target balance to reflect the funding tx. */
+export const GAS_FUNDING_TIMEOUT_MS = 60_000;
+/** Poll interval for target balance during GasStation.ensureGas. */
+export const GAS_FUNDING_POLL_INTERVAL_MS = 1_000;
+
+/**
+ * Tops up a target wallet from a dedicated funding wallet so it has gas for the
+ * next on-chain tx. Custody-agnostic: works with any signer/provider pair.
+ *
+ * `ensureGas` blocks until the target balance is observed on-chain (poll-by-
+ * balance) — the side-effect that actually matters is the same regardless of
+ * whether the underlying signer's sendTransaction returns after broadcast or
+ * after mining.
+ */
+export class GasStation {
+  constructor(
+    public readonly wallet: CustodyWallet,
+    public readonly amount: string,
+  ) {}
+
+  async ensureGas(walletAddress: string): Promise<void> {
+    const threshold = parseEther(this.amount);
+    let balance = await this.wallet.provider.getBalance(walletAddress);
+    if (balance >= threshold) return;
+
+    await this.wallet.signer.sendTransaction({
+      to: walletAddress,
+      value: threshold,
+    });
+
+    const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
+      balance = await this.wallet.provider.getBalance(walletAddress);
+      if (balance >= threshold) return;
+    }
+    throw new Error(`Gas top-up to ${walletAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
+  }
+}

--- a/src/services/direct/helpers.ts
+++ b/src/services/direct/helpers.ts
@@ -15,13 +15,14 @@ export async function getAssetFromDb(assetStore: AssetStore, assetId: string): P
 }
 
 /**
- * Top up `wallet` from the gas station only if its current balance is below the
- * configured top-up amount. Useful for direct mode (per-investor wallets each
- * may need funding once) and equally for omnibus mode (few long-lived signers
- * shared across every operation — without the balance guard we'd send a top-up
- * tx before every hold/release/transfer).
+ * Ensure `wallet` has at least the configured gas-station threshold available
+ * for the next on-chain tx; pre-fund only when the wallet is below threshold.
+ * Useful for direct mode (per-investor wallets each may need a one-off top-up)
+ * and equally for omnibus mode (few long-lived signers shared across every
+ * operation — without the balance guard we'd send a top-up tx before every
+ * hold/release/transfer).
  */
-export async function fundGasIfNeeded(logger: winston.Logger, gasStation: GasStation | undefined, wallet: CustodyWallet): Promise<void> {
+export async function ensureGas(logger: winston.Logger, gasStation: GasStation | undefined, wallet: CustodyWallet): Promise<void> {
   if (!gasStation) return;
   try {
     const targetAddress = await wallet.signer.getAddress();

--- a/src/services/direct/helpers.ts
+++ b/src/services/direct/helpers.ts
@@ -1,7 +1,4 @@
 import { AssetRecord } from '@owneraio/finp2p-ethereum-token-standard';
-import { parseEther } from 'ethers';
-import winston from 'winston';
-import { CustodyWallet, GasStation } from './custody-provider';
 import { AssetStore } from './account-mapping';
 
 export async function getAssetFromDb(assetStore: AssetStore, assetId: string): Promise<AssetRecord> {
@@ -12,29 +9,4 @@ export async function getAssetFromDb(assetStore: AssetStore, assetId: string): P
     decimals: dbAsset.decimals,
     tokenStandard: dbAsset.token_standard,
   };
-}
-
-/**
- * Ensure `wallet` has at least the configured gas-station threshold available
- * for the next on-chain tx; pre-fund only when the wallet is below threshold.
- * Useful for direct mode (per-investor wallets each may need a one-off top-up)
- * and equally for omnibus mode (few long-lived signers shared across every
- * operation — without the balance guard we'd send a top-up tx before every
- * hold/release/transfer).
- */
-export async function ensureGas(logger: winston.Logger, gasStation: GasStation | undefined, wallet: CustodyWallet): Promise<void> {
-  if (!gasStation) return;
-  try {
-    const targetAddress = await wallet.signer.getAddress();
-    const threshold = parseEther(gasStation.amount);
-    const balance = await wallet.provider.getBalance(targetAddress);
-    if (balance >= threshold) return;
-    await gasStation.wallet.signer.sendTransaction({
-      to: targetAddress,
-      value: threshold,
-    });
-    logger.info(`Gas-funded ${targetAddress} with ${gasStation.amount} (balance was ${balance})`);
-  } catch (e) {
-    logger.warn(`Gas funding failed (wallet may already have sufficient gas): ${e}`);
-  }
 }

--- a/src/services/direct/helpers.ts
+++ b/src/services/direct/helpers.ts
@@ -14,14 +14,25 @@ export async function getAssetFromDb(assetStore: AssetStore, assetId: string): P
   };
 }
 
+/**
+ * Top up `wallet` from the gas station only if its current balance is below the
+ * configured top-up amount. Useful for direct mode (per-investor wallets each
+ * may need funding once) and equally for omnibus mode (few long-lived signers
+ * shared across every operation — without the balance guard we'd send a top-up
+ * tx before every hold/release/transfer).
+ */
 export async function fundGasIfNeeded(logger: winston.Logger, gasStation: GasStation | undefined, wallet: CustodyWallet): Promise<void> {
   if (!gasStation) return;
   try {
     const targetAddress = await wallet.signer.getAddress();
+    const threshold = parseEther(gasStation.amount);
+    const balance = await wallet.provider.getBalance(targetAddress);
+    if (balance >= threshold) return;
     await gasStation.wallet.signer.sendTransaction({
       to: targetAddress,
-      value: parseEther(gasStation.amount),
+      value: threshold,
     });
+    logger.info(`Gas-funded ${targetAddress} with ${gasStation.amount} (balance was ${balance})`);
   } catch (e) {
     logger.warn(`Gas funding failed (wallet may already have sufficient gas): ${e}`);
   }

--- a/src/services/direct/index.ts
+++ b/src/services/direct/index.ts
@@ -1,4 +1,5 @@
 export * from './custody-provider'
+export * from './gas-station'
 export * from './custody-registry'
 export * from './account-mapping'
 export * from './token-service'

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -47,7 +47,8 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
   }
 
   private async ensureGas(wallet: CustodyWallet): Promise<void> {
-    if (this.custodyProvider.ensureGas) await this.custodyProvider.ensureGas(wallet);
+    if (!this.custodyProvider.ensureGas) return;
+    await this.custodyProvider.ensureGas(await wallet.signer.getAddress());
   }
 
   async outboundTransfer(

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -61,6 +61,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
 
     const amount = parseUnits(quantity, dbAsset.decimals);
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.ensureGas(this.omnibusWallet);
     const result = await standard.transfer(this.omnibusWallet, dbAsset, destinationAddress, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -47,8 +47,8 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
   }
 
   private async ensureGas(wallet: CustodyWallet): Promise<void> {
-    if (!this.custodyProvider.ensureGas) return;
-    await this.custodyProvider.ensureGas(await wallet.signer.getAddress());
+    if (!this.custodyProvider.gasStation) return;
+    await this.custodyProvider.gasStation.ensureGas(await wallet.signer.getAddress());
   }
 
   async outboundTransfer(

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -13,7 +13,7 @@ import { tokenStandardRegistry } from "./token-standards/registry";
 import { ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from "./token-standards/erc20";
 import { ERC20Contract } from "@owneraio/finp2p-contracts";
 import { AccountMappingService, AssetStore } from './account-mapping';
-import { getAssetFromDb, fundGasIfNeeded } from './helpers';
+import { getAssetFromDb, ensureGas } from './helpers';
 
 export interface ReceiptPollingConfig {
   timeoutMs: number;
@@ -46,8 +46,8 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     this.receiptPolling = { ...defaultReceiptPolling, ...receiptPolling };
   }
 
-  private async fundGas(wallet: CustodyWallet): Promise<void> {
-    return fundGasIfNeeded(this.logger, this.custodyProvider.gasStation, wallet);
+  private async ensureGas(wallet: CustodyWallet): Promise<void> {
+    return ensureGas(this.logger, this.custodyProvider.gasStation, wallet);
   }
 
   async outboundTransfer(
@@ -171,7 +171,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const amount = parseUnits(quantity, dbAsset.decimals);
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
-    await this.fundGas(this.omnibusWallet);
+    await this.ensureGas(this.omnibusWallet);
     const result = await standard.hold(this.omnibusWallet, this.custodyProvider.escrow, dbAsset, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -201,7 +201,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const onChainTarget = localAddress ? omnibusAddress : externalAddress!;
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
-    await this.fundGas(escrowWallet);
+    await this.ensureGas(escrowWallet);
     const result = await standard.release(escrowWallet, dbAsset, onChainTarget, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -219,7 +219,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const amount = parseUnits(quantity, dbAsset.decimals);
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
-    await this.fundGas(escrowWallet);
+    await this.ensureGas(escrowWallet);
     const result = await standard.release(escrowWallet, dbAsset, omnibusAddress, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -308,7 +308,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
 
     if (assetBind === undefined || assetBind.tokenIdentifier === undefined) {
       const symbol = 'OWNERA';
-      await this.fundGas(this.omnibusWallet);
+      await this.ensureGas(this.omnibusWallet);
       const result = await standard.deploy(this.omnibusWallet, assetName ?? 'OWNERACOIN', symbol, DEFAULT_NEW_ERC20_DECIMALS, this.logger);
       await this.assetStore.saveAsset({ contract_address: result.contractAddress, decimals: result.decimals, token_standard: result.tokenStandard, id: assetId });
       await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -61,7 +61,6 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
 
     const amount = parseUnits(quantity, dbAsset.decimals);
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
-    await this.fundGas(this.omnibusWallet);
     const result = await standard.transfer(this.omnibusWallet, dbAsset, destinationAddress, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -13,7 +13,7 @@ import { tokenStandardRegistry } from "./token-standards/registry";
 import { ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from "./token-standards/erc20";
 import { ERC20Contract } from "@owneraio/finp2p-contracts";
 import { AccountMappingService, AssetStore } from './account-mapping';
-import { getAssetFromDb, ensureGas } from './helpers';
+import { getAssetFromDb } from './helpers';
 
 export interface ReceiptPollingConfig {
   timeoutMs: number;
@@ -47,7 +47,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
   }
 
   private async ensureGas(wallet: CustodyWallet): Promise<void> {
-    return ensureGas(this.logger, this.custodyProvider.gasStation, wallet);
+    if (this.custodyProvider.ensureGas) await this.custodyProvider.ensureGas(wallet);
   }
 
   async outboundTransfer(

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -13,7 +13,7 @@ import { tokenStandardRegistry } from "./token-standards/registry";
 import { ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from "./token-standards/erc20";
 import { ERC20Contract } from "@owneraio/finp2p-contracts";
 import { AccountMappingService, AssetStore } from './account-mapping';
-import { getAssetFromDb } from './helpers';
+import { getAssetFromDb, fundGasIfNeeded } from './helpers';
 
 export interface ReceiptPollingConfig {
   timeoutMs: number;
@@ -46,6 +46,10 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     this.receiptPolling = { ...defaultReceiptPolling, ...receiptPolling };
   }
 
+  private async fundGas(wallet: CustodyWallet): Promise<void> {
+    return fundGasIfNeeded(this.logger, this.custodyProvider.gasStation, wallet);
+  }
+
   async outboundTransfer(
     idempotencyKey: string, source: Source, destination: Destination,
     asset: Asset, quantity: string, exCtx: ExecutionContext | undefined,
@@ -57,6 +61,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
 
     const amount = parseUnits(quantity, dbAsset.decimals);
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.fundGas(this.omnibusWallet);
     const result = await standard.transfer(this.omnibusWallet, dbAsset, destinationAddress, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -167,6 +172,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const amount = parseUnits(quantity, dbAsset.decimals);
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.fundGas(this.omnibusWallet);
     const result = await standard.hold(this.omnibusWallet, this.custodyProvider.escrow, dbAsset, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -196,6 +202,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const onChainTarget = localAddress ? omnibusAddress : externalAddress!;
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.fundGas(escrowWallet);
     const result = await standard.release(escrowWallet, dbAsset, onChainTarget, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -213,6 +220,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const amount = parseUnits(quantity, dbAsset.decimals);
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.fundGas(escrowWallet);
     const result = await standard.release(escrowWallet, dbAsset, omnibusAddress, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -301,6 +309,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
 
     if (assetBind === undefined || assetBind.tokenIdentifier === undefined) {
       const symbol = 'OWNERA';
+      await this.fundGas(this.omnibusWallet);
       const result = await standard.deploy(this.omnibusWallet, assetName ?? 'OWNERACOIN', symbol, DEFAULT_NEW_ERC20_DECIMALS, this.logger);
       await this.assetStore.saveAsset({ contract_address: result.contractAddress, decimals: result.decimals, token_standard: result.tokenStandard, id: assetId });
       await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -9,7 +9,7 @@ import { parseUnits } from "ethers";
 import { TokenOperationResult } from '@owneraio/finp2p-ethereum-token-standard';
 import { CustodyProvider, CustodyWallet } from './custody-provider';
 import { AccountMappingService, AssetStore } from './account-mapping';
-import { getAssetFromDb, fundGasIfNeeded } from './helpers';
+import { getAssetFromDb, ensureGas } from './helpers';
 import { tokenStandardRegistry } from './token-standards/registry';
 import { ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from './token-standards/erc20';
 import { ERC20Contract } from '@owneraio/finp2p-contracts';
@@ -74,8 +74,8 @@ export class DirectTokenService implements TokenService, EscrowService {
     return { address, wallet };
   }
 
-  private async fundGas(wallet: CustodyWallet): Promise<void> {
-    return fundGasIfNeeded(this.logger, this.custodyProvider.gasStation, wallet);
+  private async ensureGas(wallet: CustodyWallet): Promise<void> {
+    return ensureGas(this.logger, this.custodyProvider.gasStation, wallet);
   }
 
   async createAsset(
@@ -155,7 +155,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const address = await this.resolveAddress(toFinId);
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(wallet);
+      await this.ensureGas(wallet);
       const result = await standard.mint(wallet, asset, address, amount, this.logger);
       const dest: Destination = { finId: toFinId };
       return resultToReceipt(result, ast, "issue", quantity, dest, dest, exCtx, undefined);
@@ -178,7 +178,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const { wallet } = resolved;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(wallet);
+      await this.ensureGas(wallet);
       const destinationAddress = await this.accountMapping.resolveAccount(destination.finId)
         ?? destination.account?.address;
       if (!destinationAddress) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
@@ -203,7 +203,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const wallet = this.custodyProvider.issuer;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(wallet);
+      await this.ensureGas(wallet);
       const opCtx = buildOperationContext(ast, signature, exCtx, operationId);
       const result = await standard.burn(wallet, asset, escrowAddress, amount, this.logger, opCtx);
       const source: Source = { finId: sourceFinId };
@@ -227,7 +227,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const { wallet } = resolved;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(wallet);
+      await this.ensureGas(wallet);
       const opCtx = buildOperationContext(ast, signature, exCtx, operationId);
       const result = await standard.hold(wallet, this.custodyProvider.escrow, asset, amount, this.logger, opCtx);
       return resultToReceipt(result, ast, "hold", quantity, source, destination, exCtx, operationId);
@@ -250,7 +250,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const escrowWallet = this.custodyProvider.escrow;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(escrowWallet);
+      await this.ensureGas(escrowWallet);
       const opCtx = buildOperationContext(ast, undefined, exCtx, operationId);
       const result = await standard.release(escrowWallet, asset, destinationAddress, amount, this.logger, opCtx);
       return resultToReceipt(result, ast, "release", quantity, source, destination, exCtx, operationId);
@@ -271,7 +271,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const escrowWallet = this.custodyProvider.escrow;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(escrowWallet);
+      await this.ensureGas(escrowWallet);
       const opCtx = buildOperationContext(ast, undefined, exCtx, operationId);
       const result = await standard.release(escrowWallet, asset, sourceAddress, amount, this.logger, opCtx);
       return resultToReceipt(result, ast, "release", quantity, source, undefined, exCtx, operationId);

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -75,8 +75,8 @@ export class DirectTokenService implements TokenService, EscrowService {
   }
 
   private async ensureGas(wallet: CustodyWallet): Promise<void> {
-    if (!this.custodyProvider.ensureGas) return;
-    await this.custodyProvider.ensureGas(await wallet.signer.getAddress());
+    if (!this.custodyProvider.gasStation) return;
+    await this.custodyProvider.gasStation.ensureGas(await wallet.signer.getAddress());
   }
 
   async createAsset(

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -75,7 +75,8 @@ export class DirectTokenService implements TokenService, EscrowService {
   }
 
   private async ensureGas(wallet: CustodyWallet): Promise<void> {
-    if (this.custodyProvider.ensureGas) await this.custodyProvider.ensureGas(wallet);
+    if (!this.custodyProvider.ensureGas) return;
+    await this.custodyProvider.ensureGas(await wallet.signer.getAddress());
   }
 
   async createAsset(

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -9,7 +9,7 @@ import { parseUnits } from "ethers";
 import { TokenOperationResult } from '@owneraio/finp2p-ethereum-token-standard';
 import { CustodyProvider, CustodyWallet } from './custody-provider';
 import { AccountMappingService, AssetStore } from './account-mapping';
-import { getAssetFromDb, ensureGas } from './helpers';
+import { getAssetFromDb } from './helpers';
 import { tokenStandardRegistry } from './token-standards/registry';
 import { ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from './token-standards/erc20';
 import { ERC20Contract } from '@owneraio/finp2p-contracts';
@@ -75,7 +75,7 @@ export class DirectTokenService implements TokenService, EscrowService {
   }
 
   private async ensureGas(wallet: CustodyWallet): Promise<void> {
-    return ensureGas(this.logger, this.custodyProvider.gasStation, wallet);
+    if (this.custodyProvider.ensureGas) await this.custodyProvider.ensureGas(wallet);
   }
 
   async createAsset(


### PR DESCRIPTION
## Summary
`OmnibusDelegate` had no gas-funding plumbing — every on-chain signing method (`outboundTransfer`, `hold`, `release`, `rollback`, `createAsset` deploy path) skipped `fundGasIfNeeded`. Direct mode (`DirectTokenService`) already covers this; this PR brings omnibus to parity.

In our k3d-local6 deployments the gap is masked because the omnibus + escrow vaults are statically pre-funded. If either drops below the gas threshold, every flow fails out-of-gas with no auto-topup.

### Wired in
| Method | Funded signer |
|---|---|
| `outboundTransfer` | omnibus wallet |
| `hold` | omnibus wallet (sends to escrow) |
| `release` | escrow wallet |
| `rollback` | escrow wallet |
| `createAsset` (deploy path only) | omnibus wallet |

`onInboundTransfer`, `getOmnibusBalance`, `getDepositInstruction`, `payout` are read-only / no-ops; not relevant.

### Balance-guard added to `fundGasIfNeeded`
Direct mode tops up unique per-investor wallets that may need funding once each — the previous fire-on-every-call behaviour was tolerable. Omnibus reuses the same one or two signers across every operation; without a balance check we'd send a top-up tx before every hold/release/transfer for no reason. Helper now reads the wallet's current balance and only sends the top-up when below threshold.

### Custody-agnostic
`CustodyProvider.gasStation` interface unchanged. Both Fireblocks and DFNS wire their respective gas wallets without modification.

## Test plan
- [x] tsc --noEmit clean
- [x] omnibus-delegate tests 16/16 (existing mocks don't set `gasStation`, balance-probe is bypassed via early-return)
- [ ] CI green
- [ ] Live: drain org-b's omnibus below threshold, confirm next operation triggers a single top-up tx and proceeds