### PR TITLE
Cherry-pick #224 (deposit plugins) into release/v0.28

### DIFF
--- a/jest.deposits-omnibus.config.js
+++ b/jest.deposits-omnibus.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "./tests/utils/fireblocks-omnibus-test-environment.ts",
+  testTimeout: 1200000,
+  roots: ["<rootDir>/tests"],
+  testMatch: ["<rootDir>/tests/deposits-omnibus.test.ts"],
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest",
+  },
+  moduleNameMapper: {
+    "\\.graphql$": "<rootDir>/tests/utils/graphql-stub.js",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:dfns": "jest --config jest.dfns.config.js",
     "test:account-mapping": "jest --config jest.account-mapping.config.js",
     "test:omnibus": "jest --config jest.omnibus.config.js",
+    "test:deposits-omnibus": "jest --config jest.deposits-omnibus.config.js",
     "test-server": "ts-node ./scripts/test-server.ts",
     "migration": "ts-node ./scripts/migration.ts",
     "sync-balances": "ts-node ./scripts/sync-balances.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,49 +55,59 @@ function wrapWithWorkflowProxy<T extends object>(
   return workflows.createServiceProxy(() => Promise.resolve(), workflowStorage, finP2PClient, service, ...methods);
 }
 
+/**
+ * Pre-built omnibus services. Created in createApp BEFORE registerIntegrations so the
+ * inboundTransferHook can be threaded into the deposit plugins at construction time —
+ * otherwise the plugins capture undefined and successful omnibus deposits silently fall
+ * back to importTransactions only, never crediting the adapter's own omnibus ledger.
+ */
+interface OmnibusContext {
+  delegate: OmnibusDelegate;
+  vanilla: {
+    tokenService: VanillaServiceImpl;
+    escrowService: VanillaServiceImpl;
+    commonService: VanillaServiceImpl;
+    mappingService: VanillaServiceImpl;
+    distributionService: VanillaServiceImpl;
+    inboundTransferHook: VanillaServiceImpl;
+  };
+}
+
 function registerDirectServices(
   app: express.Application, logger: winston.Logger, custodyProvider: CustodyProvider, appConfig: AppConfig,
   paymentsService: PaymentsServiceImpl, pluginManager: PluginManager,
   dbPool: any, finP2PClient: FinP2PClient | undefined,
   accountMappingStore: AccountMappingStore | undefined,
+  accountMappingService: AccountMappingServiceImpl | undefined,
   assetStore: AssetStore | undefined,
+  accountMapping: AccountMappingService,
+  omnibusCtx: OmnibusContext | undefined,
   ledgerSchema: string | undefined,
 ) {
   const healthService = new DirectHealthServiceImpl(custodyProvider.rpcProvider);
   const mappingConfig = buildMappingConfig(custodyProvider);
-  // Skeleton 0.28.11+: caseSensitive=false makes the service lowercase
-  // FIELD_LEDGER_ACCOUNT_ID values on save and lookup, so EIP-55 checksummed
-  // and lowercase EVM addresses resolve to the same record.
-  const accountMappingService = accountMappingStore
-    ? new AccountMappingServiceImpl(accountMappingStore, { caseSensitive: false })
-    : undefined;
-  const accountMapping: AccountMappingService = appConfig.accountMappingType === 'database' && accountMappingService
-    ? new DbAccountMapping(accountMappingService)
-    : new DerivationAccountMapping();
   const workflowStorage = dbPool ? new workflows.WorkflowStorage(dbPool, ledgerSchema) : undefined;
 
   if (appConfig.accountModel === 'omnibus') {
-    if (!dbPool || !assetStore) throw new Error('DB connection is required for omnibus account model');
-    const delegate = new OmnibusDelegate(logger, custodyProvider, accountMapping, assetStore);
-    // vanilla 0.28.2's createVanillaServices doesn't forward schemaName to its
-    // LedgerStorage, so its account_mappings/accounts/transactions queries hit
-    // the default `ledger_adapter` schema even when migrations placed those
-    // tables in `ethereum_adapter`. Build the storage + service ourselves to
-    // pin the schema. (LedgerStorage + VanillaServiceImpl are public exports.)
-    const ledgerStorage = new LedgerStorage(dbPool, ledgerSchema);
-    const vanillaService = new VanillaServiceImpl(ledgerStorage, delegate, delegate, delegate, delegate, finP2PClient);
-    const tokenService = vanillaService;
-    const escrowService = vanillaService;
-    const commonService = vanillaService;
-    const mappingService = vanillaService;
-    const distributionService = vanillaService;
-    const inboundTransferHook = vanillaService;
+    if (!omnibusCtx) throw new Error('Omnibus context not built — createVanillaServices must run before registerDirectServices');
+    const { delegate, vanilla } = omnibusCtx;
+    const { tokenService, escrowService, commonService, mappingService, distributionService, inboundTransferHook } = vanilla;
     const planApprovalService = new PlanApprovalServiceImpl(appConfig.orgId, pluginManager, finP2PClient, inboundTransferHook);
     const proxiedPlanService = wrapWithWorkflowProxy(planApprovalService, workflowStorage, finP2PClient, 'approvePlan', 'proposeCancelPlan', 'proposeResetPlan', 'proposeInstructionApproval');
     const proxiedTokenService = wrapWithWorkflowProxy(tokenService, workflowStorage, finP2PClient, 'createAsset', 'issue', 'transfer', 'redeem');
     const proxiedEscrowService = wrapWithWorkflowProxy(escrowService, workflowStorage, finP2PClient, 'hold', 'release', 'rollback');
-    const proxiedPaymentService = wrapWithWorkflowProxy(delegate, workflowStorage, finP2PClient, 'getDepositInstruction', 'payout');
-    register(app, proxiedTokenService, proxiedEscrowService, commonService, commonService, proxiedPaymentService, proxiedPlanService, mappingConfig, mappingService);
+    // When a PaymentsPlugin is registered (e.g. ota-deposit / pull-deposit), route deposits
+    // through it so per-deposit ephemeral addresses, approval-watchers, and FinAPI receipt
+    // export run. Otherwise fall back to the omnibus delegate's barebones "deposit to omnibus"
+    // instruction, which has no plugin awareness.
+    const paymentImpl = pluginManager.getPaymentsPlugin() !== null ? paymentsService : delegate;
+    const proxiedPaymentService = wrapWithWorkflowProxy(paymentImpl, workflowStorage, finP2PClient, 'getDepositInstruction', 'payout');
+    // vanilla-service's commonService.operationStatus unconditionally throws — async ops
+    // persisted by the workflow proxy would be unreachable via /operations/status. Use the
+    // workflow-storage-backed DirectCommonServiceImpl for that route, keep vanilla
+    // commonService for liveness/readiness.
+    const directCommonService = workflowStorage ? new DirectCommonServiceImpl(workflowStorage) : commonService;
+    register(app, proxiedTokenService, proxiedEscrowService, directCommonService, commonService, proxiedPaymentService, proxiedPlanService, mappingConfig, mappingService);
     if (distributionService) {
       registerDistributionRoutes(app, distributionService);
     }
@@ -181,6 +191,45 @@ async function createApp(
     custodyProvider = await custodyRegistry.create(appConfig.type, appConfig);
   }
 
+  // Pre-build accountMapping + (in omnibus mode) the OmnibusDelegate and vanilla services
+  // BEFORE plugin registration. Deposit plugins capture inboundTransferHook in their
+  // constructors; if it's undefined at registration time they fall back to
+  // finP2PClient.importTransactions only, skipping the vanilla hook's storage.credit(...)
+  // and leaving the adapter's omnibus balance state stale.
+  //
+  // Skeleton 0.28.11+: caseSensitive=false makes the account-mapping service lowercase
+  // FIELD_LEDGER_ACCOUNT_ID values on save and lookup, so EIP-55 checksummed and lowercase
+  // EVM addresses resolve to the same record.
+  const accountMappingService = accountMappingStore
+    ? new AccountMappingServiceImpl(accountMappingStore, { caseSensitive: false })
+    : undefined;
+  const accountMapping: AccountMappingService = appConfig.accountMappingType === 'database' && accountMappingService
+    ? new DbAccountMapping(accountMappingService)
+    : new DerivationAccountMapping();
+
+  let omnibusCtx: OmnibusContext | undefined;
+  if (appConfig.accountModel === 'omnibus' && custodyProvider) {
+    if (!dbPool || !assetStore) throw new Error('DB connection is required for omnibus account model');
+    const delegate = new OmnibusDelegate(logger, custodyProvider, accountMapping, assetStore);
+    // vanilla 0.28.2's createVanillaServices doesn't forward schemaName to its LedgerStorage,
+    // so its account_mappings/accounts/transactions queries hit the default `ledger_adapter`
+    // schema even when migrations placed those tables in `ethereum_adapter`. Build the storage
+    // + service ourselves to pin the schema. (LedgerStorage + VanillaServiceImpl are public.)
+    const ledgerStorage = new LedgerStorage(dbPool, ledgerSchema);
+    const vanillaService = new VanillaServiceImpl(ledgerStorage, delegate, delegate, delegate, delegate, finP2PClient);
+    omnibusCtx = {
+      delegate,
+      vanilla: {
+        tokenService: vanillaService,
+        escrowService: vanillaService,
+        commonService: vanillaService,
+        mappingService: vanillaService,
+        distributionService: vanillaService,
+        inboundTransferHook: vanillaService,
+      },
+    };
+  }
+
   registerIntegrations({
     orgId: appConfig.orgId,
     logger,
@@ -188,12 +237,16 @@ async function createApp(
     finP2PClient: finP2PClient!,
     walletResolver: custodyProvider && accountMappingStore ? createWalletResolver(accountMappingStore, custodyProvider) : undefined,
     rpcUrl: process.env.NETWORK_HOST ? getNetworkRpcUrl() : undefined,
+    assetStore,
+    accountModel: appConfig.accountModel,
+    custodyProvider,
+    inboundTransferHook: omnibusCtx?.vanilla.inboundTransferHook,
   });
 
   const paymentsService = new PaymentsServiceImpl(pluginManager);
 
   if (custodyProvider) {
-    registerDirectServices(app, logger, custodyProvider, appConfig, paymentsService, pluginManager, dbPool, finP2PClient, accountMappingStore, assetStore, ledgerSchema);
+    registerDirectServices(app, logger, custodyProvider, appConfig, paymentsService, pluginManager, dbPool, finP2PClient, accountMappingStore, accountMappingService, assetStore, accountMapping, omnibusCtx, ledgerSchema);
   } else if (appConfig.type === 'finp2p-contract') {
     registerFinP2PContractServices(app, appConfig as FinP2PContractAppConfig, paymentsService, pluginManager, dbPool, finP2PClient, ledgerSchema);
   } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,13 +13,23 @@ export type AccountMappingType = 'derivation' | 'database'
 
 const ACCOUNT_MAPPING_TYPES: ReadonlyArray<AccountMappingType> = ['derivation', 'database'];
 
-function resolveAccountMappingType(rawValue: string | undefined): AccountMappingType {
-  if (!rawValue) return 'derivation';
+/**
+ * @deprecated `derivation` is retained for backward compatibility and will be removed.
+ * Switch to `database` (the default); it is DB-backed and supports custody-account mappings.
+ */
+const DEPRECATED_ACCOUNT_MAPPING_TYPES: ReadonlyArray<AccountMappingType> = ['derivation'];
+
+function resolveAccountMappingType(rawValue: string | undefined, logger: Logger): AccountMappingType {
+  if (!rawValue) return 'database';
 
   const normalized = rawValue.trim() as AccountMappingType;
-  if (ACCOUNT_MAPPING_TYPES.includes(normalized)) return normalized;
-
-  throw new Error(`Invalid ACCOUNT_MAPPING_TYPE: ${rawValue}. Supported values: ${ACCOUNT_MAPPING_TYPES.join(', ')}`);
+  if (!ACCOUNT_MAPPING_TYPES.includes(normalized)) {
+    throw new Error(`Invalid ACCOUNT_MAPPING_TYPE: ${rawValue}. Supported values: ${ACCOUNT_MAPPING_TYPES.join(', ')}`);
+  }
+  if (DEPRECATED_ACCOUNT_MAPPING_TYPES.includes(normalized)) {
+    logger.warning(`ACCOUNT_MAPPING_TYPE='${normalized}' is deprecated and will be removed; switch to 'database'`);
+  }
+  return normalized;
 }
 
 export type AccountModel = 'segregated' | 'omnibus'
@@ -99,7 +109,7 @@ export const createJsonProvider = (
 
 export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
   const configType = (process.env.PROVIDER_TYPE || 'finp2p-contract') as AppConfig['type']
-  const accountMappingType = resolveAccountMappingType(process.env.ACCOUNT_MAPPING_TYPE)
+  const accountMappingType = resolveAccountMappingType(process.env.ACCOUNT_MAPPING_TYPE, logger)
   const accountModel = resolveAccountModel(process.env.ACCOUNT_MODEL)
 
   switch (configType) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,10 @@ import * as process from "process";
 import { logger } from "@owneraio/finp2p-nodejs-skeleton-adapter";
 import { FinP2PClient } from "@owneraio/finp2p-client";
 import winston, { format, transports } from "winston";
-import { FinP2PContract } from "@owneraio/finp2p-contracts";
 import { migrationsDir as vanillaMigrationsDir, migrationsTableName as vanillaMigrationsTable } from "@owneraio/finp2p-vanilla-service";
 import { join } from "path";
 import { envVarsToAppConfig } from "./config";
 import createApp from "./app";
-import { InMemoryExecDetailsStore } from "./services/finp2p-contract";
 
 const init = async () => {
   const port = process.env.PORT || "3000";

--- a/src/integrations/deposits/ota-deposit/balance-watcher.ts
+++ b/src/integrations/deposits/ota-deposit/balance-watcher.ts
@@ -1,0 +1,113 @@
+import winston from "winston";
+import { formatUnits, parseUnits } from "ethers";
+import { ERC20Contract } from "@owneraio/finp2p-contracts";
+import { GasStation } from "../../../services/direct";
+import { OtaDeposit, OtaResult } from "./models";
+
+const DEFAULT_POLL_INTERVAL_MS = 60000;
+
+/**
+ * Per-deposit balance-poll watcher: every `pollIntervalMs` it queries
+ * `balanceOf(ephemeralAddress)` for each open OTA deposit. When the balance crosses
+ * the expected threshold, it sweeps to `sweepTarget` (gas funded via the operator's
+ * gas-station), invokes onTransferDetected, and stops polling for that deposit.
+ *
+ * Polling rather than event subscription because event-listener semantics vary across
+ * providers (Fireblocks BrowserProvider drops filters; public RPCs garbage-collect them),
+ * and we already know the destination address per deposit — direct balanceOf is simpler
+ * and deterministic.
+ */
+export class BalanceWatcher {
+  private readonly deposits = new Map<string, OtaDeposit>();
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly inFlight = new Set<string>();
+
+  constructor(
+    private readonly logger: winston.Logger,
+    private readonly gasStation: GasStation | undefined,
+    private readonly onTransferDetected: (result: OtaResult) => Promise<void>,
+    private readonly pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
+  ) {}
+
+  addDeposit(deposit: OtaDeposit): void {
+    this.deposits.set(deposit.correlationId, deposit);
+    this.logger.info(`OTA-deposit: polling balanceOf(${deposit.ephemeralAddress}) on ${deposit.contractAddress} every ${this.pollIntervalMs}ms`);
+    const timer = setInterval(() => {
+      this.pollOnce(deposit).catch((e) =>
+        this.logger.error(`OTA-deposit: poll failed for deposit ${deposit.correlationId}: ${e?.message ?? e}`),
+      );
+    }, this.pollIntervalMs);
+    this.timers.set(deposit.correlationId, timer);
+  }
+
+  private stop(correlationId: string): void {
+    const t = this.timers.get(correlationId);
+    if (t) clearInterval(t);
+    this.timers.delete(correlationId);
+    this.deposits.delete(correlationId);
+    this.inFlight.delete(correlationId);
+  }
+
+  private async pollOnce(deposit: OtaDeposit): Promise<void> {
+    if (this.inFlight.has(deposit.correlationId)) return;
+    if (!this.deposits.has(deposit.correlationId)) return;
+    // ERC20Contract requires a signer for read calls; reuse the ephemeral wallet's
+    // (it's already provider-attached and the read still goes through the provider).
+    const erc20 = new ERC20Contract(
+      deposit.ephemeralWallet.provider, deposit.ephemeralWallet.signer,
+      deposit.contractAddress, this.logger,
+    );
+    const balance: bigint = await erc20.balanceOf(deposit.ephemeralAddress);
+    if (balance === 0n) return;
+    // expectedAmount is human-readable (caller convention); convert to base units for
+    // on-chain math.
+    const expectedBaseUnits = deposit.expectedAmount ? parseUnits(deposit.expectedAmount, deposit.decimals) : undefined;
+    if (expectedBaseUnits !== undefined && balance < expectedBaseUnits) {
+      this.logger.info(`OTA-deposit: balance ${balance} < expected ${expectedBaseUnits} (${deposit.expectedAmount}) on ${deposit.ephemeralAddress}, waiting for more`);
+      return;
+    }
+    this.inFlight.add(deposit.correlationId);
+    try {
+      this.logger.info(`OTA-deposit: detected balance ${balance} on ${deposit.ephemeralAddress} for deposit ${deposit.correlationId}`);
+      const sweepTxHash = await this.sweep(deposit, balance, erc20);
+      if (!sweepTxHash) {
+        // Sweep didn't succeed (no gasStation, sweep tx failed, or gas-funding tx
+        // not yet settled → INSUFFICIENT_FUNDS_FOR_FEE). Don't fire onTransferDetected
+        // — that would credit a receipt with no on-chain proof and leave the funds
+        // stranded at the ephemeral. The next poll will retry the sweep with the
+        // same balance. Operator should ensure gasStation is configured if it isn't.
+        this.logger.info(`OTA-deposit: sweep not yet confirmed for deposit ${deposit.correlationId}, keeping it open for retry`);
+        return;
+      }
+      this.stop(deposit.correlationId);
+      await this.onTransferDetected({
+        deposit,
+        // Hand caller-facing receivedAmount in human-readable units — vanilla hook does
+        // parseUnits(amount, decimals) internally; FinAPI importTransactions expects the
+        // same convention.
+        receivedAmount: formatUnits(balance, deposit.decimals),
+        sweepTxHash,
+      });
+    } finally {
+      this.inFlight.delete(deposit.correlationId);
+    }
+  }
+
+  private async sweep(deposit: OtaDeposit, amount: bigint, erc20: ERC20Contract): Promise<string | undefined> {
+    if (!this.gasStation) {
+      this.logger.warn(
+        `OTA-deposit: no gasStation configured — leaving ${amount} at ephemeral ${deposit.ephemeralAddress} (deposit ${deposit.correlationId}, custodyId ${deposit.custodyAccountId})`,
+      );
+      return undefined;
+    }
+    await this.gasStation.ensureGas(await deposit.ephemeralWallet.signer.getAddress());
+    const tx = await erc20.transfer(deposit.sweepTarget, amount);
+    const receipt = await tx.wait();
+    if (!receipt || receipt.status !== 1) {
+      this.logger.error(`OTA-deposit: sweep tx failed for deposit ${deposit.correlationId}`);
+      return undefined;
+    }
+    this.logger.info(`OTA-deposit: swept ${amount} from ${deposit.ephemeralAddress} → ${deposit.sweepTarget} (tx ${receipt.hash})`);
+    return receipt.hash;
+  }
+}

--- a/src/integrations/deposits/ota-deposit/index.ts
+++ b/src/integrations/deposits/ota-deposit/index.ts
@@ -1,0 +1,1 @@
+export { registerOtaDeposit } from "./register";

--- a/src/integrations/deposits/ota-deposit/models.ts
+++ b/src/integrations/deposits/ota-deposit/models.ts
@@ -1,0 +1,35 @@
+import { CustodyWallet } from "../../../services/direct";
+
+/**
+ * In-flight OTA deposit: a freshly-provisioned custody account waiting for funds.
+ * Held in memory by the BalanceWatcher; cleared once the inbound has been swept
+ * and the receipt exported.
+ */
+export interface OtaDeposit {
+  correlationId: string;
+  finId: string;
+  assetId: string;
+  contractAddress: string;
+  /** ERC20 decimals — used to translate between the caller's human-readable amount
+   * (the deposit API convention, e.g. "0.1") and on-chain base units (100000). */
+  decimals: number;
+  ephemeralAddress: string;
+  custodyAccountId: string;
+  ephemeralWallet: CustodyWallet;
+  sweepTarget: string;
+  /** Human-readable amount as accepted from the caller (e.g. "0.1"); optional. */
+  expectedAmount?: string;
+  createdAt: number;
+}
+
+/**
+ * Result handed to the plugin only after the OTA watcher has detected the inbound AND
+ * successfully swept the funds to the sweep target. The watcher does not fire this until
+ * sweep confirms — see BalanceWatcher.pollOnce. This guarantees the receipt downstream
+ * carries a real on-chain transaction id and that funds are no longer at the ephemeral.
+ */
+export interface OtaResult {
+  deposit: OtaDeposit;
+  receivedAmount: string;
+  sweepTxHash: string;
+}

--- a/src/integrations/deposits/ota-deposit/plugin.ts
+++ b/src/integrations/deposits/ota-deposit/plugin.ts
@@ -1,0 +1,215 @@
+import winston from "winston";
+import {
+  PaymentsPlugin,
+  DepositAsset,
+  DepositOperation,
+  Asset,
+  ReceiptOperation,
+  Signature,
+  InboundTransferHook,
+} from "@owneraio/finp2p-nodejs-skeleton-adapter/plugin";
+import {
+  workflows,
+  successfulDepositOperation,
+  failedDepositOperation,
+} from "@owneraio/finp2p-nodejs-skeleton-adapter";
+import { FinP2PClient } from "@owneraio/finp2p-client";
+import { AssetStore, CustodyProvider } from "../../../services/direct";
+import { DepositTargetResolver } from "../types";
+import { BalanceWatcher } from "./balance-watcher";
+import { OtaResult } from "./models";
+
+export class OtaDepositPlugin implements PaymentsPlugin {
+
+  private watcher: BalanceWatcher | undefined;
+
+  constructor(
+    private readonly logger: winston.Logger,
+    private readonly assetStore: AssetStore,
+    private readonly resolveSweepTarget: DepositTargetResolver,
+    private readonly network: string,
+    private readonly custodyProvider: CustodyProvider,
+    private readonly finP2PClient: FinP2PClient | undefined,
+    private readonly inboundTransferHook: InboundTransferHook | undefined,
+  ) {}
+
+  // ─── PaymentsPlugin interface ───────────────────────────────────────────────
+
+  async deposit(
+    idempotencyKey: string,
+    ownerFinId: string,
+    asset: DepositAsset,
+    amount: string | undefined,
+    signature: Signature | undefined,
+  ): Promise<DepositOperation> {
+    if (asset.assetType !== 'finp2p' || !('assetId' in asset)) {
+      this.logger.warn(`OTA-deposit: unsupported asset type for finId=${ownerFinId}`);
+      return failedDepositOperation(1, 'OTA deposit only supports finp2p asset type');
+    }
+
+    const dbAsset = await this.assetStore.getAsset(asset.assetId);
+    if (!dbAsset) {
+      this.logger.warn(`OTA-deposit: asset ${asset.assetId} not registered for finId=${ownerFinId}`);
+      return failedDepositOperation(1, `Asset ${asset.assetId} is not registered`);
+    }
+
+    const sweepTarget = await this.resolveSweepTarget(ownerFinId);
+    if (!sweepTarget) {
+      this.logger.warn(`OTA-deposit: no sweep target for finId=${ownerFinId}`);
+      return failedDepositOperation(1, `No sweep target available for finId ${ownerFinId}`);
+    }
+
+    const correlationId = workflows.generateCid();
+    const { custodyAccountId, address: ephemeralAddress } = await this.custodyProvider.createCustodyAccount!(
+      `ota-${correlationId}`,
+    );
+    const ephemeralWallet = await this.custodyProvider.createWalletForCustodyId!(custodyAccountId);
+
+    this.getWatcher().addDeposit({
+      correlationId,
+      finId: ownerFinId,
+      assetId: asset.assetId,
+      contractAddress: dbAsset.contract_address,
+      decimals: dbAsset.decimals,
+      ephemeralAddress,
+      custodyAccountId,
+      ephemeralWallet,
+      sweepTarget,
+      expectedAmount: amount,
+      createdAt: Date.now(),
+    });
+
+    this.logger.info(
+      `OTA-deposit: created deposit ${correlationId} for finId=${ownerFinId} custodyId=${custodyAccountId} ephemeral=${ephemeralAddress} sweepTarget=${sweepTarget}`,
+    );
+
+    return successfulDepositOperation({
+      asset,
+      account: { finId: ownerFinId, account: { type: 'crypto', address: ephemeralAddress } },
+      description: `Send ${asset.assetId} to one-time address ${ephemeralAddress}; funds will be swept to ${sweepTarget}`,
+      paymentOptions: [{
+        description: 'One-time-address deposit',
+        currency: asset.assetId,
+        methodInstruction: {
+          type: 'cryptoTransfer',
+          network: this.network,
+          contractAddress: dbAsset.contract_address,
+          walletAddress: ephemeralAddress,
+        },
+      }],
+      operationId: correlationId,
+      // Surface the underlying custody account id so operators (and integration tests)
+      // can inspect/audit the per-deposit account directly via the custody provider.
+      details: { custodyAccountId },
+    });
+  }
+
+  async depositCustom(
+    idempotencyKey: string, ownerFinId: string, amount: string | undefined, details: any, signature: Signature | undefined,
+  ): Promise<DepositOperation> {
+    return failedDepositOperation(1, 'Custom deposits are not supported by ota-deposit plugin');
+  }
+
+  async payout(
+    idempotencyKey: string, sourceFinId: string, destinationFinId: string, asset: Asset, amount: string, signature: Signature | undefined,
+  ): Promise<ReceiptOperation> {
+    throw new Error('Payout not implemented for ota-deposit plugin');
+  }
+
+  // ─── Internal helpers ───────────────────────────────────────────────────────
+
+  private getWatcher(): BalanceWatcher {
+    if (this.watcher) return this.watcher;
+    this.watcher = new BalanceWatcher(
+      this.logger,
+      this.custodyProvider.gasStation,
+      (result: OtaResult) => this.onTransferDetected(result),
+    );
+    return this.watcher;
+  }
+
+  private async onTransferDetected(result: OtaResult): Promise<void> {
+    // Both paths run when present:
+    //   - notifyInboundHook (omnibus mode): vanilla hook credits the operator's internal
+    //     omnibus ledger (storage.credit). Without it, omnibus balances stay stale.
+    //   - exportReceipt: importTransactions tells FinAPI about the deposit so the
+    //     investor's finId reflects the new holdings. The vanilla hook does NOT do this.
+    if (this.inboundTransferHook) {
+      await this.notifyInboundHook(result);
+    }
+    await this.exportReceipt(result);
+    await this.archiveIfSwept(result);
+  }
+
+  private async archiveIfSwept(result: OtaResult): Promise<void> {
+    if (!this.custodyProvider.archiveCustodyAccount) return;
+    try {
+      await this.custodyProvider.archiveCustodyAccount(result.deposit.custodyAccountId);
+      this.logger.info(`OTA-deposit: archived custody account ${result.deposit.custodyAccountId}`);
+    } catch (e: any) {
+      this.logger.warn(`OTA-deposit: archive failed for ${result.deposit.custodyAccountId}: ${e?.message ?? e}`);
+    }
+  }
+
+  private async notifyInboundHook(result: OtaResult): Promise<void> {
+    try {
+      await this.inboundTransferHook!.onInboundTransfer(result.deposit.correlationId, {
+        planId: result.deposit.correlationId,
+        sourceFinId: '',
+        destinationFinId: result.deposit.finId,
+        asset: {
+          assetId: result.deposit.assetId,
+          assetType: 'finp2p',
+          ledgerIdentifier: {
+            assetIdentifierType: 'CAIP-19',
+            network: this.network,
+            tokenId: result.deposit.contractAddress,
+            standard: 'ERC20',
+          },
+        },
+        amount: result.receivedAmount,
+        instructionSequence: 0,
+        result: { type: 'receipt', transactionId: result.sweepTxHash },
+      });
+      this.logger.info(`OTA-deposit: inboundTransferHook delivered for deposit ${result.deposit.correlationId}`);
+    } catch (e: any) {
+      this.logger.error(`OTA-deposit: inboundTransferHook failed for deposit ${result.deposit.correlationId}: ${e?.message ?? e}`);
+    }
+  }
+
+  private async exportReceipt(result: OtaResult): Promise<void> {
+    if (!this.finP2PClient) {
+      this.logger.warn(`OTA-deposit: no FinP2PClient configured — skipping importTransactions for deposit ${result.deposit.correlationId}`);
+      return;
+    }
+    try {
+      await this.finP2PClient.importTransactions([{
+        id: result.sweepTxHash,
+        quantity: result.receivedAmount,
+        timestamp: Math.floor(Date.now() / 1000),
+        destination: {
+          finp2pAccount: {
+            account: { finId: result.deposit.finId },
+            asset: {
+              id: result.deposit.assetId,
+              ledgerIdentifier: {
+                assetIdentifierType: 'CAIP-19',
+                network: this.network,
+                tokenId: result.deposit.contractAddress,
+                standard: 'ERC20',
+              },
+            },
+          },
+        },
+        transactionDetails: {
+          transactionId: result.sweepTxHash,
+          operationId: result.deposit.correlationId,
+        },
+        operationType: 'transfer',
+      }] as any);
+      this.logger.info(`OTA-deposit: importTransactions succeeded for deposit ${result.deposit.correlationId}`);
+    } catch (e: any) {
+      this.logger.error(`OTA-deposit: importTransactions failed for deposit ${result.deposit.correlationId}: ${e?.message ?? e}`);
+    }
+  }
+}

--- a/src/integrations/deposits/ota-deposit/register.ts
+++ b/src/integrations/deposits/ota-deposit/register.ts
@@ -1,0 +1,71 @@
+import { IntegrationContext } from "../../registry";
+import { DepositTargetResolver, resolveDepositMethod } from "../types";
+import { OtaDepositPlugin } from "./plugin";
+
+/**
+ * One-time-address (OTA) deposit method: provisions a fresh custody account per deposit
+ * via CustodyProvider.createCustodyAccount and returns its EVM address as the deposit
+ * target. The investor sends funds to this address; a BalanceWatcher detects the
+ * inbound, sweeps the balance to the configured sweep target, and exports a receipt
+ * to FinAPI. The ephemeral key never leaves custody — the sweep is signed by the
+ * custody-issued signer obtained via createWalletForCustodyId.
+ *
+ * Sweep target depends on account model:
+ *   - segregated: the investor's mapped wallet W_I (resolved via walletResolver)
+ *   - omnibus:    the operator's omnibus wallet (custodyProvider.omnibus)
+ *
+ * Useful when the depositor's source address is not known in advance and 1:1
+ * attribution (deposit ↔ address) is required.
+ *
+ * In-memory deposit store; persistence is a TODO. Note: because the custody account
+ * is durable, deposits can be recovered after process restart by re-instantiating
+ * the wallet via createWalletForCustodyId(custodyAccountId) — the EVM key isn't
+ * lost on crash, only the in-memory deposit metadata is.
+ *
+ * Not registered when:
+ *   - DTCC_PLUGIN_ENABLED=true (DTCC owns the single PaymentsPlugin slot)
+ *   - resolved deposit method != 'ota' (omnibus defaults to 'ota'; segregated defaults
+ *     to 'wallet'; explicit DEPOSIT_METHOD env wins in either case)
+ *   - custody provider lacks createCustodyAccount / createWalletForCustodyId
+ *   - segregated mode without walletResolver, or omnibus mode without an omnibus wallet
+ */
+export function registerOtaDeposit(ctx: IntegrationContext): void {
+  if (process.env.DTCC_PLUGIN_ENABLED === 'true') return;
+  if (resolveDepositMethod(ctx.accountModel) !== 'ota') return;
+
+  const { pluginManager, logger, custodyProvider, assetStore, walletResolver, accountModel, finP2PClient, inboundTransferHook } = ctx;
+  if (!custodyProvider || !assetStore) {
+    logger.info('OTA-deposit plugin not registered: requires custody provider + asset store');
+    return;
+  }
+  if (!custodyProvider.createCustodyAccount || !custodyProvider.createWalletForCustodyId) {
+    logger.info('OTA-deposit plugin not registered: custody provider does not support per-deposit account creation');
+    return;
+  }
+  if (accountModel === 'omnibus' && !custodyProvider.omnibus) {
+    logger.info('OTA-deposit plugin not registered (omnibus mode): custody provider has no omnibus wallet configured');
+    return;
+  }
+  if (accountModel === 'segregated' && !walletResolver) {
+    logger.info('OTA-deposit plugin not registered (segregated mode): no wallet resolver available');
+    return;
+  }
+
+  const network = process.env.NETWORK_NAME ?? 'ethereum';
+
+  let resolveSweepTarget: DepositTargetResolver;
+  if (accountModel === 'omnibus') {
+    let omnibusAddress: string | undefined;
+    resolveSweepTarget = async () => {
+      if (!omnibusAddress) omnibusAddress = await custodyProvider.omnibus!.signer.getAddress();
+      return omnibusAddress;
+    };
+  } else {
+    resolveSweepTarget = async (finId) => (await walletResolver!(finId))?.walletAddress;
+  }
+
+  pluginManager.registerPaymentsPlugin(
+    new OtaDepositPlugin(logger, assetStore, resolveSweepTarget, network, custodyProvider, finP2PClient, inboundTransferHook),
+  );
+  logger.info(`OTA-deposit plugin activated (network='${network}', accountModel='${accountModel}', inboundTransferHook=${inboundTransferHook ? 'present' : 'absent'})`);
+}

--- a/src/integrations/deposits/pull-deposit/approval-watcher.ts
+++ b/src/integrations/deposits/pull-deposit/approval-watcher.ts
@@ -1,0 +1,189 @@
+import winston from "winston";
+import { formatUnits, Interface, Log, Provider, parseUnits, id as keccakStr, zeroPadValue } from "ethers";
+import { ERC20Contract } from "@owneraio/finp2p-contracts";
+import { CustodyWallet, GasStation } from "../../../services/direct";
+import { PullDeposit, PullResult } from "./models";
+
+const APPROVAL_IFACE = new Interface([
+  'event Approval(address indexed owner, address indexed spender, uint256 value)',
+]);
+const APPROVAL_TOPIC = keccakStr("Approval(address,address,uint256)");
+const DEFAULT_POLL_INTERVAL_MS = 60000;
+
+/**
+ * Polls `eth_getLogs` for ERC20 Approval(_, operator) events since the last seen block
+ * on every contract that has an open deposit, then runs transferFrom for the matching
+ * owner. Switched from `contract.on(filter, ...)` to log polling because event
+ * subscriptions are unreliable across the providers we run against (Fireblocks
+ * BrowserProvider drops filters; public RPCs garbage-collect them) — log polling
+ * works on any RPC and is stateless on the provider side.
+ *
+ * Concurrency: pull-deposit currently lacks a declared-sender mechanism (the deposit
+ * API only carries finId, not the depositor's external EVM address), so we cannot tell
+ * which investor a given Approval event belongs to. To keep correctness, addDeposit()
+ * enforces one open deposit per contract — a second deposit on the same contract while
+ * the first is still in flight is rejected. This serializes throughput per contract but
+ * eliminates the cross-investor mis-credit risk that FIFO matching would create.
+ *
+ * TODO: persist deposits (DB), declared-sender support (match by owner), reorg
+ * handling (block-confirmation lag), retry on transient failures.
+ */
+export class ApprovalWatcher {
+
+  private readonly deposits = new Map<string, PullDeposit>();
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly lastSeen = new Map<string, number>();
+  private readonly inFlight = new Set<string>();
+
+  constructor(
+    private readonly operatorAddress: string,
+    private readonly operatorWallet: CustodyWallet,
+    private readonly provider: Provider,
+    private readonly logger: winston.Logger,
+    private readonly gasStation: GasStation | undefined,
+    private readonly onPullCompleted?: (result: PullResult) => Promise<void>,
+    private readonly pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
+  ) {}
+
+  async addDeposit(deposit: PullDeposit): Promise<void> {
+    if (this.hasOpenDepositFor(deposit.contractAddress)) {
+      throw new Error(
+        `Pull-deposit: another deposit on contract ${deposit.contractAddress} is already in flight; ` +
+        `concurrent pull-deposits on the same token are not yet supported (no declared-sender API).`,
+      );
+    }
+    this.deposits.set(deposit.correlationId, deposit);
+    await this.ensurePolling(deposit.contractAddress);
+  }
+
+  private async ensurePolling(contractAddress: string): Promise<void> {
+    const key = contractAddress.toLowerCase();
+    if (this.timers.has(key)) return;
+    // Seed one block before "now" so the first scan covers the current block —
+    // an Approval mined in the same block as deposit creation would otherwise be
+    // skipped forever (fromBlock = lastSeen + 1 would land at currentBlock + 1).
+    const currentBlock = await this.provider.getBlockNumber();
+    this.lastSeen.set(key, Math.max(0, currentBlock - 1));
+    const timer = setInterval(() => {
+      this.pollOnce(contractAddress).catch((e) =>
+        this.logger.error(`Pull-deposit: poll failed for ${contractAddress}: ${e?.message ?? e}`),
+      );
+    }, this.pollIntervalMs);
+    this.timers.set(key, timer);
+    this.logger.info(`Pull-deposit: polling Approval(_, ${this.operatorAddress}) on ${contractAddress} every ${this.pollIntervalMs}ms`);
+  }
+
+  private stopPolling(contractAddress: string): void {
+    const key = contractAddress.toLowerCase();
+    const t = this.timers.get(key);
+    if (t) clearInterval(t);
+    this.timers.delete(key);
+    this.lastSeen.delete(key);
+  }
+
+  private async pollOnce(contractAddress: string): Promise<void> {
+    const key = contractAddress.toLowerCase();
+    if (this.inFlight.has(key)) return;
+    if (!this.hasOpenDepositFor(contractAddress)) {
+      this.stopPolling(contractAddress);
+      return;
+    }
+    const fromBlock = (this.lastSeen.get(key) ?? 0) + 1;
+    const latest = await this.provider.getBlockNumber();
+    if (latest < fromBlock) return;
+
+    const logs: Log[] = await this.provider.getLogs({
+      address: contractAddress,
+      fromBlock,
+      toBlock: latest,
+      topics: [APPROVAL_TOPIC, null, zeroPadValue(this.operatorAddress, 32)],
+    });
+    if (logs.length === 0) {
+      this.lastSeen.set(key, latest);
+      return;
+    }
+
+    this.inFlight.add(key);
+    try {
+      for (const log of logs) {
+        const parsed = APPROVAL_IFACE.parseLog({ topics: [...log.topics], data: log.data });
+        if (!parsed) continue;
+        const owner: string = parsed.args[0];
+        const value: bigint = parsed.args[2];
+        await this.handleApproval(contractAddress, owner, value);
+      }
+      // Only advance the cursor after the batch processed cleanly. If any
+      // handleApproval threw (e.g. transferFrom failed because operator gas
+      // funding hasn't settled), leave lastSeen so the next poll retries.
+      this.lastSeen.set(key, latest);
+    } finally {
+      this.inFlight.delete(key);
+    }
+  }
+
+  private hasOpenDepositFor(contractAddress: string): boolean {
+    const lower = contractAddress.toLowerCase();
+    for (const deposit of this.deposits.values()) {
+      if (deposit.contractAddress.toLowerCase() === lower) return true;
+    }
+    return false;
+  }
+
+  private findMatchingDeposit(contractAddress: string): PullDeposit | undefined {
+    let match: PullDeposit | undefined;
+    for (const deposit of this.deposits.values()) {
+      if (deposit.contractAddress.toLowerCase() !== contractAddress.toLowerCase()) continue;
+      if (!match || deposit.createdAt < match.createdAt) match = deposit;
+    }
+    return match;
+  }
+
+  private async handleApproval(contractAddress: string, owner: string, eventValue: bigint): Promise<void> {
+    const deposit = this.findMatchingDeposit(contractAddress);
+    if (!deposit) {
+      this.logger.info(`Pull-deposit: no open deposit for contract ${contractAddress}, ignoring approval from ${owner} (${eventValue})`);
+      return;
+    }
+
+    const erc20 = new ERC20Contract(this.provider, this.operatorWallet.signer, contractAddress, this.logger);
+    const currentAllowance: bigint = await erc20.allowance(owner, this.operatorAddress);
+    // expectedAmount is human-readable (caller convention); fall back to the on-chain
+    // event value when not specified. Compare and pull in base units; report in
+    // human-readable to match FinAPI / vanilla-hook conventions.
+    const desired: bigint = deposit.expectedAmount
+      ? parseUnits(deposit.expectedAmount, deposit.decimals)
+      : eventValue;
+    if (currentAllowance < desired) {
+      this.logger.info(`Pull-deposit: allowance ${currentAllowance} < desired ${desired} for owner=${owner}, waiting for more`);
+      return;
+    }
+
+    this.logger.info(
+      `Pull-deposit: executing transferFrom(${owner}, ${deposit.destinationAddress}, ${desired}) for deposit ${deposit.correlationId}`,
+    );
+    // Top up the operator with gas before transferFrom — Fireblocks rejects with
+    // INSUFFICIENT_FUNDS_FOR_FEE if the operator wallet drifts low.
+    if (this.gasStation) {
+      await this.gasStation.ensureGas(await this.operatorWallet.signer.getAddress());
+    }
+    const tx = await erc20.transferFrom(owner, deposit.destinationAddress, desired);
+    const receipt = await tx.wait();
+    if (!receipt || receipt.status !== 1) {
+      this.logger.error(`Pull-deposit: transferFrom failed for deposit ${deposit.correlationId}`);
+      return;
+    }
+
+    this.deposits.delete(deposit.correlationId);
+    if (!this.hasOpenDepositFor(contractAddress)) this.stopPolling(contractAddress);
+    this.logger.info(`Pull-deposit: pulled ${desired} from ${owner} → ${deposit.destinationAddress} (tx ${receipt.hash})`);
+
+    if (this.onPullCompleted) {
+      await this.onPullCompleted({
+        deposit,
+        owner,
+        txHash: receipt.hash,
+        amount: formatUnits(desired, deposit.decimals),
+      });
+    }
+  }
+}

--- a/src/integrations/deposits/pull-deposit/index.ts
+++ b/src/integrations/deposits/pull-deposit/index.ts
@@ -1,0 +1,1 @@
+export { registerPullDeposit } from "./register";

--- a/src/integrations/deposits/pull-deposit/models.ts
+++ b/src/integrations/deposits/pull-deposit/models.ts
@@ -1,0 +1,26 @@
+/**
+ * In-flight pull-deposit: a deposit waiting for an Approval(_, operator) event
+ * from the depositor's external wallet so the operator can transferFrom on their behalf.
+ * Held in memory by the ApprovalWatcher; cleared once the transferFrom succeeds.
+ */
+export interface PullDeposit {
+  correlationId: string;
+  finId: string;
+  assetId: string;
+  contractAddress: string;
+  /** ERC20 decimals — used to translate between the caller's human-readable amount
+   * (the deposit API convention, e.g. "0.1") and on-chain base units (100000). */
+  decimals: number;
+  destinationAddress: string;
+  /** Human-readable amount as accepted from the caller (e.g. "0.1"); optional. */
+  expectedAmount?: string;
+  createdAt: number;
+}
+
+/** Result handed to the plugin once the operator's transferFrom has settled. */
+export interface PullResult {
+  deposit: PullDeposit;
+  owner: string;
+  txHash: string;
+  amount: string;
+}

--- a/src/integrations/deposits/pull-deposit/plugin.ts
+++ b/src/integrations/deposits/pull-deposit/plugin.ts
@@ -1,0 +1,209 @@
+import winston from "winston";
+import {
+  PaymentsPlugin,
+  DepositAsset,
+  DepositOperation,
+  Asset,
+  ReceiptOperation,
+  Signature,
+  InboundTransferHook,
+} from "@owneraio/finp2p-nodejs-skeleton-adapter/plugin";
+import {
+  workflows,
+  successfulDepositOperation,
+  failedDepositOperation,
+} from "@owneraio/finp2p-nodejs-skeleton-adapter";
+import { FinP2PClient } from "@owneraio/finp2p-client";
+import { AssetStore, CustodyProvider, CustodyWallet } from "../../../services/direct";
+import { DepositTargetResolver } from "../types";
+import { ApprovalWatcher } from "./approval-watcher";
+import { PullResult } from "./models";
+
+export class PullDepositPlugin implements PaymentsPlugin {
+
+  private watcher: ApprovalWatcher | undefined;
+
+  constructor(
+    private readonly logger: winston.Logger,
+    private readonly assetStore: AssetStore,
+    private readonly resolveDepositTarget: DepositTargetResolver,
+    private readonly network: string,
+    private readonly operatorWallet: CustodyWallet,
+    private readonly custodyProvider: CustodyProvider,
+    private readonly finP2PClient: FinP2PClient | undefined,
+    private readonly inboundTransferHook: InboundTransferHook | undefined,
+  ) {}
+
+  // ─── PaymentsPlugin interface ───────────────────────────────────────────────
+
+  async deposit(
+    idempotencyKey: string,
+    ownerFinId: string,
+    asset: DepositAsset,
+    amount: string | undefined,
+    signature: Signature | undefined,
+  ): Promise<DepositOperation> {
+    if (asset.assetType !== 'finp2p' || !('assetId' in asset)) {
+      this.logger.warn(`Pull-deposit: unsupported asset type for finId=${ownerFinId}`);
+      return failedDepositOperation(1, 'Pull deposit only supports finp2p asset type');
+    }
+
+    const dbAsset = await this.assetStore.getAsset(asset.assetId);
+    if (!dbAsset) {
+      this.logger.warn(`Pull-deposit: asset ${asset.assetId} not registered for finId=${ownerFinId}`);
+      return failedDepositOperation(1, `Asset ${asset.assetId} is not registered`);
+    }
+
+    const destinationAddress = await this.resolveDepositTarget(ownerFinId);
+    if (!destinationAddress) {
+      this.logger.warn(`Pull-deposit: no deposit target for finId=${ownerFinId}`);
+      return failedDepositOperation(1, `No deposit target available for finId ${ownerFinId}`);
+    }
+
+    const watcher = await this.getWatcher();
+    const operatorAddress = await this.operatorWallet.signer.getAddress();
+    const correlationId = workflows.generateCid();
+
+    try {
+      await watcher.addDeposit({
+        correlationId,
+        finId: ownerFinId,
+        assetId: asset.assetId,
+        contractAddress: dbAsset.contract_address,
+        decimals: dbAsset.decimals,
+        destinationAddress,
+        expectedAmount: amount,
+        createdAt: Date.now(),
+      });
+    } catch (e: any) {
+      this.logger.warn(`Pull-deposit: addDeposit failed for finId=${ownerFinId}: ${e?.message ?? e}`);
+      return failedDepositOperation(1, e?.message ?? String(e));
+    }
+
+    this.logger.info(
+      `Pull-deposit: created deposit ${correlationId} for finId=${ownerFinId} assetId=${asset.assetId} contract=${dbAsset.contract_address} operator=${operatorAddress} destination=${destinationAddress} expectedAmount=${amount ?? 'any'}`,
+    );
+
+    return successfulDepositOperation({
+      asset,
+      account: { finId: ownerFinId, account: { type: 'crypto', address: destinationAddress } },
+      description: `Approve ${operatorAddress} on the token contract to deposit into ${destinationAddress}`,
+      paymentOptions: [{
+        description: 'ERC20 approve + pull',
+        currency: asset.assetId,
+        methodInstruction: {
+          type: 'cryptoTransfer',
+          network: this.network,
+          contractAddress: dbAsset.contract_address,
+          walletAddress: operatorAddress,
+        },
+      }],
+      operationId: correlationId,
+      details: undefined,
+    });
+  }
+
+  async depositCustom(
+    idempotencyKey: string, ownerFinId: string, amount: string | undefined, details: any, signature: Signature | undefined,
+  ): Promise<DepositOperation> {
+    return failedDepositOperation(1, 'Custom deposits are not supported by pull-deposit plugin');
+  }
+
+  async payout(
+    idempotencyKey: string, sourceFinId: string, destinationFinId: string, asset: Asset, amount: string, signature: Signature | undefined,
+  ): Promise<ReceiptOperation> {
+    throw new Error('Payout not implemented for pull-deposit plugin');
+  }
+
+  // ─── Internal helpers ───────────────────────────────────────────────────────
+
+  private async getWatcher(): Promise<ApprovalWatcher> {
+    if (this.watcher) return this.watcher;
+    const operatorAddress = await this.operatorWallet.signer.getAddress();
+    this.watcher = new ApprovalWatcher(
+      operatorAddress,
+      this.operatorWallet,
+      this.custodyProvider.rpcProvider,
+      this.logger,
+      this.custodyProvider.gasStation,
+      (result) => this.onPullCompleted(result),
+    );
+    this.logger.info(`Pull-deposit: operator address=${operatorAddress}`);
+    return this.watcher;
+  }
+
+  private async onPullCompleted(result: PullResult): Promise<void> {
+    // Both paths run when present:
+    //   - notifyInboundHook (omnibus mode): vanilla hook credits the operator's internal
+    //     omnibus ledger (storage.credit). Without it, omnibus balances stay stale.
+    //   - exportReceipt: importTransactions tells FinAPI about the deposit so the
+    //     investor's finId reflects the new holdings. The vanilla hook does NOT do this.
+    if (this.inboundTransferHook) {
+      await this.notifyInboundHook(result);
+    }
+    await this.exportReceipt(result);
+  }
+
+  private async notifyInboundHook(result: PullResult): Promise<void> {
+    // Synthetic plan context is used until the skeleton makes plan fields optional.
+    try {
+      await this.inboundTransferHook!.onInboundTransfer(result.deposit.correlationId, {
+        planId: result.deposit.correlationId,
+        sourceFinId: '', // TODO: no plan-scoped sender for out-of-plan deposits
+        destinationFinId: result.deposit.finId,
+        asset: {
+          assetId: result.deposit.assetId,
+          assetType: 'finp2p',
+          ledgerIdentifier: {
+            assetIdentifierType: 'CAIP-19',
+            network: this.network,
+            tokenId: result.deposit.contractAddress,
+            standard: 'ERC20',
+          },
+        },
+        amount: result.amount,
+        instructionSequence: 0, // TODO: no plan sequence for out-of-plan deposits
+        result: { type: 'receipt', transactionId: result.txHash },
+      });
+      this.logger.info(`Pull-deposit: inboundTransferHook delivered for deposit ${result.deposit.correlationId}`);
+    } catch (e: any) {
+      this.logger.error(`Pull-deposit: inboundTransferHook failed for deposit ${result.deposit.correlationId}: ${e?.message ?? e}`);
+    }
+  }
+
+  private async exportReceipt(result: PullResult): Promise<void> {
+    if (!this.finP2PClient) {
+      this.logger.warn(`Pull-deposit: no FinP2PClient configured — skipping importTransactions for deposit ${result.deposit.correlationId}`);
+      return;
+    }
+    try {
+      await this.finP2PClient.importTransactions([{
+        id: result.txHash,
+        quantity: result.amount,
+        timestamp: Math.floor(Date.now() / 1000),
+        destination: {
+          finp2pAccount: {
+            account: { finId: result.deposit.finId },
+            asset: {
+              id: result.deposit.assetId,
+              ledgerIdentifier: {
+                assetIdentifierType: 'CAIP-19',
+                network: this.network,
+                tokenId: result.deposit.contractAddress,
+                standard: 'ERC20',
+              },
+            },
+          },
+        },
+        transactionDetails: {
+          transactionId: result.txHash,
+          operationId: result.deposit.correlationId,
+        },
+        operationType: 'transfer',
+      }] as any);
+      this.logger.info(`Pull-deposit: importTransactions succeeded for deposit ${result.deposit.correlationId}`);
+    } catch (e: any) {
+      this.logger.error(`Pull-deposit: importTransactions failed for deposit ${result.deposit.correlationId}: ${e?.message ?? e}`);
+    }
+  }
+}

--- a/src/integrations/deposits/pull-deposit/register.ts
+++ b/src/integrations/deposits/pull-deposit/register.ts
@@ -1,0 +1,67 @@
+import { IntegrationContext } from "../../registry";
+import { DepositTargetResolver, resolveDepositMethod } from "../types";
+import { PullDepositPlugin } from "./plugin";
+
+/**
+ * Pull-deposit method: returns the adapter's operator address as the spender to approve.
+ * The investor approves from their external wallet (E_I). The ApprovalWatcher detects
+ * the approval and executes transferFrom(E_I, destination, amount) — moving funds into
+ * the deposit target.
+ *
+ * Destination depends on account model:
+ *   - segregated: the investor's mapped wallet W_I (via walletResolver)
+ *   - omnibus:    the operator's omnibus wallet
+ *
+ * After a successful transferFrom, the plugin either delegates crediting to an
+ * InboundTransferHook (omnibus) or calls finP2PClient.importTransactions to register
+ * the deposit with FinAPI (segregated).
+ *
+ * The operator wallet (env / adapter constant) is the ERC20 spender AND the transferFrom
+ * signer. For v1 it reuses `custodyProvider.escrow`; a dedicated
+ * PULL_DEPOSIT_OPERATOR_CUSTODY_ID can be added later.
+ *
+ * In-memory deposit store; persistence is a TODO — see ApprovalWatcher.
+ *
+ * Not registered when:
+ *   - DTCC_PLUGIN_ENABLED=true (DTCC owns the single PaymentsPlugin slot)
+ *   - resolved deposit method != 'pull' (defaults: omnibus → 'ota', segregated →
+ *     'wallet'; explicit DEPOSIT_METHOD env wins in either case)
+ *   - segregated mode without walletResolver, or omnibus mode without an omnibus wallet
+ */
+export function registerPullDeposit(ctx: IntegrationContext): void {
+  if (process.env.DTCC_PLUGIN_ENABLED === 'true') return;
+  if (resolveDepositMethod(ctx.accountModel) !== 'pull') return;
+
+  const { pluginManager, logger, custodyProvider, assetStore, walletResolver, accountModel, finP2PClient, inboundTransferHook } = ctx;
+  if (!custodyProvider || !assetStore) {
+    logger.info('Pull-deposit plugin not registered: requires custody provider + asset store');
+    return;
+  }
+  if (accountModel === 'omnibus' && !custodyProvider.omnibus) {
+    logger.info('Pull-deposit plugin not registered (omnibus mode): custody provider has no omnibus wallet configured');
+    return;
+  }
+  if (accountModel === 'segregated' && !walletResolver) {
+    logger.info('Pull-deposit plugin not registered (segregated mode): no wallet resolver available');
+    return;
+  }
+
+  const network = process.env.NETWORK_NAME ?? 'ethereum';
+  const operatorWallet = custodyProvider.escrow;
+
+  let resolveDepositTarget: DepositTargetResolver;
+  if (accountModel === 'omnibus') {
+    let omnibusAddress: string | undefined;
+    resolveDepositTarget = async () => {
+      if (!omnibusAddress) omnibusAddress = await custodyProvider.omnibus!.signer.getAddress();
+      return omnibusAddress;
+    };
+  } else {
+    resolveDepositTarget = async (finId) => (await walletResolver!(finId))?.walletAddress;
+  }
+
+  pluginManager.registerPaymentsPlugin(
+    new PullDepositPlugin(logger, assetStore, resolveDepositTarget, network, operatorWallet, custodyProvider, finP2PClient, inboundTransferHook),
+  );
+  logger.info(`Pull-deposit plugin activated (network='${network}', accountModel='${accountModel}', inboundTransferHook=${inboundTransferHook ? 'present' : 'absent'})`);
+}

--- a/src/integrations/deposits/types.ts
+++ b/src/integrations/deposits/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolves the on-chain address that an investor's deposit funds should land at,
+ * given their finId. Returns undefined if no destination is available (e.g. unmapped
+ * investor in segregated mode).
+ *
+ * Constructed at registration time based on accountModel:
+ *  - segregated: looks up the investor's mapped W_I via the wallet resolver
+ *  - omnibus:    returns the operator's omnibus wallet address (constant)
+ *
+ * Used by deposit-method plugins (wallet-deposit, pull-deposit, ota-deposit) to keep
+ * the plugin itself decoupled from the account-model branching.
+ */
+export type DepositTargetResolver = (finId: string) => Promise<string | undefined>;
+
+export type DepositMethod = 'wallet' | 'ota' | 'pull';
+
+/**
+ * Resolved deposit method: explicit DEPOSIT_METHOD env wins; otherwise default
+ * by account model — omnibus pairs naturally with ota (per-deposit ephemeral
+ * address swept to the omnibus), segregated pairs with wallet (deposit to the
+ * investor's own mapped W_I).
+ */
+export function resolveDepositMethod(accountModel: 'omnibus' | 'segregated' | string): DepositMethod {
+  const explicit = process.env.DEPOSIT_METHOD;
+  if (explicit === 'wallet' || explicit === 'ota' || explicit === 'pull') return explicit;
+  return accountModel === 'omnibus' ? 'ota' : 'wallet';
+}

--- a/src/integrations/deposits/wallet-deposit/index.ts
+++ b/src/integrations/deposits/wallet-deposit/index.ts
@@ -1,0 +1,1 @@
+export { registerWalletDeposit } from "./plugin";

--- a/src/integrations/deposits/wallet-deposit/plugin.ts
+++ b/src/integrations/deposits/wallet-deposit/plugin.ts
@@ -1,0 +1,116 @@
+import winston from "winston";
+import {
+  PaymentsPlugin,
+  DepositAsset,
+  DepositOperation,
+  Asset,
+  ReceiptOperation,
+  Signature,
+} from "@owneraio/finp2p-nodejs-skeleton-adapter/plugin";
+import {
+  workflows,
+  successfulDepositOperation,
+  failedDepositOperation,
+} from "@owneraio/finp2p-nodejs-skeleton-adapter";
+import { AssetStore, WalletResolver } from "../../../services/direct";
+import { IntegrationContext } from "../../registry";
+import { resolveDepositMethod } from "../types";
+
+/**
+ * Wallet-deposit method: returns the investor's own on-chain wallet address
+ * (resolved from the account-mapping store) as the deposit target.
+ *
+ * TODO: auto-create a custody account + mapping when no mapping exists for the finId.
+ * For now, deposits fail if the finId has no pre-registered wallet mapping — the
+ * operator must provision it via the existing account-mapping API first.
+ *
+ * Not registered when:
+ *   - ACCOUNT_MODEL is omnibus (omnibus has its own deposit flow)
+ *   - DTCC_PLUGIN_ENABLED=true (DTCC registers its own PaymentsPlugin — single-plugin manager)
+ */
+export function registerWalletDeposit(ctx: IntegrationContext): void {
+  const dtccEnabled = process.env.DTCC_PLUGIN_ENABLED === 'true';
+  if (dtccEnabled) return;
+  if (ctx.accountModel === 'omnibus') return;
+  if (resolveDepositMethod(ctx.accountModel) !== 'wallet') return;
+
+  const { pluginManager, logger, assetStore, walletResolver } = ctx;
+  if (!assetStore || !walletResolver) {
+    logger.info('Wallet-deposit plugin not registered: requires asset store + wallet resolver');
+    return;
+  }
+
+  const network = process.env.NETWORK_NAME ?? 'ethereum';
+  pluginManager.registerPaymentsPlugin(new WalletDepositPlugin(logger, assetStore, walletResolver, network));
+  logger.info(`Wallet-deposit plugin activated (network='${network}')`);
+}
+
+class WalletDepositPlugin implements PaymentsPlugin {
+
+  constructor(
+    private readonly logger: winston.Logger,
+    private readonly assetStore: AssetStore,
+    private readonly walletResolver: WalletResolver,
+    private readonly network: string,
+  ) {}
+
+  async deposit(
+    idempotencyKey: string,
+    ownerFinId: string,
+    asset: DepositAsset,
+    amount: string | undefined,
+    signature: Signature | undefined,
+  ): Promise<DepositOperation> {
+    if (asset.assetType !== 'finp2p' || !('assetId' in asset)) {
+      this.logger.warn(`Wallet-deposit: unsupported asset type for finId=${ownerFinId}`);
+      return failedDepositOperation(1, 'Wallet deposit only supports finp2p asset type');
+    }
+
+    const dbAsset = await this.assetStore.getAsset(asset.assetId);
+    if (!dbAsset) {
+      this.logger.warn(`Wallet-deposit: asset ${asset.assetId} not registered for finId=${ownerFinId}`);
+      return failedDepositOperation(1, `Asset ${asset.assetId} is not registered`);
+    }
+
+    const resolved = await this.walletResolver(ownerFinId);
+    if (!resolved) {
+      this.logger.warn(`Wallet-deposit: no wallet mapping for finId=${ownerFinId}`);
+      // TODO: auto-provision a custody account + mapping when missing.
+      return failedDepositOperation(1, `No wallet mapping registered for finId ${ownerFinId}`);
+    }
+
+    const operationId = workflows.generateCid();
+    this.logger.info(
+      `Wallet-deposit: created deposit ${operationId} for finId=${ownerFinId} assetId=${asset.assetId} target=${resolved.walletAddress}`,
+    );
+    return successfulDepositOperation({
+      asset,
+      account: { finId: ownerFinId, account: { type: 'crypto', address: resolved.walletAddress } },
+      description: 'Wallet deposit to investor address',
+      paymentOptions: [{
+        description: 'Crypto transfer',
+        currency: asset.assetId,
+        methodInstruction: {
+          type: 'cryptoTransfer',
+          network: this.network,
+          contractAddress: dbAsset.contract_address,
+          walletAddress: resolved.walletAddress,
+        },
+      }],
+      operationId,
+      details: undefined,
+    });
+  }
+
+  async depositCustom(
+    idempotencyKey: string, ownerFinId: string, amount: string | undefined, details: any, signature: Signature | undefined,
+  ): Promise<DepositOperation> {
+    return failedDepositOperation(1, 'Custom deposits are not supported by wallet-deposit plugin');
+  }
+
+  async payout(
+    idempotencyKey: string, sourceFinId: string, destinationFinId: string, asset: Asset, amount: string, signature: Signature | undefined,
+  ): Promise<ReceiptOperation> {
+    throw new Error('Payout not implemented for wallet-deposit plugin');
+  }
+}

--- a/src/integrations/dfns/config.ts
+++ b/src/integrations/dfns/config.ts
@@ -76,21 +76,21 @@ export async function createDfnsAppConfig(): Promise<Omit<DfnsAppConfig, 'accoun
   const rpcUrl = getNetworkRpcUrl();
   const provider = new JsonRpcProvider(rpcUrl);
 
-  const issuerWalletId = process.env.DFNS_ASSET_ISSUER_WALLET_ID;
-  if (!issuerWalletId) throw new Error('DFNS_ASSET_ISSUER_WALLET_ID is not set');
+  const issuerWalletId = process.env.ASSET_ISSUER_CUSTODY_ACCOUNT_ID;
+  if (!issuerWalletId) throw new Error('ASSET_ISSUER_CUSTODY_ACCOUNT_ID is not set');
 
-  const escrowWalletId = process.env.DFNS_ASSET_ESCROW_WALLET_ID;
-  if (!escrowWalletId) throw new Error('DFNS_ASSET_ESCROW_WALLET_ID is not set');
+  const escrowWalletId = process.env.ASSET_ESCROW_CUSTODY_ACCOUNT_ID;
+  if (!escrowWalletId) throw new Error('ASSET_ESCROW_CUSTODY_ACCOUNT_ID is not set');
 
-  const omnibusWalletId = process.env.DFNS_OMNIBUS_WALLET_ID || undefined;
+  const omnibusWalletId = process.env.OMNIBUS_CUSTODY_ACCOUNT_ID || undefined;
 
   const keySigner = new AsymmetricKeySigner({ credId: dfnsCredId, privateKey: dfnsPrivateKey });
   const dfnsClient = new DfnsApiClient({ baseUrl: dfnsBaseUrl, orgId: dfnsOrgId, authToken: dfnsAuthToken, signer: keySigner });
   const { signer } = await createDfnsEthersProvider({ dfnsClient, walletId: issuerWalletId, rpcUrl });
 
   let gasFunding: DfnsAppConfig['gasFunding'] = undefined
-  const fundingWalletId = process.env.DFNS_GAS_FUNDING_WALLET_ID
-  const fundingAmount = process.env.DFNS_GAS_FUNDING_AMOUNT
+  const fundingWalletId = process.env.GAS_FUNDING_CUSTODY_ACCOUNT_ID
+  const fundingAmount = process.env.GAS_FUNDING_AMOUNT
   if (fundingWalletId !== undefined && fundingAmount !== undefined) {
     gasFunding = { walletId: fundingWalletId, amount: fundingAmount }
   }

--- a/src/integrations/dfns/provider.ts
+++ b/src/integrations/dfns/provider.ts
@@ -92,4 +92,22 @@ export class DfnsCustodyProvider implements CustodyProvider {
     return wallet.address;
   }
 
+  async archiveCustodyAccount(walletId: string): Promise<void> {
+    // DFNS has no delete API; tag the wallet as archived so listing/filtering can exclude it.
+    await this.dfnsClient.wallets.tagWallet({ walletId, body: { tags: ['ota-archived'] } });
+  }
+
+  async createCustodyAccount(label?: string): Promise<{ custodyAccountId: string; address: string }> {
+    const network = process.env.DFNS_NETWORK;
+    if (!network) {
+      throw new Error('DFNS_NETWORK env var is required for createCustodyAccount (e.g. EthereumSepolia)');
+    }
+    const name = label ?? `ota-${Date.now()}`;
+    const wallet = await this.dfnsClient.wallets.createWallet({ body: { network: network as any, name } });
+    if (!wallet.address) {
+      throw new Error(`DFNS wallet ${wallet.id} created but address is not yet available (network=${network})`);
+    }
+    this.addressToWalletId.set(wallet.address.toLowerCase(), wallet.id);
+    return { custodyAccountId: wallet.id, address: wallet.address };
+  }
 }

--- a/src/integrations/fireblocks/config.ts
+++ b/src/integrations/fireblocks/config.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import { ApiBaseUrl, ChainId, FireblocksWeb3Provider } from "@fireblocks/fireblocks-web3-provider";
 import { BrowserProvider, JsonRpcProvider, Provider, Signer } from "ethers";
 import { BaseAppConfig } from "../../config";
@@ -75,9 +74,9 @@ export async function createFireblocksAppConfig(): Promise<Omit<FireblocksAppCon
   const chainId = (process.env.FIREBLOCKS_CHAIN_ID || ChainId.MAINNET) as ChainId;
   const apiBaseUrl = (process.env.FIREBLOCKS_API_BASE_URL || ApiBaseUrl.Production) as ApiBaseUrl;
 
-  const assetIssuerVaultId = process.env.FIREBLOCKS_ASSET_ISSUER_VAULT_ID || undefined
-  const assetEscrowVaultId = process.env.FIREBLOCKS_ASSET_ESCROW_VAULT_ID || undefined
-  const omnibusVaultId = process.env.FIREBLOCKS_OMNIBUS_VAULT_ID || undefined
+  const assetIssuerVaultId = process.env.ASSET_ISSUER_CUSTODY_ACCOUNT_ID || undefined
+  const assetEscrowVaultId = process.env.ASSET_ESCROW_CUSTODY_ACCOUNT_ID || undefined
+  const omnibusVaultId = process.env.OMNIBUS_CUSTODY_ACCOUNT_ID || undefined
 
   const localSubmit = process.env.LOCAL_SUBMIT === 'true';
 
@@ -92,7 +91,7 @@ export async function createFireblocksAppConfig(): Promise<Omit<FireblocksAppCon
   } else {
     const baseVaultId = assetIssuerVaultId ?? omnibusVaultId;
     if (!baseVaultId) {
-      throw new Error('At least one of FIREBLOCKS_ASSET_ISSUER_VAULT_ID or FIREBLOCKS_OMNIBUS_VAULT_ID must be set');
+      throw new Error('At least one of ASSET_ISSUER_CUSTODY_ACCOUNT_ID or OMNIBUS_CUSTODY_ACCOUNT_ID must be set');
     }
     const fb = await createFireblocksEthersProvider({
       apiKey, privateKey: apiPrivateKey, chainId, apiBaseUrl, vaultAccountIds: [baseVaultId]
@@ -102,8 +101,8 @@ export async function createFireblocksAppConfig(): Promise<Omit<FireblocksAppCon
   }
 
   let gasFunding: FireblocksAppConfig['gasFunding'] = undefined
-  const fundingVaultId = process.env.FIREBLOCKS_GAS_FUNDING_VAULT_ID
-  const fundingAssetAmount = process.env.FIREBLOCKS_GAS_FUNDING_AMOUNT
+  const fundingVaultId = process.env.GAS_FUNDING_CUSTODY_ACCOUNT_ID
+  const fundingAssetAmount = process.env.GAS_FUNDING_AMOUNT
   if (fundingVaultId !== undefined && fundingAssetAmount !== undefined) {
     gasFunding = { vaultId: fundingVaultId, amount: fundingAssetAmount }
   }

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -66,7 +66,7 @@ export class FireblocksCustodyProvider implements CustodyProvider {
 
     // In standard mode, issuer and escrow are required
     if (!config.localSubmit && (!issuerWallet || !escrowWallet)) {
-      throw new Error('Either FIREBLOCKS_ASSET_ISSUER_VAULT_ID/FIREBLOCKS_ASSET_ESCROW_VAULT_ID or FIREBLOCKS_OMNIBUS_VAULT_ID must be set');
+      throw new Error('Either ASSET_ISSUER_CUSTODY_ACCOUNT_ID/ASSET_ESCROW_CUSTODY_ACCOUNT_ID or OMNIBUS_CUSTODY_ACCOUNT_ID must be set');
     }
 
     let gasStation: GasStation | undefined;
@@ -122,6 +122,28 @@ export class FireblocksCustodyProvider implements CustodyProvider {
       throw new Error(`No deposit address found for vault ${vaultAccountId} asset ${assetId}`);
     }
     return addresses[0].address;
+  }
+
+  async archiveCustodyAccount(vaultAccountId: string): Promise<void> {
+    await this.fireblocksSdk.hideVaultAccount(vaultAccountId);
+  }
+
+  async createCustodyAccount(label?: string): Promise<{ custodyAccountId: string; address: string }> {
+    const assetId = process.env.FIREBLOCKS_ASSET_ID ?? 'ETH_TEST5';
+    const name = label ?? `ota-${Date.now()}`;
+    const vault = await this.fireblocksSdk.createVaultAccount(name);
+    const vaultAsset = await this.fireblocksSdk.createVaultAsset(vault.id, assetId);
+    let address = vaultAsset.address;
+    if (!address) {
+      // Fallback: address may not be returned synchronously by createVaultAsset on
+      // some Fireblocks tenants. Query getDepositAddresses to fetch it.
+      const addresses = await this.fireblocksSdk.getDepositAddresses(vault.id, assetId);
+      if (addresses.length === 0) {
+        throw new Error(`Vault ${vault.id} created but no deposit address available for asset ${assetId}`);
+      }
+      address = addresses[0].address;
+    }
+    return { custodyAccountId: vault.id, address };
   }
 
   async onAssetRegistered(tokenAddress: string, symbol?: string): Promise<void> {

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -1,10 +1,15 @@
 import winston from "winston";
 import { PluginManager } from "@owneraio/finp2p-nodejs-skeleton-adapter";
+import { InboundTransferHook } from "@owneraio/finp2p-nodejs-skeleton-adapter/plugin";
 import { FinP2PClient } from "@owneraio/finp2p-client";
-import { WalletResolver } from "../services/direct";
+import { AssetStore, CustodyProvider, WalletResolver } from "../services/direct";
+import { AccountModel } from "../config";
 import { registerFireblocks } from "./fireblocks";
 import { registerDfns } from "./dfns";
 import { registerDtccPlugin } from "./dtcc";
+import { registerWalletDeposit } from "./deposits/wallet-deposit";
+import { registerPullDeposit } from "./deposits/pull-deposit";
+import { registerOtaDeposit } from "./deposits/ota-deposit";
 
 export interface IntegrationContext {
   orgId: string;
@@ -13,6 +18,10 @@ export interface IntegrationContext {
   finP2PClient: FinP2PClient;
   walletResolver: WalletResolver | undefined;
   rpcUrl: string | undefined;
+  assetStore: AssetStore | undefined;
+  accountModel: AccountModel;
+  custodyProvider: CustodyProvider | undefined;
+  inboundTransferHook: InboundTransferHook | undefined;
 }
 
 export type IntegrationRegistrar = (ctx: IntegrationContext) => void;
@@ -24,6 +33,9 @@ export function registerCustodyIntegrations(): void {
 }
 
 const integrations: IntegrationRegistrar[] = [
+  registerWalletDeposit,
+  registerPullDeposit,
+  registerOtaDeposit,
   registerDtccPlugin,
 ];
 

--- a/src/services/direct/custody-provider.ts
+++ b/src/services/direct/custody-provider.ts
@@ -18,4 +18,24 @@ export interface CustodyProvider {
   createWalletForCustodyId?(custodyAccountId: string): Promise<CustodyWallet>;
   resolveAddressFromCustodyId?(custodyAccountId: string): Promise<string>;
   onAssetRegistered?(tokenAddress: string, symbol?: string): Promise<void>;
+  /**
+   * Provision a brand-new custody account (vault / wallet) and return its identifier
+   * and EVM deposit address. Used by deposit methods that allocate a single-use address
+   * per deposit (see ota-deposit). The returned `custodyAccountId` is a valid input to
+   * `createWalletForCustodyId` for later signing — callers compose the two when they
+   * need the signer (e.g. at sweep time).
+   *
+   * Implementations should ensure the new account is EVM-enabled (deposit address
+   * generated for the chain in use). The optional `label` is for operator visibility
+   * in the custody dashboard (not load-bearing).
+   */
+  createCustodyAccount?(label?: string): Promise<{ custodyAccountId: string; address: string }>;
+  /**
+   * Mark a previously-created custody account as no-longer-in-use. Best-effort cleanup
+   * after a single-use OTA-deposit account has been swept. Neither Fireblocks nor DFNS
+   * support hard-delete of vault accounts/wallets — the underlying call is `hideVaultAccount`
+   * (Fireblocks) or `tagWallet` (DFNS). Any leftover dust (e.g. unused gas) remains in
+   * custody but invisible to operators.
+   */
+  archiveCustodyAccount?(custodyAccountId: string): Promise<void>;
 }

--- a/src/services/direct/omnibus-delegate.ts
+++ b/src/services/direct/omnibus-delegate.ts
@@ -3,7 +3,8 @@ import {
   LedgerAssetIdentifier,
   Destination, ExecutionContext, Source,
   PaymentService, DepositAsset, DepositOperation, ReceiptOperation, Signature,
-  successfulDepositOperation, failedReceiptOperation,
+  successfulDepositOperation, failedDepositOperation, failedReceiptOperation,
+  workflows,
 } from '@owneraio/finp2p-nodejs-skeleton-adapter';
 import { TransferDelegate, AssetDelegate, EscrowDelegate, OmnibusDelegate as OmnibusDelegateInterface, DelegateResult, InboundTransferVerificationError } from '@owneraio/finp2p-vanilla-service';
 import { parseUnits, id as keccak256 } from 'ethers';
@@ -246,6 +247,11 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     _nonce: string | undefined,
     _signature: Signature | undefined,
   ): Promise<DepositOperation> {
+    if (_asset.assetType !== 'finp2p' || !('assetId' in _asset)) {
+      return failedDepositOperation(1, 'Omnibus deposit only supports finp2p asset type');
+    }
+    const dbAsset = await getAssetFromDb(this.assetStore, _asset.assetId);
+
     const omnibusAddress = await this.omnibusWallet.signer.getAddress();
     const network = await this.custodyProvider.rpcProvider.getNetwork();
     const chainId = Number(network.chainId);
@@ -253,7 +259,13 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     return successfulDepositOperation({
       asset: _asset,
       account: {
-        finId: '',
+        // Skeleton's depositPayoutAccountToAPI reads `finId` here and emits it
+        // both as the top-level finId AND as the inner discriminator's finId.
+        // An empty value violates the router's minimum-length check.
+        finId: _owner.finId,
+        // Skeleton overwrites this inner shape unconditionally with
+        // { type: 'finId', finId }; the depositor learns the on-chain address
+        // from paymentOptions[].methodInstruction.walletAddress instead.
         account: {
           type: 'crypto',
           address: omnibusAddress,
@@ -266,11 +278,11 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
         methodInstruction: {
           type: 'cryptoTransfer',
           network: `eip155:${chainId}`,
-          contractAddress: '',
+          contractAddress: dbAsset.contractAddress,
           walletAddress: omnibusAddress,
         },
       }],
-      operationId: undefined,
+      operationId: workflows.generateCid(),
       details: undefined,
     });
   }

--- a/tests/deposits-omnibus.test.ts
+++ b/tests/deposits-omnibus.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Fireblocks + omnibus + ETH integration tests for the deposit-method plugins.
+ *
+ * Flow per method (pull, ota):
+ *   1. Boot the adapter wired to Fireblocks-omnibus + a mocked FinP2PClient.
+ *   2. Bind the asset to the existing Sepolia USDC contract via /assets/create.
+ *   3. Call /payments/depositInstruction → receive the deposit target address
+ *      (operator address for pull, ephemeral one-time address for ota).
+ *   4. Donor vault sends USDC:
+ *        - ota:  ERC20 transfer donor → ephemeral
+ *        - pull: ERC20 approve(operator, amount) from donor; adapter pulls into omnibus
+ *   5. Poll until omnibus USDC balance increases AND mock FinAPI captured an
+ *      importTransactions call for the deposit.
+ *   6. Assert receipt fields, swept-balance is zero (ota), and the ephemeral
+ *      vault was archived.
+ *
+ * Requires real Fireblocks credentials + a donor vault funded with USDC + ETH.
+ * Run with: npm run test:deposits-omnibus
+ */
+
+import http from "http";
+import { Contract, JsonRpcProvider, parseUnits } from "ethers";
+import { FireblocksSDK, PeerType, TransactionOperation, TransactionStatus } from "fireblocks-sdk";
+import { ApiBaseUrl, ChainId } from "@fireblocks/fireblocks-web3-provider";
+import winston, { format, transports } from "winston";
+import createApp, { WorkflowsConfig } from "../src/app";
+import { FireblocksAppConfig, createFireblocksEthersProvider } from "../src/integrations/fireblocks/config";
+import { randomPort } from "./utils/utils";
+
+declare const fireblocksConfig: {
+  apiKey: string;
+  apiPrivateKey: string;
+  apiBaseUrl: ApiBaseUrl;
+  chainId: ChainId;
+  operatorVaultId: string;
+  omnibusVaultId: string;
+  donorVaultId: string;
+  gasFundingVaultId: string;
+  gasFundingAmount: string;
+  usdcAssetId: string;
+  usdcContractAddress: string;
+  omnibusAddress: string;
+  donorAddress: string;
+};
+declare const connectionString: string;
+declare const gooseExecutablePath: string;
+
+const ASSET_ID_OTA = "USDC-OMNIBUS-OTA";
+const ASSET_ID_PULL = "USDC-OMNIBUS-PULL";
+const TEST_INVESTOR_FIN_ID = "0376339d3cd3c44d704d27cfba39e13234732f47f2d10927c4f3a7b5032daa3649";
+const TEST_ISSUER_FIN_ID = "0341bf2178bc4e047f5782f3a25ed4ffd742edf4604ba22ae2f771036d3e4a6710";
+
+const ERC20_ABI = [
+  "function balanceOf(address) view returns (uint256)",
+  "function approve(address,uint256) returns (bool)",
+];
+
+const logger = winston.createLogger({
+  level: "info",
+  transports: [new transports.Console({ level: "info" })],
+  format: format.json(),
+});
+
+interface CapturedReceipt {
+  txs: any[];
+}
+
+function makeMockFinP2PClient(captured: CapturedReceipt[]): any {
+  return {
+    importTransactions: async (txs: any[]) => {
+      captured.push({ txs });
+      return { ok: true };
+    },
+    // The workflow proxy invokes sendCallback after every wrapped op; provide a no-op
+    // so we don't get noisy "Failed to send callback to router" logs.
+    sendCallback: async () => undefined,
+  };
+}
+
+async function startAdapter(depositMethod: "pull" | "ota", finP2PClientMock: any): Promise<{ url: string; close: () => Promise<void> }> {
+  process.env.DEPOSIT_METHOD = depositMethod;
+
+  const { provider, signer } = await createFireblocksEthersProvider({
+    apiKey: fireblocksConfig.apiKey,
+    privateKey: fireblocksConfig.apiPrivateKey,
+    chainId: fireblocksConfig.chainId,
+    apiBaseUrl: fireblocksConfig.apiBaseUrl as string,
+    vaultAccountIds: [fireblocksConfig.operatorVaultId],
+  });
+
+  const appConfig: FireblocksAppConfig = {
+    type: "fireblocks",
+    orgId: "test-org",
+    provider,
+    signer,
+    finP2PClient: finP2PClientMock,
+    proofProvider: undefined,
+    accountMappingType: "database",
+    accountModel: "omnibus",
+    apiKey: fireblocksConfig.apiKey,
+    apiPrivateKey: fireblocksConfig.apiPrivateKey,
+    chainId: fireblocksConfig.chainId,
+    apiBaseUrl: fireblocksConfig.apiBaseUrl,
+    assetIssuerVaultId: fireblocksConfig.operatorVaultId,
+    assetEscrowVaultId: fireblocksConfig.operatorVaultId,
+    omnibusVaultId: fireblocksConfig.omnibusVaultId,
+    gasFunding: {
+      vaultId: fireblocksConfig.gasFundingVaultId,
+      amount: fireblocksConfig.gasFundingAmount,
+    },
+  };
+
+  const workflowsConfig: WorkflowsConfig = {
+    migration: {
+      connectionString,
+      gooseExecutablePath,
+      migrationListTableName: "deposit_omnibus_test_migrations",
+      storageUser: new URL(connectionString).username,
+    },
+    finP2PClient: finP2PClientMock,
+  };
+
+  const port = randomPort();
+  const app = await createApp(workflowsConfig, logger, appConfig, connectionString);
+  const server: http.Server = app.listen(port);
+  await new Promise<void>((res) => server.once("listening", () => res()));
+
+  const readiness = await fetch(`http://localhost:${port}/health/readiness`);
+  if (!readiness.ok) throw new Error(`adapter not ready: ${await readiness.text()}`);
+
+  return {
+    url: `http://localhost:${port}/api`,
+    close: () =>
+      new Promise<void>((res, rej) => server.close((err) => (err ? rej(err) : res()))),
+  };
+}
+
+async function postJson(url: string, body: any): Promise<any> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", "idempotency-key": String(Date.now()) },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`POST ${url} → ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function bindAsset(adapterUrl: string, assetId: string): Promise<void> {
+  await postJson(`${adapterUrl}/assets/create`, {
+    asset: { resourceId: assetId },
+    ledgerAssetBinding: {
+      tokenId: fireblocksConfig.usdcContractAddress,
+      network: "sepolia",
+      standard: "ERC20",
+    },
+    name: "USDC (test)",
+    issuerId: TEST_ISSUER_FIN_ID,
+    denomination: { type: "fiat", code: "USD" },
+  });
+}
+
+async function requestDeposit(adapterUrl: string, assetId: string, amount: string): Promise<{ walletAddress: string; operationId: string; cid: string; custodyAccountId: string | undefined }> {
+  const resp = await postJson(`${adapterUrl}/payments/depositInstruction/`, {
+    owner: { finId: TEST_INVESTOR_FIN_ID },
+    destination: { finId: TEST_INVESTOR_FIN_ID },
+    asset: { type: "finp2p", resourceId: assetId },
+    amount,
+  });
+  // The workflow proxy returns { isCompleted: false, cid } and runs the call async,
+  // persisting the result. Either we already have `response`, or we poll status.
+  let depositOp = resp;
+  if (!depositOp?.response && !depositOp?.error) {
+    if (!resp?.cid) throw new Error(`depositInstruction had no cid in pending response: ${JSON.stringify(resp)}`);
+    depositOp = await waitForDepositCompletion(adapterUrl, resp.cid);
+  }
+  if (depositOp?.error && Object.keys(depositOp.error).length > 0) {
+    throw new Error(`depositInstruction failed: ${JSON.stringify(depositOp.error)}`);
+  }
+  const instr = depositOp?.response;
+  const opt = instr?.paymentOptions?.[0];
+  const walletAddress = opt?.methodInstruction?.walletAddress;
+  if (!walletAddress) {
+    throw new Error(`depositInstruction returned no walletAddress: ${JSON.stringify(depositOp)}`);
+  }
+  return {
+    walletAddress,
+    operationId: instr?.operationId,
+    cid: resp.cid,
+    custodyAccountId: instr?.details?.custodyAccountId,
+  };
+}
+
+async function waitForDepositCompletion(adapterUrl: string, cid: string): Promise<any> {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    const res = await fetch(`${adapterUrl}/operations/status/${cid}`);
+    if (res.ok) {
+      const body = await res.json() as any;
+      const op = body?.operation ?? body;
+      if (op?.isCompleted) return op;
+    }
+    await sleep(200);
+  }
+  throw new Error(`Operation ${cid} did not complete in time`);
+}
+
+async function donorTransferUsdc(sdk: FireblocksSDK, toAddress: string, amount: string): Promise<string> {
+  const tx = await sdk.createTransaction({
+    operation: TransactionOperation.TRANSFER,
+    assetId: fireblocksConfig.usdcAssetId,
+    source: { type: PeerType.VAULT_ACCOUNT, id: fireblocksConfig.donorVaultId },
+    destination: { type: PeerType.ONE_TIME_ADDRESS, oneTimeAddress: { address: toAddress } },
+    amount,
+    note: "deposit-omnibus-test: donor → ephemeral",
+  });
+  return waitForFireblocksTx(sdk, tx.id);
+}
+
+async function donorApproveUsdc(spender: string, amount: bigint): Promise<string> {
+  // Use fireblocks-web3-provider (via the adapter's helper) to make the donor vault
+  // sign an ERC20 approve.
+  const { signer } = await createFireblocksEthersProvider({
+    apiKey: fireblocksConfig.apiKey,
+    privateKey: fireblocksConfig.apiPrivateKey,
+    chainId: fireblocksConfig.chainId,
+    apiBaseUrl: fireblocksConfig.apiBaseUrl as string,
+    vaultAccountIds: [fireblocksConfig.donorVaultId],
+  });
+  const usdc = new Contract(fireblocksConfig.usdcContractAddress, ERC20_ABI, signer);
+  const tx = await usdc.approve(spender, amount);
+  const receipt = await tx.wait();
+  if (!receipt || receipt.status !== 1) throw new Error(`donor approve failed: ${tx.hash}`);
+  return receipt.hash;
+}
+
+async function waitForFireblocksTx(sdk: FireblocksSDK, txId: string): Promise<string> {
+  const TERMINAL_FAIL: TransactionStatus[] = [
+    TransactionStatus.FAILED,
+    TransactionStatus.BLOCKED,
+    TransactionStatus.CANCELLED,
+    TransactionStatus.REJECTED,
+  ];
+  for (let i = 0; i < 200; i++) {
+    const info = await sdk.getTransactionById(txId);
+    if (info.status === TransactionStatus.COMPLETED) return info.txHash || txId;
+    if (TERMINAL_FAIL.includes(info.status)) {
+      throw new Error(`Fireblocks tx ${txId} reached terminal status ${info.status}`);
+    }
+    await sleep(3000);
+  }
+  throw new Error(`Fireblocks tx ${txId} did not complete in time`);
+}
+
+async function readUsdcBalance(provider: JsonRpcProvider, address: string): Promise<bigint> {
+  const usdc = new Contract(fireblocksConfig.usdcContractAddress, ERC20_ABI, provider);
+  return await usdc.balanceOf(address) as bigint;
+}
+
+async function pollUntil<T>(label: string, fn: () => Promise<T | undefined>, timeoutMs = 300000, intervalMs = 5000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const v = await fn();
+    if (v !== undefined) return v;
+    await sleep(intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${label}`);
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe("Fireblocks + omnibus deposit plugins", () => {
+  const captured: CapturedReceipt[] = [];
+  let adapter: { url: string; close: () => Promise<void> } | undefined;
+  let provider: JsonRpcProvider;
+  let fireblocksSdk: FireblocksSDK;
+
+  beforeAll(() => {
+    fireblocksSdk = new FireblocksSDK(fireblocksConfig.apiPrivateKey, fireblocksConfig.apiKey, fireblocksConfig.apiBaseUrl as string);
+    const networkUrl = process.env.SEPOLIA_RPC_URL || process.env.NETWORK_HOST;
+    if (!networkUrl) throw new Error("SEPOLIA_RPC_URL (or NETWORK_HOST) must point to a Sepolia RPC for balance assertions");
+    provider = new JsonRpcProvider(networkUrl);
+  });
+
+  afterEach(async () => {
+    captured.length = 0;
+    if (adapter) {
+      await adapter.close();
+      adapter = undefined;
+    }
+  });
+
+  describe("ota-deposit", () => {
+    it("sweeps a donor transfer to omnibus and reports a receipt", async () => {
+      adapter = await startAdapter("ota", makeMockFinP2PClient(captured));
+
+      await bindAsset(adapter.url, ASSET_ID_OTA);
+
+      // Caller convention: amount is human-readable (FinAPI / vanilla hook expect this).
+      const amount = "0.1"; // 0.1 USDC (6 decimals)
+      const amountBaseUnits = parseUnits(amount, 6);
+      const omnibusBefore = await readUsdcBalance(provider, fireblocksConfig.omnibusAddress);
+
+      const { walletAddress: ephemeral, custodyAccountId } = await requestDeposit(adapter.url, ASSET_ID_OTA, amount);
+      expect(ephemeral).toMatch(/^0x[a-fA-F0-9]{40}$/);
+      expect(ephemeral.toLowerCase()).not.toBe(fireblocksConfig.omnibusAddress.toLowerCase());
+      expect(custodyAccountId).toBeDefined();
+
+      logger.info(`[ota] donor → ephemeral ${ephemeral} (${amount})`);
+      await donorTransferUsdc(fireblocksSdk, ephemeral, amount);
+
+      // Wait until the mock has the receipt; the watcher fires this only after the
+      // sweep tx (when a gas-station is configured). Then verify the full lifecycle.
+      const receipt = await pollUntil(
+        "FinAPI receipt",
+        async () => (captured.length > 0 ? captured[0] : undefined),
+        600000,
+      );
+
+      const ephemeralAfter = await readUsdcBalance(provider, ephemeral);
+      const omnibusAfter = await readUsdcBalance(provider, fireblocksConfig.omnibusAddress);
+      logger.info(`[ota] result: ephemeralAfter=${ephemeralAfter} omnibusDelta=${omnibusAfter - omnibusBefore}`);
+
+      expect(ephemeralAfter).toBe(0n);
+      expect(omnibusAfter - omnibusBefore).toBe(amountBaseUnits);
+
+      expect(receipt.txs).toHaveLength(1);
+      const tx = receipt.txs[0];
+      expect(tx.quantity).toBe(amount);
+      expect(tx.destination?.finp2pAccount?.account?.finId).toBe(TEST_INVESTOR_FIN_ID);
+      expect(tx.destination?.finp2pAccount?.asset?.id).toBe(ASSET_ID_OTA);
+
+      // Archive verification: Fireblocks archive = hideVaultAccount → vault.hiddenOnUI=true.
+      // archiveCustodyAccount runs AFTER exportReceipt fires (which is what `captured` signals),
+      // so poll the vault state instead of asserting it synchronously.
+      await pollUntil(
+        "vault archived",
+        async () => {
+          const v = await fireblocksSdk.getVaultAccountById(custodyAccountId!);
+          return v.hiddenOnUI ? v : undefined;
+        },
+        30000,
+        1000,
+      );
+    }, 600000);
+  });
+
+  describe("pull-deposit", () => {
+    it("pulls an approved transfer into omnibus and reports a receipt", async () => {
+      adapter = await startAdapter("pull", makeMockFinP2PClient(captured));
+
+      await bindAsset(adapter.url, ASSET_ID_PULL);
+
+      // Caller convention: amount is human-readable (FinAPI / vanilla hook expect this).
+      const amount = "0.1"; // 0.1 USDC (6 decimals)
+      const amountBaseUnits = parseUnits(amount, 6);
+      const omnibusBefore = await readUsdcBalance(provider, fireblocksConfig.omnibusAddress);
+
+      const { walletAddress: spender } = await requestDeposit(adapter.url, ASSET_ID_PULL, amount);
+      expect(spender).toMatch(/^0x[a-fA-F0-9]{40}$/);
+
+      logger.info(`[pull] donor approving spender=${spender} amount=${amount}`);
+      await donorApproveUsdc(spender, amountBaseUnits);
+
+      // Pull can retry the watcher → transferFrom cycle several times when the
+      // operator's gas-funding tx hasn't settled. Allow up to 14 min so the inner
+      // poll doesn't fire before the jest test timeout (900s) does.
+      const receipt = await pollUntil(
+        "FinAPI receipt",
+        async () => (captured.length > 0 ? captured[0] : undefined),
+        840000,
+      );
+
+      const omnibusAfter = await readUsdcBalance(provider, fireblocksConfig.omnibusAddress);
+      logger.info(`[pull] result: omnibusDelta=${omnibusAfter - omnibusBefore}`);
+      expect(omnibusAfter - omnibusBefore).toBe(amountBaseUnits);
+
+      expect(receipt.txs).toHaveLength(1);
+      const tx = receipt.txs[0];
+      expect(tx.quantity).toBe(amount);
+      expect(tx.destination?.finp2pAccount?.account?.finId).toBe(TEST_INVESTOR_FIN_ID);
+      expect(tx.destination?.finp2pAccount?.asset?.id).toBe(ASSET_ID_PULL);
+    }, 900000);
+  });
+});

--- a/tests/utils/fireblocks-omnibus-test-environment.ts
+++ b/tests/utils/fireblocks-omnibus-test-environment.ts
@@ -1,0 +1,157 @@
+import { EnvironmentContext, JestEnvironmentConfig } from "@jest/environment";
+import { ApiBaseUrl, ChainId } from "@fireblocks/fireblocks-web3-provider";
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import * as console from "console";
+import * as dotenv from "dotenv";
+import * as fs from "fs";
+import NodeEnvironment from "jest-environment-node";
+import { exec } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { FireblocksSDK } from "fireblocks-sdk";
+
+dotenv.config({ path: resolve(process.cwd(), ".env.fireblocks") });
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Required env ${name} not set`);
+  return v;
+}
+
+const OPERATOR_VAULT_ID_DEFAULT = "85";
+const OMNIBUS_VAULT_ID_DEFAULT = "17";
+const DONOR_VAULT_ID_DEFAULT = "25";
+const GAS_FUNDING_VAULT_ID_DEFAULT = "15";
+const GAS_FUNDING_AMOUNT_DEFAULT = "0.001"; // ETH per OTA sweep — covers Sepolia ERC20 transfer gas
+const USDC_CONTRACT_DEFAULT = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238";
+
+class FireblocksOmnibusTestEnvironment extends NodeEnvironment {
+
+  private postgresSqlContainer: StartedPostgreSqlContainer | undefined;
+
+  constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+    super(config, context);
+  }
+
+  async setup() {
+    console.log("[fbtest] Setting up Fireblocks omnibus test environment...");
+
+    // Suppress pg pool errors during teardown (postgres container stop drops live connections,
+    // pg-protocol then emits 'error' from a Client that has no listener → unhandled error crash).
+    const pg = require("pg");
+    const OrigPool = pg.Pool;
+    pg.Pool = class PatchedPool extends OrigPool {
+      constructor(...args: any[]) {
+        super(...args);
+        this.on("error", () => {});
+      }
+    };
+
+    const apiKey = requireEnv("FIREBLOCKS_API_KEY");
+    const chainId = Number(requireEnv("FIREBLOCKS_CHAIN_ID")) as ChainId;
+    const apiBaseUrl = (process.env.FIREBLOCKS_API_BASE_URL || ApiBaseUrl.Production) as ApiBaseUrl;
+
+    let apiPrivateKey: string;
+    if (process.env.FIREBLOCKS_API_PRIVATE_KEY) {
+      apiPrivateKey = Buffer.from(process.env.FIREBLOCKS_API_PRIVATE_KEY, "base64").toString("utf-8");
+    } else {
+      apiPrivateKey = fs.readFileSync(requireEnv("FIREBLOCKS_API_PRIVATE_KEY_PATH"), "utf-8");
+    }
+
+    const operatorVaultId = process.env.FIREBLOCKS_VAULT_ID || OPERATOR_VAULT_ID_DEFAULT;
+    const omnibusVaultId = process.env.FIREBLOCKS_OMNIBUS_VAULT_ID || OMNIBUS_VAULT_ID_DEFAULT;
+    const donorVaultId = process.env.FIREBLOCKS_DONOR_VAULT_ID || DONOR_VAULT_ID_DEFAULT;
+    const gasFundingVaultId = process.env.FIREBLOCKS_GAS_FUNDING_VAULT_ID || GAS_FUNDING_VAULT_ID_DEFAULT;
+    const gasFundingAmount = process.env.FIREBLOCKS_GAS_FUNDING_AMOUNT || GAS_FUNDING_AMOUNT_DEFAULT;
+    const usdcContractAddress = (process.env.USDC_CONTRACT_ADDRESS || USDC_CONTRACT_DEFAULT).toLowerCase();
+
+    const fireblocksSdk = new FireblocksSDK(apiPrivateKey, apiKey, apiBaseUrl as string);
+
+    console.log("[fbtest] Looking up USDC Fireblocks asset id by contract address ...");
+    const usdcAssetId = await this.findFireblocksAssetIdByContract(fireblocksSdk, donorVaultId, usdcContractAddress);
+    console.log(`[fbtest] USDC asset id: ${usdcAssetId} (contract ${usdcContractAddress})`);
+
+    const omnibusAddresses = await fireblocksSdk.getDepositAddresses(omnibusVaultId, usdcAssetId);
+    if (omnibusAddresses.length === 0) {
+      throw new Error(`Omnibus vault ${omnibusVaultId} has no deposit address for ${usdcAssetId}`);
+    }
+    const omnibusAddress = omnibusAddresses[0].address;
+    console.log(`[fbtest] Omnibus address: ${omnibusAddress}`);
+
+    const donorAddresses = await fireblocksSdk.getDepositAddresses(donorVaultId, usdcAssetId);
+    if (donorAddresses.length === 0) {
+      throw new Error(`Donor vault ${donorVaultId} has no deposit address for ${usdcAssetId}`);
+    }
+    const donorAddress = donorAddresses[0].address;
+    console.log(`[fbtest] Donor address: ${donorAddress}`);
+
+    console.log("[fbtest] Starting Postgres container...");
+    this.postgresSqlContainer = await new PostgreSqlContainer("postgres:14.19").start();
+    const connectionString = this.postgresSqlContainer.getConnectionUri();
+    console.log("[fbtest] Postgres ready");
+
+    this.global.fireblocksConfig = {
+      apiKey,
+      apiPrivateKey,
+      apiBaseUrl,
+      chainId,
+      operatorVaultId,
+      omnibusVaultId,
+      donorVaultId,
+      gasFundingVaultId,
+      gasFundingAmount,
+      usdcAssetId,
+      usdcContractAddress,
+      omnibusAddress,
+      donorAddress,
+    };
+    this.global.connectionString = connectionString;
+    this.global.gooseExecutablePath = await this.whichGoose();
+  }
+
+  async teardown() {
+    try {
+      await this.postgresSqlContainer?.stop();
+      console.log("[fbtest] Test environment torn down");
+    } catch (err) {
+      console.error("[fbtest] Teardown error:", err);
+    }
+  }
+
+  private async findFireblocksAssetIdByContract(sdk: FireblocksSDK, vaultId: string, contractAddress: string): Promise<string> {
+    const lower = contractAddress.toLowerCase();
+    const vault = await sdk.getVaultAccountById(vaultId);
+    const assets = vault.assets ?? [];
+    for (const a of assets) {
+      try {
+        const info = await sdk.getAssetById(a.id);
+        const onchain = (info as any).onchain?.address?.toLowerCase();
+        if (onchain && onchain === lower) return a.id;
+      } catch {
+        // skip non-EVM / unsupported lookups
+      }
+    }
+    throw new Error(
+      `No Fireblocks asset on vault ${vaultId} matches contract ${contractAddress}. ` +
+      `Enable USDC on the donor vault, or set USDC_CONTRACT_ADDRESS to the right token.`
+    );
+  }
+
+  private async whichGoose(): Promise<string> {
+    return new Promise<string>((resolveBin, reject) => {
+      const localGoose = join(process.cwd(), "bin", "goose");
+      if (existsSync(localGoose)) return resolveBin(localGoose);
+      exec("which goose", (err, stdout) => {
+        if (err) return reject(err);
+        const path = stdout.trim();
+        if (!path) return reject(new Error("which goose returned empty"));
+        resolveBin(path);
+      });
+    });
+  }
+}
+
+module.exports = FireblocksOmnibusTestEnvironment;

--- a/tests/utils/graphql-stub.js
+++ b/tests/utils/graphql-stub.js
@@ -1,0 +1,1 @@
+module.exports = '';


### PR DESCRIPTION
Cherry-pick of #224 ('3344ae5'). Brings the full deposit-plugins feature: wallet/OTA/pull plugins, custody-agnostic env vars (OMNIBUS_CUSTODY_ACCOUNT_ID, ASSET_ISSUER_CUSTODY_ACCOUNT_ID, ASSET_ESCROW_CUSTODY_ACCOUNT_ID, GAS_FUNDING_CUSTODY_ACCOUNT_ID, GAS_FUNDING_AMOUNT), GasStation class with ensureGas balance-poll-until-reflected, default DEPOSIT_METHOD by accountModel (omnibus→ota, segregated→wallet), operationId correlation across deposit response and imported receipts, logging across every step.

Test plan:
- [x] tsc clean
- [x] omnibus tests 16/16
- [ ] CI green
- [ ] Live verification with cross-org DvP / transfer flows on k3d-local6