### PR TITLE
Bump @owneraio/finp2p-contracts 0.28.11 → 0.28.12 + TX_CONFIRMATION_TIMEOUT_MS env

### DIFF
--- a/finp2p-contracts/test/nonce-recovery.ts
+++ b/finp2p-contracts/test/nonce-recovery.ts
@@ -1,0 +1,105 @@
+import { expect } from "chai";
+// @ts-ignore
+import { ethers } from "hardhat";
+import { NonceManager, Wallet } from "ethers";
+import { ContractsManager } from "../src/manager";
+import { Logger } from "../src/adapter-types";
+
+/**
+ * Hardhat-network unit test for the safeExecuteTransaction nonce-recovery
+ * mechanism in `manager.ts`. Mirrors the real-Sepolia diagnostic in
+ * `tests/nonce-recovery-sepolia.test.ts` but runs in-memory so it stays
+ * cheap, deterministic, and CI-friendly.
+ *
+ * Scenario: two NonceManager instances wrap the same operator key; both
+ * prime their internal caches (cachedNonce = N); A submits a tx → A.cache
+ * = N+1, on-chain = N+1, B.cache stale at N. B then submits via the
+ * wrapper — first attempt fails on a nonce-already-used type error;
+ * detectError categorizes it; the wrapper calls `NonceManager.reset()`
+ * on B and retries; second attempt succeeds.
+ *
+ * Assertions:
+ *   • B's call returns a successful receipt (no throw).
+ *   • On-chain nonce moved by exactly 2 (one from A, one from the
+ *     successfully-retried B).
+ */
+
+// Hardhat default account 0 — the deployer / DEFAULT_ADMIN_ROLE holder
+// on freshly-deployed FINP2POperator instances.
+const HARDHAT_DEFAULT_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+// Silent logger so test output stays focused on assertions.
+const silentLogger: Logger = {
+  info: () => {},
+  debug: () => {},
+  warning: () => {},
+  error: () => {},
+} as unknown as Logger;
+
+describe("safeExecuteTransaction nonce recovery (hardhat)", function () {
+
+  it("two managers sharing a key: wrapper detects+resets+retries on stale nonce, B succeeds", async () => {
+    const provider = ethers.provider;
+
+    // Deploy a FINP2POperator the operator key has admin role on, so
+    // grantAssetManagerRole (the public method we use as a "go through
+    // safeExecuteTransaction" probe) is callable. The operator key
+    // matches hardhat account 0 → the deployer → DEFAULT_ADMIN_ROLE.
+    const factory = await ethers.getContractFactory("FINP2POperator");
+    const operatorAddress = new Wallet(HARDHAT_DEFAULT_KEY).address;
+    const finP2P = await factory.deploy(operatorAddress);
+    const finP2PAddress = await finP2P.getAddress();
+
+    // Two NonceManager instances, same operator key.
+    const signerA = new NonceManager(new Wallet(HARDHAT_DEFAULT_KEY)).connect(provider);
+    const signerB = new NonceManager(new Wallet(HARDHAT_DEFAULT_KEY)).connect(provider);
+    const managerA = new ContractsManager(provider, signerA, silentLogger);
+    const managerB = new ContractsManager(provider, signerB, silentLogger);
+
+    // Both prime their nonce caches against on-chain state.
+    const cachedA = await signerA.getNonce();
+    const cachedB = await signerB.getNonce();
+    expect(cachedA).to.equal(cachedB);
+
+    const startingOnchain = await provider.getTransactionCount(operatorAddress, "latest");
+
+    // A submits via the wrapper — chain nonce moves from N to N+1, A.cache to N+1.
+    await managerA.grantAssetManagerRole(finP2PAddress, operatorAddress);
+    const onchainAfterA = await provider.getTransactionCount(operatorAddress, "latest");
+    expect(onchainAfterA).to.equal(startingOnchain + 1);
+
+    // B's cache is still at N (stale). Submit through the wrapper.
+    // First attempt MUST fail with a nonce-already-used type error;
+    // safeExecuteTransaction must detect, reset B, retry, and succeed.
+    let bError: any = undefined;
+    try {
+      await managerB.grantAssetManagerRole(finP2PAddress, operatorAddress);
+    } catch (e) {
+      bError = e;
+    }
+    expect(bError, `wrapper should have recovered, got ${bError?.message ?? bError}`).to.be.undefined;
+
+    const onchainAfterB = await provider.getTransactionCount(operatorAddress, "latest");
+    expect(onchainAfterB).to.equal(startingOnchain + 2);
+  });
+
+  it("when only one manager is in play: nonce conflict cannot occur — sanity baseline", async () => {
+    // Sanity: a single manager's wrapped call moves the chain nonce by 1
+    // every time. Confirms the test's "starting state" assumptions are
+    // correct and the fixture isn't already broken.
+    const provider = ethers.provider;
+    const factory = await ethers.getContractFactory("FINP2POperator");
+    const operatorAddress = new Wallet(HARDHAT_DEFAULT_KEY).address;
+    const finP2P = await factory.deploy(operatorAddress);
+    const finP2PAddress = await finP2P.getAddress();
+
+    const signer = new NonceManager(new Wallet(HARDHAT_DEFAULT_KEY)).connect(provider);
+    const manager = new ContractsManager(provider, signer, silentLogger);
+
+    const start = await provider.getTransactionCount(operatorAddress, "latest");
+    await manager.grantAssetManagerRole(finP2PAddress, operatorAddress);
+    await manager.grantTransactionManagerRole(finP2PAddress, operatorAddress);
+    const end = await provider.getTransactionCount(operatorAddress, "latest");
+    expect(end - start).to.equal(2);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.28.1",
+  "version": "0.28.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-ethereum-adapter",
-      "version": "0.28.1",
+      "version": "0.28.3",
       "hasInstallScript": true,
       "license": "TBD",
       "dependencies": {
@@ -15,7 +15,7 @@
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
-        "@owneraio/finp2p-contracts": "^0.28.11",
+        "@owneraio/finp2p-contracts": "^0.28.12",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",
@@ -1707,9 +1707,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.11",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.11/7dffe24c7c4b59ec6c1f8ddfb74246e44eede8b3",
-      "integrity": "sha512-39tsG1TqOrq+qd/4klGCslvf87OrPo1cKjaoKKlCi+OATcMoprW1MteVlvjwj7hucjBjKrH9+RWUBAoTuK/sUQ==",
+      "version": "0.28.12",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.12/2c091a46adf85df7e4cedf5e74cbd43f6b3dad7f",
+      "integrity": "sha512-Y7qaVDryYTCJ1LmA7gECSJaVt+Q/zNTa2yZdy4qGN9diBf0g5YN2q1wB/VEex5QXMJJJH2L+Jnux0FxwwuMuWQ==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.28.1",
+  "version": "0.28.3",
   "description": "",
   "main": "dist/src/index.js",
   "homepage": "https://ownera.io/",
@@ -44,7 +44,7 @@
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
-    "@owneraio/finp2p-contracts": "^0.28.11",
+    "@owneraio/finp2p-contracts": "^0.28.12",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,11 +143,21 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
 
       const { provider, signer } = createJsonProvider(operatorPrivateKey, ethereumRPCUrl, useNonceManager)
 
+      // Per-attempt confirmation timeout for safeExecuteTransaction's
+      // response.wait(); defaults to 10 min in finp2p-contracts. Operator can
+      // raise/lower for slower / faster networks.
+      const txConfirmationTimeoutMsRaw = process.env.TX_CONFIRMATION_TIMEOUT_MS;
+      const txConfirmationTimeoutMs = txConfirmationTimeoutMsRaw ? Number(txConfirmationTimeoutMsRaw) : undefined;
+      if (txConfirmationTimeoutMsRaw && Number.isNaN(txConfirmationTimeoutMs!)) {
+        throw new Error(`Invalid TX_CONFIRMATION_TIMEOUT_MS: ${txConfirmationTimeoutMsRaw}`);
+      }
+
       const finP2PContract = new FinP2PContract(
         provider,
         signer,
         finP2PContractAddress,
-        logger
+        logger,
+        txConfirmationTimeoutMs,
       );
       const finP2PClient = new FinP2PClient(finP2PUrl, ossUrl);
       const execDetailsStore = new InMemoryExecDetailsStore();


### PR DESCRIPTION
## Summary

Picks up the configurable per-attempt confirmation timeout from #253 and wires the env knob.

## Changes

- \`@owneraio/finp2p-contracts\` dep \`^0.28.11\` → \`^0.28.12\` + lockfile.
- \`src/config.ts\` reads \`TX_CONFIRMATION_TIMEOUT_MS\` and passes it as the new 5th arg to the \`FinP2PContract\` constructor. Absent env keeps the package default (10 min, was 60 s in 0.28.11). Non-numeric env value fails fast at boot.
- Adapter version \`0.28.1\` → \`0.28.3\` (skipping 0.28.2 which exists only on \`release/v0.28\` with different content; cherry-pick to release will bump there to 0.28.3 too).

## Why

Issue #251 — the hardcoded 60 s wait was too short for slower / congested networks (Sepolia, Hashio), causing the adapter to declare FAILED on transactions that often did confirm a moment later. Picks up the configurable knob from #253; lets operators tune per-deployment via env.

## Verification

- Type-check + build clean.
- 16 omnibus + 14 account-mapping unit tests pass.
- Verified the published 0.28.12 actually contains \`DEFAULT_CONFIRMATION_TIMEOUT_MS = 600_000\` and the new ctor signature.

## After merge

Cherry-pick to \`release/v0.28\`; tag \`v0.28.3\` from the merged release commit + create the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)