### PR TITLE
Cherry-pick #237 (omnibus gas funding) into release/v0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",
-        "@owneraio/finp2p-vanilla-service": "^0.28.5",
+        "@owneraio/finp2p-vanilla-service": "^0.28.6",
         "@types/node": "^24.10.1",
         "axios": "^1.1.3",
         "express": "^5.1.0",
@@ -1911,9 +1911,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-vanilla-service": {
-      "version": "0.28.5",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-vanilla-service/0.28.5/c518523deac2f57551bf28ad02baccf671406cf9",
-      "integrity": "sha512-XvzO51ocXdJysFUIVAt3vMIrjUzuGnXZYeUkSvhiv1Nbien8bbcrDcfcp1C0sMkEhlrhBUKMGLQF942Oslh95w==",
+      "version": "0.28.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-vanilla-service/0.28.6/83388880b1d6f35a0f7d29af2128e6e243018e96",
+      "integrity": "sha512-1JgL0XKpsUyiD0V+IwNEHRZhNqqPNgEsj1bt6WCUPfdTJ/Vo6QaNByrKH/SWoFxq4/22TnraTmeGF7toqZ84ZA==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-client": "^0.28.12",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",
-    "@owneraio/finp2p-vanilla-service": "^0.28.5",
+    "@owneraio/finp2p-vanilla-service": "^0.28.6",
     "@types/node": "^24.10.1",
     "axios": "^1.1.3",
     "express": "^5.1.0",

--- a/src/integrations/dfns/provider.ts
+++ b/src/integrations/dfns/provider.ts
@@ -63,7 +63,7 @@ export class DfnsCustodyProvider implements CustodyProvider {
     let gasStation: GasStation | undefined;
     if (config.gasFunding) {
       const gasWallet = await DfnsCustodyProvider.createWalletProvider(dfnsClient, config.gasFunding.walletId, config.rpcUrl);
-      gasStation = { wallet: gasWallet, amount: config.gasFunding.amount };
+      gasStation = new GasStation(gasWallet, config.gasFunding.amount);
     }
 
     let omnibusWallet: CustodyWallet | undefined;
@@ -91,4 +91,5 @@ export class DfnsCustodyProvider implements CustodyProvider {
     }
     return wallet.address;
   }
+
 }

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -72,7 +72,7 @@ export class FireblocksCustodyProvider implements CustodyProvider {
     let gasStation: GasStation | undefined;
     if (config.gasFunding) {
       const gasWallet = await createWallet(config.gasFunding.vaultId);
-      gasStation = { wallet: gasWallet, amount: config.gasFunding.amount };
+      gasStation = new GasStation(gasWallet, config.gasFunding.amount);
     }
 
     let omnibusWallet: CustodyWallet | undefined;

--- a/src/services/direct/custody-provider.ts
+++ b/src/services/direct/custody-provider.ts
@@ -1,13 +1,9 @@
 import { Provider, Signer } from "ethers";
+import { GasStation } from "./gas-station";
 
 export interface CustodyWallet {
   provider: Provider;
   signer: Signer;
-}
-
-export interface GasStation {
-  wallet: CustodyWallet;
-  amount: string;
 }
 
 export interface CustodyProvider {

--- a/src/services/direct/gas-station.ts
+++ b/src/services/direct/gas-station.ts
@@ -1,0 +1,42 @@
+import { parseEther } from 'ethers';
+import { CustodyWallet } from './custody-provider';
+
+/** How long GasStation.ensureGas waits for the target balance to reflect the funding tx. */
+export const GAS_FUNDING_TIMEOUT_MS = 60_000;
+/** Poll interval for target balance during GasStation.ensureGas. */
+export const GAS_FUNDING_POLL_INTERVAL_MS = 1_000;
+
+/**
+ * Tops up a target wallet from a dedicated funding wallet so it has gas for the
+ * next on-chain tx. Custody-agnostic: works with any signer/provider pair.
+ *
+ * `ensureGas` blocks until the target balance is observed on-chain (poll-by-
+ * balance) — the side-effect that actually matters is the same regardless of
+ * whether the underlying signer's sendTransaction returns after broadcast or
+ * after mining.
+ */
+export class GasStation {
+  constructor(
+    public readonly wallet: CustodyWallet,
+    public readonly amount: string,
+  ) {}
+
+  async ensureGas(walletAddress: string): Promise<void> {
+    const threshold = parseEther(this.amount);
+    let balance = await this.wallet.provider.getBalance(walletAddress);
+    if (balance >= threshold) return;
+
+    await this.wallet.signer.sendTransaction({
+      to: walletAddress,
+      value: threshold,
+    });
+
+    const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
+      balance = await this.wallet.provider.getBalance(walletAddress);
+      if (balance >= threshold) return;
+    }
+    throw new Error(`Gas top-up to ${walletAddress} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms (last balance: ${balance})`);
+  }
+}

--- a/src/services/direct/helpers.ts
+++ b/src/services/direct/helpers.ts
@@ -1,7 +1,4 @@
 import { AssetRecord } from '@owneraio/finp2p-ethereum-token-standard';
-import { parseEther } from 'ethers';
-import winston from 'winston';
-import { CustodyWallet, GasStation } from './custody-provider';
 import { AssetStore } from './account-mapping';
 
 export async function getAssetFromDb(assetStore: AssetStore, assetId: string): Promise<AssetRecord> {
@@ -12,17 +9,4 @@ export async function getAssetFromDb(assetStore: AssetStore, assetId: string): P
     decimals: dbAsset.decimals,
     tokenStandard: dbAsset.token_standard,
   };
-}
-
-export async function fundGasIfNeeded(logger: winston.Logger, gasStation: GasStation | undefined, wallet: CustodyWallet): Promise<void> {
-  if (!gasStation) return;
-  try {
-    const targetAddress = await wallet.signer.getAddress();
-    await gasStation.wallet.signer.sendTransaction({
-      to: targetAddress,
-      value: parseEther(gasStation.amount),
-    });
-  } catch (e) {
-    logger.warn(`Gas funding failed (wallet may already have sufficient gas): ${e}`);
-  }
 }

