### PR TITLE
finp2p-contracts: add configurable EIP-1559 gas tier (slow/normal/fast)

### DIFF
--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.12",
+  "version": "0.28.13",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-contracts/src/erc20.ts
+++ b/finp2p-contracts/src/erc20.ts
@@ -1,4 +1,4 @@
-import { ContractsManager } from "./manager";
+import { ContractsManager, GasTier } from "./manager";
 import { Logger } from "./adapter-types";
 import { BigNumberish, ContractFactory, Interface, keccak256, Provider, Signer, toUtf8Bytes } from "ethers";
 import { ERC20WithOperator } from "../typechain-types";
@@ -15,8 +15,8 @@ export class ERC20Contract extends ContractsManager {
 
   tokenAddress: string;
 
-  constructor(provider: Provider, signer: Signer, tokenAddress: string, logger: Logger, confirmationTimeoutMs?: number) {
-    super(provider, signer, logger, confirmationTimeoutMs);
+  constructor(provider: Provider, signer: Signer, tokenAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier) {
+    super(provider, signer, logger, confirmationTimeoutMs, gasTier);
     this.tokenAddress = tokenAddress;
     const factory = new ContractFactory<any[], ERC20WithOperator>(
       ERC20.abi, ERC20.bytecode, this.signer

--- a/finp2p-contracts/src/finp2p.ts
+++ b/finp2p-contracts/src/finp2p.ts
@@ -9,7 +9,7 @@ import {
   Term
 } from "./model";
 import { parseTransactionReceipt } from "./utils";
-import { ContractsManager } from "./manager";
+import { ContractsManager, GasTier } from "./manager";
 import {
   EIP712Domain, EIP712LoanTerms, PrimaryType, ReceiptOperation,
   failedReceiptOperation, pendingReceiptOperation,
@@ -28,8 +28,8 @@ export class FinP2PContract extends ContractsManager {
 
   finP2PContractAddress: string;
 
-  constructor(provider: Provider, signer: Signer, finP2PContractAddress: string, logger: Logger, confirmationTimeoutMs?: number) {
-    super(provider, signer, logger, confirmationTimeoutMs);
+  constructor(provider: Provider, signer: Signer, finP2PContractAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier) {
+    super(provider, signer, logger, confirmationTimeoutMs, gasTier);
     const factory = new ContractFactory<any[], FINP2POperator>(
       FINP2P.abi, FINP2P.bytecode, this.signer
     );

--- a/finp2p-contracts/src/manager.ts
+++ b/finp2p-contracts/src/manager.ts
@@ -32,17 +32,55 @@ const DefaultDecimalsCurrencies = 2;
  */
 export const DEFAULT_CONFIRMATION_TIMEOUT_MS = 600_000;
 
+/**
+ * EIP-1559 inclusion-speed tier. Multiplies the node's `getFeeData()`
+ * `maxPriorityFeePerGas` (and `maxFeePerGas` to preserve baseFee headroom)
+ * to position the tx in the validator's priority queue.
+ *
+ *   • slow   — 0.75× node default. Underbid; OK when fees matter more than
+ *              inclusion latency.
+ *   • normal — 1.0× (no overrides applied, ethers' built-in default flows
+ *              through). Backwards-compatible behavior — same as before
+ *              this option existed.
+ *   • fast   — 1.5× node default. Push tx near the front of the mempool
+ *              priority queue when the chain is congested (e.g. Sepolia
+ *              under load).
+ *
+ * The multipliers apply ON TOP of the node estimate, so if the chain is
+ * already busy and the node returns elevated values, "fast" stays elevated
+ * relative to that. Chains without a public mempool (Hashio / Hedera EVM
+ * testnets) get no speedup — the validator orders txs by consensus, not
+ * by tip — so the tier is a no-op there in practice.
+ */
+export type GasTier = 'slow' | 'normal' | 'fast';
+
+const GAS_TIER_MULTIPLIER_BASIS_POINTS: Record<GasTier, number> = {
+  slow: 750,
+  normal: 1000,
+  fast: 1500,
+};
+
+export const DEFAULT_GAS_TIER: GasTier = 'normal';
+
 export class ContractsManager {
   provider: Provider;
   signer: Signer;
   logger: Logger;
   confirmationTimeoutMs: number;
+  gasTier: GasTier;
 
-  constructor(provider: Provider, signer: Signer, logger: Logger, confirmationTimeoutMs: number = DEFAULT_CONFIRMATION_TIMEOUT_MS) {
+  constructor(
+    provider: Provider,
+    signer: Signer,
+    logger: Logger,
+    confirmationTimeoutMs: number = DEFAULT_CONFIRMATION_TIMEOUT_MS,
+    gasTier: GasTier = DEFAULT_GAS_TIER,
+  ) {
     this.provider = provider;
     this.signer = signer;
     this.logger = logger;
     this.confirmationTimeoutMs = confirmationTimeoutMs;
+    this.gasTier = gasTier;
     if (this.signer instanceof NonceManager) {
       this.signer.getNonce().then((nonce) => {
         this.logger.info(`Using nonce-manager, current nonce: ${nonce}`);
@@ -187,7 +225,8 @@ export class ContractsManager {
         } else {
           nonce = await this.getLatestTransactionCount();
         }
-        const response = await call(contract, { nonce })
+        const overrides = await this.buildTxOverrides(nonce);
+        const response = await call(contract, overrides)
         const receipt = await response.wait(undefined, this.confirmationTimeoutMs) // wait for 1 confirmation
         if (receipt !== null) {
           return receipt
@@ -221,5 +260,32 @@ export class ContractsManager {
     if (this.signer instanceof NonceManager) {
       (this.signer as NonceManager).reset();
     }
+  }
+
+  /**
+   * Build the per-attempt tx overrides for `safeExecuteTransaction`.
+   *
+   * Always sets `nonce`. For tiers other than `normal`, also computes
+   * `maxPriorityFeePerGas` and `maxFeePerGas` by scaling the node's
+   * `getFeeData()` estimate. `normal` leaves the gas fields unset so
+   * ethers' default path (which itself queries `getFeeData()`) flows
+   * through — preserves the pre-tier behavior exactly.
+   *
+   * Non-EIP-1559 chains (no `maxPriorityFeePerGas` in feeData) fall back
+   * to the bare `{ nonce }` overrides — same as ethers' default would do.
+   */
+  protected async buildTxOverrides(nonce: number): Promise<PayableOverrides> {
+    if (this.gasTier === 'normal') {
+      return { nonce };
+    }
+    const feeData = await this.provider.getFeeData();
+    if (feeData.maxPriorityFeePerGas == null || feeData.maxFeePerGas == null) {
+      // Pre-EIP-1559 chain (legacy gas only). Tier has no meaning here.
+      return { nonce };
+    }
+    const basisPoints = BigInt(GAS_TIER_MULTIPLIER_BASIS_POINTS[this.gasTier]);
+    const maxPriorityFeePerGas = (feeData.maxPriorityFeePerGas * basisPoints) / 1000n;
+    const maxFeePerGas = (feeData.maxFeePerGas * basisPoints) / 1000n;
+    return { nonce, maxPriorityFeePerGas, maxFeePerGas };
   }
 }

--- a/finp2p-contracts/test/gas-tier.ts
+++ b/finp2p-contracts/test/gas-tier.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+// @ts-ignore
+import { ethers } from "hardhat";
+import { NonceManager, Wallet } from "ethers";
+import { ContractsManager, GasTier } from "../src/manager";
+import { Logger } from "../src/adapter-types";
+
+/**
+ * Hardhat-network unit test for the EIP-1559 gas-tier mechanism in
+ * `safeExecuteTransaction`. Confirms:
+ *
+ *   • `normal` (default) leaves gas fields unset → ethers' built-in
+ *     default flows through unchanged.
+ *   • `fast` scales maxPriorityFeePerGas and maxFeePerGas by 1.5×
+ *     vs the node's getFeeData() estimate.
+ *   • `slow` scales them by 0.75×.
+ *
+ * We capture the actual override values passed into the call by
+ * wrapping the public `grantAssetManagerRole` method's underlying
+ * safeExecuteTransaction via a minimal test subclass.
+ */
+
+const HARDHAT_DEFAULT_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+const silentLogger: Logger = {
+  info: () => {},
+  debug: () => {},
+  warning: () => {},
+  error: () => {},
+} as unknown as Logger;
+
+describe("safeExecuteTransaction gas-tier overrides (hardhat)", function () {
+
+  async function setupManager(gasTier: GasTier | undefined) {
+    const provider = ethers.provider;
+    const signer = new NonceManager(new Wallet(HARDHAT_DEFAULT_KEY)).connect(provider);
+    const manager = new ContractsManager(provider, signer, silentLogger, undefined, gasTier);
+    return { provider, signer, manager };
+  }
+
+  it("normal tier (default): leaves maxPriorityFeePerGas / maxFeePerGas unset", async () => {
+    const { manager } = await setupManager(undefined); // default tier = 'normal'
+    const overrides = await (manager as any).buildTxOverrides(0);
+    expect(overrides.nonce).to.equal(0);
+    expect(overrides.maxPriorityFeePerGas).to.be.undefined;
+    expect(overrides.maxFeePerGas).to.be.undefined;
+  });
+
+  it("fast tier: scales gas fields by 1.5x of node feeData", async () => {
+    const { provider, manager } = await setupManager('fast');
+    const feeData = await provider.getFeeData();
+    if (feeData.maxPriorityFeePerGas == null || feeData.maxFeePerGas == null) {
+      // Hardhat may not return EIP-1559 fields on some configs — skip.
+      this.skip?.();
+      return;
+    }
+    const overrides = await (manager as any).buildTxOverrides(7);
+    expect(overrides.nonce).to.equal(7);
+    const expectedPriority = (feeData.maxPriorityFeePerGas * 1500n) / 1000n;
+    const expectedMax = (feeData.maxFeePerGas * 1500n) / 1000n;
+    expect(overrides.maxPriorityFeePerGas).to.equal(expectedPriority);
+    expect(overrides.maxFeePerGas).to.equal(expectedMax);
+  });
+
+  it("slow tier: scales gas fields by 0.75x of node feeData", async () => {
+    const { provider, manager } = await setupManager('slow');
+    const feeData = await provider.getFeeData();
+    if (feeData.maxPriorityFeePerGas == null || feeData.maxFeePerGas == null) {
+      this.skip?.();
+      return;
+    }
+    const overrides = await (manager as any).buildTxOverrides(3);
+    expect(overrides.nonce).to.equal(3);
+    const expectedPriority = (feeData.maxPriorityFeePerGas * 750n) / 1000n;
+    const expectedMax = (feeData.maxFeePerGas * 750n) / 1000n;
+    expect(overrides.maxPriorityFeePerGas).to.equal(expectedPriority);
+    expect(overrides.maxFeePerGas).to.equal(expectedMax);
+  });
+
+  it("fast tier end-to-end: a wrapped grantAssetManagerRole tx confirms with our overrides", async () => {
+    // Sanity: with fast tier active, the wrapper still produces a healthy receipt
+    // (i.e. the override values we generate are valid and accepted on-chain).
+    const { provider, manager } = await setupManager('fast');
+    const factory = await ethers.getContractFactory("FINP2POperator");
+    const operatorAddress = new Wallet(HARDHAT_DEFAULT_KEY).address;
+    const finP2P = await factory.deploy(operatorAddress);
+    const finP2PAddress = await finP2P.getAddress();
+
+    const startingNonce = await provider.getTransactionCount(operatorAddress, "latest");
+    await manager.grantAssetManagerRole(finP2PAddress, operatorAddress);
+    const endingNonce = await provider.getTransactionCount(operatorAddress, "latest");
+    expect(endingNonce - startingNonce).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a \`GasTier\` ctor option to \`ContractsManager\` that scales the EIP-1559 priority and max fees applied per tx in \`safeExecuteTransaction\`. Goal: let operators speed up txs on congested networks (Sepolia under load) without per-chain tuning of raw gwei values.

## Tiers

Applied as multipliers on the node's \`provider.getFeeData()\` estimate, per attempt:

| Tier   | Multiplier | When to use |
|--------|------------|-------------|
| slow   | 0.75×      | Fees matter more than inclusion latency |
| **normal** (default) | 1.0× (no overrides; ethers default flows through) | Backwards-compatible |
| fast   | 1.5×       | Push to the front of the priority queue when chain is hot |

The multipliers are applied **on top of** the node estimate — so if the chain is already busy and the node returns elevated values, \"fast\" stays elevated relative to that. Pre-EIP-1559 chains and chains without a public mempool (Hashio / Hedera EVM) fall through to bare \`{ nonce }\` overrides (same as ethers' built-in default, no speedup).

## Changes

- \`ContractsManager\` ctor adds optional 5th arg \`gasTier\` (default \`normal\`).
- New \`buildTxOverrides(nonce)\` helper inside \`safeExecuteTransaction\` builds the per-attempt overrides.
- Subclasses \`FinP2PContract\` / \`ERC20Contract\` pass the new arg through.
- Bumps finp2p-contracts to 0.28.13.
- 4 hardhat tests:
  - normal tier doesn't set gas fields
  - fast tier scales by 1.5×
  - slow tier scales by 0.75×
  - end-to-end fast tier tx confirms

## Verification

- Adapter type-check clean.
- 144 → 148 hardhat tests passing (added 4).
- Backwards-compatible: default tier is \`normal\` which produces the exact same \`{ nonce }\` overrides as before.

## After merge

Tag \`finp2p-contracts-v0.28.13\` to publish; follow-up small PR adds \`TX_GAS_TIER\` env wiring in the adapter's \`config.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)