### PR TITLE
Bump @owneraio/adapter-tests 0.28.5 → 0.28.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "sync-balances": "dist/scripts/sync-balances.js"
       },
       "devDependencies": {
-        "@owneraio/adapter-tests": "^0.28.5",
+        "@owneraio/adapter-tests": "^0.28.7",
         "@testcontainers/postgresql": "^11.8.1",
         "@types/express": "^5.0.3",
         "@types/jest": "^29.2.0",
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/@owneraio/adapter-tests": {
-      "version": "0.28.5",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/adapter-tests/0.28.5/94206e50c558ad5f2f1d7f35a132e01576aa8736",
-      "integrity": "sha512-pyboUSyuYtyiEPaIyLgUdnJnkWNXhRXMQCj72RnHi9etrFcxj8ol5xCuHIsM1ngPMsucMTvJfnIPs9bvHfBsSg==",
+      "version": "0.28.7",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/adapter-tests/0.28.7/35d9d8f0753985a2d5ae13e76e1999557637dd9d",
+      "integrity": "sha512-9QIa1iEE3Zm5rkqzxe0VySZNCMGNbh1bOciPzEmbZapAoMkx4iuijWjZYVRPSEWsZ7HgptFFSUc6Wnb4UVcmSQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "sync-balances": "dist/scripts/sync-balances.js"
       },
       "devDependencies": {
-        "@owneraio/adapter-tests": "^0.28.7",
+        "@owneraio/adapter-tests": "^0.28.8",
         "@testcontainers/postgresql": "^11.8.1",
         "@types/express": "^5.0.3",
         "@types/jest": "^29.2.0",
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/@owneraio/adapter-tests": {
-      "version": "0.28.7",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/adapter-tests/0.28.7/35d9d8f0753985a2d5ae13e76e1999557637dd9d",
-      "integrity": "sha512-9QIa1iEE3Zm5rkqzxe0VySZNCMGNbh1bOciPzEmbZapAoMkx4iuijWjZYVRPSEWsZ7HgptFFSUc6Wnb4UVcmSQ==",
+      "version": "0.28.8",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/adapter-tests/0.28.8/8958002fd4722ca04da19f6cd7bf3756f01256d6",
+      "integrity": "sha512-NLzZddn4gCMHmxco6VNjoD0p+dWUgL/AnDd+v/6q1rpNw8uRj5zOjMcGuSGN7sySu1O2yUvak6gEbgpFA8uzYQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@owneraio/adapter-tests": "^0.28.7",
+    "@owneraio/adapter-tests": "^0.28.8",
     "@testcontainers/postgresql": "^11.8.1",
     "@types/express": "^5.0.3",
     "@types/jest": "^29.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@owneraio/adapter-tests": "^0.28.5",
+    "@owneraio/adapter-tests": "^0.28.7",
     "@testcontainers/postgresql": "^11.8.1",
     "@types/express": "^5.0.3",
     "@types/jest": "^29.2.0",

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -1,3 +1,9 @@
 import {runAdapterTests} from "@owneraio/adapter-tests"
 
-runAdapterTests();
+// `mapping: true` is required as of adapter-tests 0.28.7 — it threads the
+// LedgerAPIClient into TestDataBuilder so `buildActor` can call
+// `/api/mapping/owners` to register the finId → ledgerAccountId mapping
+// before the test submits any signed op. Without it the builder runs
+// client-less and registrations silently no-op, so every test fails with
+// `Credential not found`.
+runAdapterTests({ mapping: true });

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -1,9 +1,3 @@
 import {runAdapterTests} from "@owneraio/adapter-tests"
 
-// `mapping: true` is required as of adapter-tests 0.28.7 — it threads the
-// LedgerAPIClient into TestDataBuilder so `buildActor` can call
-// `/api/mapping/owners` to register the finId → ledgerAccountId mapping
-// before the test submits any signed op. Without it the builder runs
-// client-less and registrations silently no-op, so every test fails with
-// `Credential not found`.
-runAdapterTests({ mapping: true });
+runAdapterTests();


### PR DESCRIPTION
## Summary

Picks up upstream skeleton-level adjustments in the shared test harness.

Transitive `@owneraio/finp2p-nodejs-skeleton-adapter` stays at `^0.28.19` (satisfies 0.28.7's `^0.28.10` requirement).

## Verification

- Adapter type-check clean.
- 16 omnibus + 9 account-mapping unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)