--- a/src/services/direct/index.ts
+++ b/src/services/direct/index.ts
@@ -1,4 +1,5 @@
 export * from './custody-provider'
+export * from './gas-station'
 export * from './custody-registry'
 export * from './account-mapping'
 export * from './token-service'

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -46,6 +46,11 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     this.receiptPolling = { ...defaultReceiptPolling, ...receiptPolling };
   }
 
+  private async ensureGas(wallet: CustodyWallet): Promise<void> {
+    if (!this.custodyProvider.gasStation) return;
+    await this.custodyProvider.gasStation.ensureGas(await wallet.signer.getAddress());
+  }
+
   async outboundTransfer(
     idempotencyKey: string, source: Source, destination: Destination,
     asset: Asset, quantity: string, exCtx: ExecutionContext | undefined,
@@ -57,6 +62,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
 
     const amount = parseUnits(quantity, dbAsset.decimals);
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.ensureGas(this.omnibusWallet);
     const result = await standard.transfer(this.omnibusWallet, dbAsset, destinationAddress, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -167,6 +173,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const amount = parseUnits(quantity, dbAsset.decimals);
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.ensureGas(this.omnibusWallet);
     const result = await standard.hold(this.omnibusWallet, this.custodyProvider.escrow, dbAsset, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -196,6 +203,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const onChainTarget = localAddress ? omnibusAddress : externalAddress!;
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.ensureGas(escrowWallet);
     const result = await standard.release(escrowWallet, dbAsset, onChainTarget, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -213,6 +221,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     const amount = parseUnits(quantity, dbAsset.decimals);
 
     const standard = tokenStandardRegistry.resolve(dbAsset.tokenStandard);
+    await this.ensureGas(escrowWallet);
     const result = await standard.release(escrowWallet, dbAsset, omnibusAddress, amount, this.logger);
     if (result.status === 'failure') return { success: false, error: result.reason };
 
@@ -301,6 +310,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
 
     if (assetBind === undefined || assetBind.tokenIdentifier === undefined) {
       const symbol = 'OWNERA';
+      await this.ensureGas(this.omnibusWallet);
       const result = await standard.deploy(this.omnibusWallet, assetName ?? 'OWNERACOIN', symbol, DEFAULT_NEW_ERC20_DECIMALS, this.logger);
       await this.assetStore.saveAsset({ contract_address: result.contractAddress, decimals: result.decimals, token_standard: result.tokenStandard, id: assetId });
       await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -9,7 +9,7 @@ import { parseUnits } from "ethers";
 import { TokenOperationResult } from '@owneraio/finp2p-ethereum-token-standard';
 import { CustodyProvider, CustodyWallet } from './custody-provider';
 import { AccountMappingService, AssetStore } from './account-mapping';
-import { getAssetFromDb, fundGasIfNeeded } from './helpers';
+import { getAssetFromDb } from './helpers';
 import { tokenStandardRegistry } from './token-standards/registry';
 import { ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from './token-standards/erc20';
 import { ERC20Contract } from '@owneraio/finp2p-contracts';
@@ -74,8 +74,9 @@ export class DirectTokenService implements TokenService, EscrowService {
     return { address, wallet };
   }
 
-  private async fundGas(wallet: CustodyWallet): Promise<void> {
-    return fundGasIfNeeded(this.logger, this.custodyProvider.gasStation, wallet);
+  private async ensureGas(wallet: CustodyWallet): Promise<void> {
+    if (!this.custodyProvider.gasStation) return;
+    await this.custodyProvider.gasStation.ensureGas(await wallet.signer.getAddress());
   }
 
   async createAsset(
@@ -155,7 +156,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const address = await this.resolveAddress(toFinId);
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(wallet);
+      await this.ensureGas(wallet);
       const result = await standard.mint(wallet, asset, address, amount, this.logger);
       const dest: Destination = { finId: toFinId };
       return resultToReceipt(result, ast, "issue", quantity, dest, dest, exCtx, undefined);
@@ -178,7 +179,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const { wallet } = resolved;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(wallet);
+      await this.ensureGas(wallet);
       const destinationAddress = await this.accountMapping.resolveAccount(destination.finId)
         ?? destination.account?.address;
       if (!destinationAddress) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
@@ -203,7 +204,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const wallet = this.custodyProvider.issuer;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(wallet);
+      await this.ensureGas(wallet);
       const opCtx = buildOperationContext(ast, signature, exCtx, operationId);
       const result = await standard.burn(wallet, asset, escrowAddress, amount, this.logger, opCtx);
       const source: Source = { finId: sourceFinId };
@@ -227,7 +228,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const { wallet } = resolved;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(wallet);
+      await this.ensureGas(wallet);
       const opCtx = buildOperationContext(ast, signature, exCtx, operationId);
       const result = await standard.hold(wallet, this.custodyProvider.escrow, asset, amount, this.logger, opCtx);
       return resultToReceipt(result, ast, "hold", quantity, source, destination, exCtx, operationId);
@@ -250,7 +251,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const escrowWallet = this.custodyProvider.escrow;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(escrowWallet);
+      await this.ensureGas(escrowWallet);
       const opCtx = buildOperationContext(ast, undefined, exCtx, operationId);
       const result = await standard.release(escrowWallet, asset, destinationAddress, amount, this.logger, opCtx);
       return resultToReceipt(result, ast, "release", quantity, source, destination, exCtx, operationId);
@@ -271,7 +272,7 @@ export class DirectTokenService implements TokenService, EscrowService {
       const escrowWallet = this.custodyProvider.escrow;
       const amount = parseUnits(quantity, asset.decimals);
 
-      await this.fundGas(escrowWallet);
+      await this.ensureGas(escrowWallet);
       const opCtx = buildOperationContext(ast, undefined, exCtx, operationId);
       const result = await standard.release(escrowWallet, asset, sourceAddress, amount, this.logger, opCtx);
       return resultToReceipt(result, ast, "release", quantity, source, undefined, exCtx, operationId);


### PR DESCRIPTION
Cherry-pick of #237 ('7e57e69'). Wires ensureGas through every OmnibusDelegate signing path (outboundTransfer / hold / release / rollback / createAsset deploy), encapsulates the funding logic in a GasStation class with balance-poll-until-reflected semantics, vanilla 0.28.5→0.28.6.

Test plan:
- [x] tsc clean
- [x] omnibus tests 16/16
- [ ] CI green
- [ ] Live: drain org-b's omnibus below threshold, confirm next op triggers a single top-up + waits for the new balance to land before proceeding (no INSUFFICIENT_FUNDS_FOR_FEE)