### PR TITLE
Bump @owneraio/finp2p-contracts 0.28.10 → 0.28.11 (cherry-pick #246)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
-        "@owneraio/finp2p-contracts": "^0.28.10",
+        "@owneraio/finp2p-contracts": "^0.28.11",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",
@@ -1707,9 +1707,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.10",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.10/82f10fe5f53642e53dbdfdd7fa585a105a185485",
-      "integrity": "sha512-DT5i+TYecRj6cK4Cc/pjFg8IbmJzOdzXvpaqEAR6CXlLakrutnc5fczwASOe+eKvNCJoVq0njWw9SK1FyeR+tg==",
+      "version": "0.28.11",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.11/7dffe24c7c4b59ec6c1f8ddfb74246e44eede8b3",
+      "integrity": "sha512-39tsG1TqOrq+qd/4klGCslvf87OrPo1cKjaoKKlCi+OATcMoprW1MteVlvjwj7hucjBjKrH9+RWUBAoTuK/sUQ==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "0.28.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
-    "@owneraio/finp2p-contracts": "^0.28.10",
+    "@owneraio/finp2p-contracts": "^0.28.11",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",


### PR DESCRIPTION
## Summary

Cherry-pick of #246 to release/v0.28.

Picks up the widened \`detectError\` nonce detection from #244 / #245 (matches ethers v6 \`e.info.error.*\` inner shape; drops bare \`-32000\` catch-all so non-nonce RPC failures bubble up immediately).

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)