### PR TITLE
finp2p-contracts: widen nonce-error detection for ethers v6 (cherry-pick #244)

### DIFF
--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.10",
+  "version": "0.28.11",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-contracts/src/errors.ts
+++ b/finp2p-contracts/src/errors.ts
@@ -6,19 +6,61 @@ export type DetectedError = EthereumTransactionError |
   NonceAlreadyBeenUsedError |
   EthereumContractMethodSignatureError
 
+/**
+ * Map raw provider/RPC errors to typed nonce + transaction errors so the
+ * safeExecuteTransaction wrapper in `manager.ts` can decide whether to
+ * reset the NonceManager and retry.
+ *
+ * The order of the branches matters: we look for the most specific signals
+ * first (substring + ethers `code`), then fall back to the JSON-RPC inner
+ * error shape (which differs between ethers v5 and v6 — see below).
+ *
+ * Inner-error shapes:
+ *   • ethers v5: `e.error?.code`, `e.error?.message`
+ *   • ethers v6: `e.info?.error?.code`, `e.info?.error?.message`
+ * The check below covers both so the wrapper continues to recover after
+ * an ethers upgrade.
+ */
 export const detectError = (e: any): DetectedError | Error => {
   if (`${e}`.includes("no data present; likely require(false) occurred")) {
-    return new EthereumContractMethodSignatureError(`${e}`)
-  } else if ("code" in e && "error" in e && "code" in e.error && "message" in e.error) {
-    if (e.error.code === -32000 || e.error.message.startsWith("Nonce too high")
-    ) {
-      return new NonceTooHighError(e.error.message);
-    }
-  } else if (e.code === 'REPLACEMENT_UNDERPRICED' || `${e}`.includes("nonce has already been used")) {
-    return new NonceAlreadyBeenUsedError(`${e}`);
-  } else if ("code" in e && "action" in e && "message" in e && "reason" in e && "data" in e && e.reason !== undefined && e.reason !== null) {
+    return new EthereumContractMethodSignatureError(`${e}`);
+  }
+
+  const innerCode = e?.error?.code ?? e?.info?.error?.code;
+  const innerMessage = e?.error?.message ?? e?.info?.error?.message;
+  const messageString = `${e}`;
+
+  // "Nonce already used" / "nonce too low" — local nonce is BEHIND the chain.
+  // Match: ethers code, OZ-style substring, and the v5/v6 inner-error message.
+  if (
+    e?.code === 'REPLACEMENT_UNDERPRICED' ||
+    e?.code === 'NONCE_EXPIRED' ||
+    messageString.includes("nonce has already been used") ||
+    (typeof innerMessage === 'string' && innerMessage.startsWith("nonce too low"))
+  ) {
+    return new NonceAlreadyBeenUsedError(messageString);
+  }
+
+  // "Nonce too high" — local nonce is AHEAD of the chain (queued in mempool).
+  // Match the explicit "Nonce too high" message string in the inner error
+  // (v5 `e.error.message` or v6 `e.info.error.message`). We deliberately do
+  // NOT match on bare `code === -32000`: that's a generic JSON-RPC "Server
+  // error" used for many non-nonce failures ("insufficient funds for gas",
+  // "execution reverted", "transaction underpriced", …). Matching it here
+  // would force the wrapper to reset the NonceManager and retry up to 10×
+  // before surfacing a non-nonce error, masking the real cause.
+  if (typeof innerMessage === 'string' && innerMessage.startsWith("Nonce too high")) {
+    return new NonceTooHighError(innerMessage);
+  }
+
+  // Generic on-chain revert / transaction error.
+  if (
+    typeof e === 'object' && e !== null &&
+    'code' in e && 'action' in e && 'message' in e && 'reason' in e && 'data' in e &&
+    e.reason !== undefined && e.reason !== null
+  ) {
     return new EthereumTransactionError(e.reason);
   }
 
-  return e
+  return e;
 };

--- a/finp2p-contracts/test/errors.ts
+++ b/finp2p-contracts/test/errors.ts
@@ -1,0 +1,118 @@
+import { expect } from "chai";
+import { detectError } from "../src/errors";
+import {
+  EthereumContractMethodSignatureError,
+  EthereumTransactionError,
+  NonceAlreadyBeenUsedError,
+  NonceTooHighError,
+} from "../src/model";
+
+/**
+ * Unit tests for detectError(). Exercises the shapes that matter:
+ *  • ethers v5 inner-error shape (`e.error.code` / `e.error.message`)
+ *  • ethers v6 inner-error shape (`e.info.error.code` / `e.info.error.message`)
+ *  • ethers v6 top-level codes (NONCE_EXPIRED / REPLACEMENT_UNDERPRICED)
+ *  • the substring fallback in the printed message
+ *  • the false-positive guard: bare `code === -32000` must NOT classify
+ *    as NonceTooHighError when the message is unrelated (insufficient
+ *    funds, execution reverted, ...)
+ */
+describe("detectError", function () {
+
+  describe("NonceAlreadyBeenUsedError (local nonce behind chain)", () => {
+    it("matches ethers v6 NONCE_EXPIRED top-level code", () => {
+      const e: any = Object.assign(new Error("nonce has already been used"), {
+        code: "NONCE_EXPIRED",
+        info: { error: { code: -32000, message: "nonce too low: next nonce 1056, tx nonce 1055" } },
+      });
+      expect(detectError(e)).to.be.instanceOf(NonceAlreadyBeenUsedError);
+    });
+
+    it("matches REPLACEMENT_UNDERPRICED", () => {
+      const e: any = Object.assign(new Error("replacement transaction underpriced"), {
+        code: "REPLACEMENT_UNDERPRICED",
+      });
+      expect(detectError(e)).to.be.instanceOf(NonceAlreadyBeenUsedError);
+    });
+
+    it("matches the v5 inner-error 'nonce too low' message", () => {
+      const e: any = { error: { code: -32000, message: "nonce too low: server has 42, got 41" } };
+      expect(detectError(e)).to.be.instanceOf(NonceAlreadyBeenUsedError);
+    });
+
+    it("matches the v6 inner-error 'nonce too low' message", () => {
+      const e: any = { info: { error: { code: -32000, message: "nonce too low: server has 42, got 41" } } };
+      expect(detectError(e)).to.be.instanceOf(NonceAlreadyBeenUsedError);
+    });
+
+    it("matches the printed-message substring fallback", () => {
+      const e = new Error("some prefix nonce has already been used some suffix");
+      expect(detectError(e)).to.be.instanceOf(NonceAlreadyBeenUsedError);
+    });
+  });
+
+  describe("NonceTooHighError (local nonce ahead of chain)", () => {
+    it("matches the v5 inner-error 'Nonce too high' message", () => {
+      const e: any = { error: { code: -32000, message: "Nonce too high. Expected 5, got 7" } };
+      expect(detectError(e)).to.be.instanceOf(NonceTooHighError);
+    });
+
+    it("matches the v6 inner-error 'Nonce too high' message", () => {
+      const e: any = { info: { error: { code: -32000, message: "Nonce too high. Expected 5, got 7" } } };
+      expect(detectError(e)).to.be.instanceOf(NonceTooHighError);
+    });
+
+    it("does NOT match bare code -32000 with an unrelated 'insufficient funds' message", () => {
+      // This is the false-positive the original detector hit: -32000 is the
+      // generic JSON-RPC server-error code. Classifying it as a nonce error
+      // would make safeExecuteTransaction reset + retry 10× and mask the
+      // real cause. The fix tightens the match to the message string.
+      const e: any = { info: { error: { code: -32000, message: "insufficient funds for gas * price + value" } } };
+      const detected = detectError(e);
+      expect(detected).not.to.be.instanceOf(NonceTooHighError);
+      expect(detected).not.to.be.instanceOf(NonceAlreadyBeenUsedError);
+    });
+
+    it("does NOT match bare code -32000 with an unrelated 'execution reverted' message", () => {
+      const e: any = { error: { code: -32000, message: "execution reverted: ERC20: transfer amount exceeds balance" } };
+      const detected = detectError(e);
+      expect(detected).not.to.be.instanceOf(NonceTooHighError);
+      expect(detected).not.to.be.instanceOf(NonceAlreadyBeenUsedError);
+    });
+  });
+
+  describe("EthereumTransactionError", () => {
+    it("matches the standard ethers transaction-error shape", () => {
+      const e: any = {
+        code: "CALL_EXCEPTION",
+        action: "sendTransaction",
+        message: "execution reverted",
+        reason: "ERC20: insufficient allowance",
+        data: "0x08c379a0",
+      };
+      const detected = detectError(e);
+      expect(detected).to.be.instanceOf(EthereumTransactionError);
+      expect((detected as EthereumTransactionError).message).to.equal("ERC20: insufficient allowance");
+    });
+  });
+
+  describe("EthereumContractMethodSignatureError", () => {
+    it("matches the wrong-method-signature error string", () => {
+      const e = new Error("call exception: no data present; likely require(false) occurred");
+      expect(detectError(e)).to.be.instanceOf(EthereumContractMethodSignatureError);
+    });
+  });
+
+  describe("pass-through", () => {
+    it("returns the original Error when no branch matches", () => {
+      const e = new Error("totally unrelated failure");
+      expect(detectError(e)).to.equal(e);
+    });
+
+    it("does not throw on null-ish error shapes", () => {
+      expect(detectError({})).to.deep.equal({});
+      expect(() => detectError(null)).not.to.throw();
+      expect(() => detectError(undefined)).not.to.throw();
+    });
+  });
+});

--- a/jest.nonce-recovery.config.js
+++ b/jest.nonce-recovery.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: "ts-jest",
+  testTimeout: 600000,
+  roots: ["<rootDir>/tests"],
+  testMatch: ["<rootDir>/tests/nonce-recovery-sepolia.test.ts"],
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:account-mapping": "jest --config jest.account-mapping.config.js",
     "test:omnibus": "jest --config jest.omnibus.config.js",
     "test:deposits-omnibus": "jest --config jest.deposits-omnibus.config.js",
+    "test:nonce-recovery": "jest --config jest.nonce-recovery.config.js",
     "test-server": "ts-node ./scripts/test-server.ts",
     "migration": "ts-node ./scripts/migration.ts",
     "sync-balances": "ts-node ./scripts/sync-balances.ts",

--- a/tests/nonce-recovery-sepolia.test.ts
+++ b/tests/nonce-recovery-sepolia.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Real Sepolia diagnostic for the safeExecuteTransaction nonce-recovery wrapper
+ * in @owneraio/finp2p-contracts (manager.ts).
+ *
+ * Two NonceManager instances share one operator key; both prime their internal
+ * nonce caches; manager A submits a tx (chain nonce + 1); manager B's cache is
+ * now stale. We then exercise B and see whether the wrapper auto-resets on the
+ * resulting nonce collision.
+ *
+ * The user reports the wrapper "fell through" in production despite the recovery
+ * logic. This test is a controlled reproduction:
+ *
+ *   1. land tx_A and confirm it (chain nonce moves), then race a stale-nonce
+ *      tx_B with NO wrapper — capture the raw error shape that ethers v6
+ *      actually emits, so we can compare against detectError's pattern matches.
+ *   2. exercise the wrapper end-to-end with the same scenario and assert that
+ *      it actually recovers.
+ *
+ * Parameters default to the live values used by `k3d-local6 / org-a / ethereum`:
+ *   SEPOLIA_RPC_URL          (default https://ethereum-sepolia-rpc.publicnode.com)
+ *   OPERATOR_PRIVATE_KEY     — funded operator key, REQUIRED
+ *   ERC20_TOKEN_ADDRESS      (default 0x16C188C6966D6Fc2999b2cF9D5267D517045F65B —
+ *                             an ERC20WithOperator associated to org-a's
+ *                             FinP2P contract on Sepolia)
+ *
+ * Tx used: ERC20.approve(self, 0) on the configured token. Anyone can call;
+ * idempotent; costs ~46k gas per call. Wrapped via a tiny ContractsManager
+ * subclass that exposes safeExecuteTransaction publicly — that's the very
+ * helper we want to exercise.
+ *
+ * Run: SEPOLIA_RPC_URL=... OPERATOR_PRIVATE_KEY=... \
+ *      npx jest --config jest.nonce-recovery.config.js
+ */
+
+import { JsonRpcProvider, NonceManager, Wallet, ContractFactory, BaseContract, ContractTransactionReceipt, ContractTransactionResponse } from 'ethers';
+import { ContractsManager } from '@owneraio/finp2p-contracts';
+type PayableOverrides = { nonce?: number; gasLimit?: bigint; gasPrice?: bigint; value?: bigint };
+import winston from 'winston';
+
+const SEPOLIA_RPC = process.env.SEPOLIA_RPC_URL ?? 'https://ethereum-sepolia-rpc.publicnode.com';
+const OPERATOR_PK = process.env.OPERATOR_PRIVATE_KEY;
+const ERC20_ADDRESS = process.env.ERC20_TOKEN_ADDRESS ?? '0x16C188C6966D6Fc2999b2cF9D5267D517045F65B';
+
+const ERC20_ABI = [
+  'function approve(address spender, uint256 value) returns (bool)',
+  'function allowance(address owner, address spender) view returns (uint256)',
+  'function balanceOf(address) view returns (uint256)',
+  'function decimals() view returns (uint8)',
+];
+
+/** Test-only wrapper: exposes the protected safeExecuteTransaction. */
+class TestableManager extends ContractsManager {
+  async safeExecute<C extends BaseContract>(
+    contract: C,
+    call: (c: C, overrides: PayableOverrides) => Promise<ContractTransactionResponse>,
+    maxAttempts: number = 10,
+  ): Promise<ContractTransactionReceipt> {
+    return (this as any).safeExecuteTransaction(contract, call, maxAttempts);
+  }
+}
+
+const logger = winston.createLogger({
+  level: process.env.LOG_LEVEL ?? 'info',
+  transports: [new winston.transports.Console({ format: winston.format.simple() })],
+}) as any;
+
+(OPERATOR_PK ? describe : describe.skip)('safeExecuteTransaction nonce recovery — Sepolia', () => {
+  let provider: JsonRpcProvider;
+  let operatorAddress: string;
+
+  beforeAll(async () => {
+    provider = new JsonRpcProvider(SEPOLIA_RPC);
+    operatorAddress = new Wallet(OPERATOR_PK!).address;
+    const balance = await provider.getBalance(operatorAddress);
+    logger.info(`operator=${operatorAddress} balance=${balance.toString()} wei nonce(latest)=${await provider.getTransactionCount(operatorAddress, 'latest')}`);
+  });
+
+  it('captures the raw error shape ethers v6 emits on a stale-nonce submit (no wrapper)', async () => {
+    // Step 1: send & confirm an ERC20.approve from a fresh signer. The on-chain
+    // nonce now sits at N+1.
+    const wallet = new Wallet(OPERATOR_PK!).connect(provider);
+    const startingNonce = await provider.getTransactionCount(operatorAddress, 'latest');
+    const factory = new ContractFactory(ERC20_ABI, '0x', wallet);
+    const erc20 = factory.attach(ERC20_ADDRESS) as BaseContract & {
+      approve(spender: string, value: bigint, overrides?: PayableOverrides): Promise<ContractTransactionResponse>;
+    };
+    logger.info(`landing tx_A at nonce=${startingNonce}…`);
+    const tx1 = await erc20.approve(operatorAddress, 0n, { nonce: startingNonce });
+    await tx1.wait();
+    const onchainAfter = await provider.getTransactionCount(operatorAddress, 'latest');
+    expect(onchainAfter).toBe(startingNonce + 1);
+    logger.info(`tx_A confirmed; on-chain nonce now ${onchainAfter}`);
+
+    // Step 2: deliberately submit a *stale-nonce* tx (the just-used N).
+    let losingError: any = undefined;
+    try {
+      const tx2 = await erc20.approve(operatorAddress, 0n, { nonce: startingNonce });
+      await tx2.wait();
+    } catch (e) {
+      losingError = e;
+    }
+    expect(losingError).toBeDefined();
+
+    // Diagnostic dump — what we care about for detectError matching.
+    logger.info(`stale-nonce error code=${losingError?.code}`);
+    logger.info(`stale-nonce error shortMessage=${losingError?.shortMessage}`);
+    logger.info(`stale-nonce error info=${JSON.stringify(losingError?.info)}`);
+    logger.info(`stale-nonce error e.error=${JSON.stringify(losingError?.error)}`);
+    logger.info(`stale-nonce error message=${losingError?.message}`);
+
+    // detectError currently matches via:
+    //   • code === 'REPLACEMENT_UNDERPRICED' OR
+    //   • String(e).includes("nonce has already been used") OR
+    //   • e.error.code === -32000           (v5 inner-error shape)
+    //   • e.error.message.startsWith('Nonce too high')  (v5 inner-error shape)
+    const checks = {
+      codeReplacementUnderpriced: losingError?.code === 'REPLACEMENT_UNDERPRICED',
+      codeNonceExpired: losingError?.code === 'NONCE_EXPIRED',
+      stringIncludesAlreadyUsed: String(losingError).includes('nonce has already been used'),
+      v5InnerErrorCodeMinus32000: losingError?.error?.code === -32000,
+      v5InnerErrorStartsWithNonceTooHigh: typeof losingError?.error?.message === 'string'
+        && losingError.error.message.startsWith('Nonce too high'),
+      v6InfoErrorCodeMinus32000: losingError?.info?.error?.code === -32000,
+      v6InfoErrorMessage: losingError?.info?.error?.message,
+    };
+    logger.info(`detectError branch hits: ${JSON.stringify(checks)}`);
+  });
+
+  it('exercises safeExecuteTransaction end-to-end with two managers sharing a key', async () => {
+    // Two NonceManagers wrapping the same operator key. Both prime their cache;
+    // A submits successfully (nonce N → N+1); B's cache is now stale at N. We
+    // then ask manager B to submit through the wrapper — the wrapper should see
+    // the nonce conflict, reset B, retry at N+1, and succeed.
+    const signerA = new NonceManager(new Wallet(OPERATOR_PK!)).connect(provider);
+    const signerB = new NonceManager(new Wallet(OPERATOR_PK!)).connect(provider);
+    const managerA = new TestableManager(provider, signerA, logger);
+    const managerB = new TestableManager(provider, signerB, logger);
+
+    const cachedA = await signerA.getNonce();
+    const cachedB = await signerB.getNonce();
+    expect(cachedA).toBe(cachedB);
+    logger.info(`primed both signers at nonce=${cachedA}`);
+
+    const factoryA = new ContractFactory(ERC20_ABI, '0x', signerA);
+    const factoryB = new ContractFactory(ERC20_ABI, '0x', signerB);
+    const erc20A = factoryA.attach(ERC20_ADDRESS) as BaseContract & {
+      approve(spender: string, value: bigint, overrides?: PayableOverrides): Promise<ContractTransactionResponse>;
+    };
+    const erc20B = factoryB.attach(ERC20_ADDRESS) as BaseContract & {
+      approve(spender: string, value: bigint, overrides?: PayableOverrides): Promise<ContractTransactionResponse>;
+    };
+
+    logger.info(`A submitting via wrapper…`);
+    await managerA.safeExecute(erc20A, async (c, txParams) =>
+      c.approve(operatorAddress, 0n, txParams));
+    const onchainAfterA = await provider.getTransactionCount(operatorAddress, 'latest');
+    expect(onchainAfterA).toBe(cachedA + 1);
+    logger.info(`A landed; on-chain nonce=${onchainAfterA}; B.cache=${cachedB} (stale)`);
+
+    // B's local cache is still cachedB (= cachedA), stale by 1. Wrapper must
+    // detect-and-recover.
+    let bRecovered = true;
+    let bError: any = undefined;
+    try {
+      await managerB.safeExecute(erc20B, async (c, txParams) =>
+        c.approve(operatorAddress, 0n, txParams));
+    } catch (e) {
+      bRecovered = false;
+      bError = e;
+    }
+
+    if (!bRecovered) {
+      logger.error(`B did NOT recover — wrapper fell through.`);
+      logger.error(`error code=${bError?.code}`);
+      logger.error(`error shortMessage=${bError?.shortMessage}`);
+      logger.error(`error info=${JSON.stringify(bError?.info)}`);
+      logger.error(`error message=${bError?.message}`);
+    }
+
+    expect(bRecovered).toBe(true);
+    const onchainAfterB = await provider.getTransactionCount(operatorAddress, 'latest');
+    expect(onchainAfterB).toBe(cachedA + 2);
+  });
+});


### PR DESCRIPTION
## Summary

Cherry-pick of #244 to release/v0.28.

Patches \`detectError\` in \`finp2p-contracts/src/errors.ts\` to recognize the ethers v6 inner-error shape (\`e.info.error.code\` / \`e.info.error.message\`), so the \`safeExecuteTransaction\` wrapper in \`manager.ts\` continues to auto-recover from nonce conflicts under ethers v6.

After review feedback: tightened the \`NonceTooHighError\` match to require the explicit \`"Nonce too high"\` message prefix (no bare \`-32000\` match), so non-nonce RPC failures (insufficient funds, execution reverted) bubble up immediately instead of triggering a 10× retry loop.

## Verification

- Adds 13 unit tests in \`finp2p-contracts/test/errors.ts\` covering v5 + v6 shapes for both nonce-too-low and nonce-too-high, plus explicit false-positive guards for \`-32000\` + unrelated messages.
- Adds a Sepolia diagnostic test (\`tests/nonce-recovery-sepolia.test.ts\`) exercising the wrapper end-to-end.
- All 142 hardhat tests pass (129 existing + 13 new).

## Test plan

- [ ] CI green
- [ ] Tag \`finp2p-contracts-v0.28.11\` after merge to publish the bumped package
- [ ] Follow-up: bump the adapter's \`@owneraio/finp2p-contracts\` dep to \`^0.28.11\` + lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)