### PR TITLE
Bump adapter version 0.28.1 → 0.28.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-ethereum-adapter",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "hasInstallScript": true,
       "license": "TBD",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "",
   "main": "dist/src/index.js",
   "homepage": "https://ownera.io/",


### PR DESCRIPTION
## Summary

Version bump for the next release on \`release/v0.28\`.

## Changes since 0.28.1
- #241 / #242 — drop local \`widen_token_standard\` migration (skeleton owns it now)
- #244 / #245 — \`finp2p-contracts\`: widen \`detectError\` for ethers v6 inner-error shape; tighten \`Nonce too high\` match to drop the bare \`-32000\` false-positive
- #246 / #247 — bump \`@owneraio/finp2p-contracts\` dep \`0.28.10\` → \`0.28.11\` to pick up the above

## After merge
Tag \`adapter-v0.28.2\` on the merge commit → \`publish-adapter.yml\` workflow publishes the package and Docker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)