### PR TITLE
Bump @owneraio/finp2p-contracts 0.28.12 → 0.28.13 + TX_GAS_TIER env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owneraio/finp2p-ethereum-adapter",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "hasInstallScript": true,
       "license": "TBD",
       "dependencies": {
@@ -15,7 +15,7 @@
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
-        "@owneraio/finp2p-contracts": "^0.28.12",
+        "@owneraio/finp2p-contracts": "^0.28.13",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",
@@ -1707,9 +1707,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.12",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.12/2c091a46adf85df7e4cedf5e74cbd43f6b3dad7f",
-      "integrity": "sha512-Y7qaVDryYTCJ1LmA7gECSJaVt+Q/zNTa2yZdy4qGN9diBf0g5YN2q1wB/VEex5QXMJJJH2L+Jnux0FxwwuMuWQ==",
+      "version": "0.28.13",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.13/62ee0053114891c762c3b6b7a38caefb1b798494",
+      "integrity": "sha512-CYxfvvouEApCNrLukY574dax5bHhEp/IgceMJJegzjUyQq71dEiSJwXHdCBGDOjDq7D/0kC3OC+NhvEJkS+t8w==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "",
   "main": "dist/src/index.js",
   "homepage": "https://ownera.io/",
@@ -44,7 +44,7 @@
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
-    "@owneraio/finp2p-contracts": "^0.28.12",
+    "@owneraio/finp2p-contracts": "^0.28.13",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.16",

--- a/src/config.ts
+++ b/src/config.ts
@@ -152,12 +152,24 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
         throw new Error(`Invalid TX_CONFIRMATION_TIMEOUT_MS: ${txConfirmationTimeoutMsRaw}`);
       }
 
+      // EIP-1559 gas tier — slow|normal|fast — scales the node's feeData
+      // priority/max fees per tx to position in the validator's priority queue.
+      // Defaults to `normal` in finp2p-contracts (no overrides, pre-tier behavior).
+      const txGasTierRaw = process.env.TX_GAS_TIER?.toLowerCase();
+      const validTiers = ['slow', 'normal', 'fast'] as const;
+      type GasTier = (typeof validTiers)[number];
+      if (txGasTierRaw && !(validTiers as readonly string[]).includes(txGasTierRaw)) {
+        throw new Error(`Invalid TX_GAS_TIER: ${process.env.TX_GAS_TIER}. Supported: ${validTiers.join(', ')}`);
+      }
+      const txGasTier = txGasTierRaw as GasTier | undefined;
+
       const finP2PContract = new FinP2PContract(
         provider,
         signer,
         finP2PContractAddress,
         logger,
         txConfirmationTimeoutMs,
+        txGasTier,
       );
       const finP2PClient = new FinP2PClient(finP2PUrl, ossUrl);
       const execDetailsStore = new InMemoryExecDetailsStore();


### PR DESCRIPTION
## Summary

Picks up the EIP-1559 gas-tier feature from #255 and wires the env knob.

## Changes

- \`@owneraio/finp2p-contracts\` dep \`^0.28.12\` → \`^0.28.13\` + lockfile.
- \`src/config.ts\` reads and validates \`TX_GAS_TIER\` env (\`slow|normal|fast\`), passes as the 6th arg to \`FinP2PContract\` ctor. Absent env keeps the package default (\`normal\` — no overrides, exact pre-tier behavior). Invalid value fails fast at boot with the list of supported tiers.
- Adapter version \`0.28.3\` → \`0.28.4\` (patch).

## Operator usage

| Env value | Effect |
|---|---|
| (unset) | \`normal\` (default) — no gas overrides, ethers' built-in flows through |
| \`slow\` | 0.75× node feeData priority/max — back of priority queue |
| \`normal\` | Same as unset |
| \`fast\` | 1.5× node feeData priority/max — front of priority queue, useful on Sepolia under load |

Pre-EIP-1559 chains and chains without a public mempool (Hashio / Hedera EVM testnets) get the bare \`{ nonce }\` overrides regardless of tier — the adapter detects the absence of \`maxPriorityFeePerGas\` in feeData and falls through.

## Verification

- Verified the published 0.28.13 in \`node_modules\` exports \`GasTier\` type and the new 6-arg ctor signature.
- Adapter type-check + build clean.
- 16 omnibus + 14 account-mapping unit tests pass.

## After merge

Cherry-pick to \`release/v0.28\`; tag \`v0.28.4\` from the merged release commit + create the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)