### PR TITLE
finp2p-contract createAsset: emit CAIP-2 network (eip155:<chainId>)

### DIFF
--- a/src/services/finp2p-contract/tokens.ts
+++ b/src/services/finp2p-contract/tokens.ts
@@ -60,8 +60,10 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
 
     // TODO: parse assetMetadata to determine token standard and other details
 
-    const { chainId, name } = await this.finP2PContract.provider.getNetwork();
-    const network = `name: ${name}, chainId: ${chainId}`; // public or private network?
+    const { chainId } = await this.finP2PContract.provider.getNetwork();
+    // CAIP-2 / EIP-155 form, matching what direct-mode (DirectTokenService /
+    // OmnibusDelegate) emits and what CAIP-19 expects in the network slot.
+    const network = `eip155:${chainId}`;
     const finP2POperatorContractAddress = this.finP2PContract.finP2PContractAddress;
     const result: AssetCreationResult = {
       ledgerIdentifier: { assetIdentifierType: 'CAIP-19', network, tokenId: tokenAddress, standard: 'ERC20' },


### PR DESCRIPTION
## Summary

Aligns the asset-creation response from finp2p-contract mode with direct mode and the CAIP-2 spec.

## Before

[src/services/finp2p-contract/tokens.ts:63-64](https://github.com/owneraio/finp2p-ethereum-adapter/blob/master/src/services/finp2p-contract/tokens.ts#L63-L64) (master):

\`\`\`ts
const { chainId, name } = await this.finP2PContract.provider.getNetwork();
const network = \`name: \${name}, chainId: \${chainId}\`; // public or private network?
\`\`\`

Asset's \`ledgerIdentifier.network\` ends up looking like:
\`\`\`
"network": "name: sepolia, chainId: 11155111"
\`\`\`
…but \`assetIdentifierType\` is \`CAIP-19\`, which expects a CAIP-2 namespace in the network slot. The custom string isn't parseable by anything that strictly handles CAIP-2.

## After

\`\`\`ts
const { chainId } = await this.finP2PContract.provider.getNetwork();
const network = \`eip155:\${chainId}\`;
\`\`\`

Output:
\`\`\`
"network": "eip155:11155111"
\`\`\`

## Why

Direct mode ([\`DirectTokenService.createAsset\`](src/services/direct/token-service.ts#L90-L91), [\`OmnibusDelegate.createAsset\`](src/services/direct/omnibus-delegate.ts#L313-L314)) already emits \`eip155:<chainId>\`. Same adapter, two modes, two formats — anything downstream that filters/groups by network had to handle both. With the fix, both modes carry the same CAIP-2 form.

## Risk / breaking change

Downstream consumers that hard-code the legacy \`name: ..., chainId: ...\` string parsing will see the new format after this lands. Direct-mode deployments already see the CAIP-2 form, so any consumer that's been working with both has been parsing both already. New deployments / freshly-created assets will use the new format; existing on-FinAPI assets are unaffected (the network field is set at creation time and persisted as-is).

## Verification

- All 16 omnibus-delegate unit tests pass
- All 14 account-mapping unit tests pass
- Type-check clean
- No other call sites construct the legacy format (grep was clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)