### PR TITLE
Bump skeleton-adapter 0.28.19 → 0.28.20 (restores bare /mapping/owners)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@owneraio/finp2p-contracts": "^0.28.13",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.19",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.20",
         "@owneraio/finp2p-vanilla-service": "^0.28.6",
         "@types/node": "^24.10.1",
         "axios": "^1.1.3",
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.19",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.19/3382b6dcc8e6dc6dcff8418f91790e94d787890f",
-      "integrity": "sha512-NsefrsUHdeTowPqssgO6wVrF0Gd27tb4M2MrvMO11z3PXLQ/4w5a/W+gzkSHKP//jcvqrz3+8ZWnkMIptqhqVw==",
+      "version": "0.28.20",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.20/5fbc550f6267fda76a4b78f21296ba1dc520906e",
+      "integrity": "sha512-dwko1SU7sOGeSxR8ifK7edPDDQZoTFvWNVMBr1Xx2SF8rZ1nYGby2nUAP9tS9Z1EMhCDoKJJ15M3qxWA3hsFMw==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@owneraio/finp2p-contracts": "^0.28.13",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.19",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.20",
     "@owneraio/finp2p-vanilla-service": "^0.28.6",
     "@types/node": "^24.10.1",
     "axios": "^1.1.3",

--- a/tests/utils/test-environment.ts
+++ b/tests/utils/test-environment.ts
@@ -87,11 +87,17 @@ class CustomTestEnvironment extends NodeEnvironment {
         details.rpcUrl,
         operatorAddress
       );
-      this.global.serverAddress = await this.startApp(
+      const baseUrl = await this.startApp(
         operator,
         details.rpcUrl,
         finP2PContractAddress
       );
+      // adapter-tests' LedgerAPIClient takes (host, callbackServer, baseAddress):
+      //   • host        — used by tokens/escrow/payments/plan/common  → /api/...
+      //   • baseAddress — used by mapping                              → bare /mapping/...
+      // Skeleton 0.28.20 mounts mapping at the bare path, everything else under /api.
+      this.global.serverAddress = `${baseUrl}/api`;
+      this.global.serverBaseAddress = baseUrl;
     } catch (err) {
       console.error("Error starting container:", err);
     }
@@ -254,7 +260,7 @@ class CustomTestEnvironment extends NodeEnvironment {
       console.error(await readiness.text())
     }
 
-    return `http://localhost:${port}/api`;
+    return `http://localhost:${port}`;
   }
 
   private async whichGoose() {


### PR DESCRIPTION
## Summary

0.28.20 reverts the mapping-route path back to the bare `/mapping/owners` (no `/api/` prefix), undoing the 0.28.19 breaking change. Other operational endpoints (`/api/assets/*`, `/api/plan/*`, etc.) stay under `/api`.

## Test env wiring

adapter-tests' `LedgerAPIClient(host, cb, baseAddress)` was already designed for this split:
- `host` → tokens/escrow/payments/plan/common (`/api/...`)
- `baseAddress` → mapping (bare `/...`)

Wires both globals from a single `startApp` return:
- `serverAddress` = `http://localhost:${port}/api`
- `serverBaseAddress` = `http://localhost:${port}`

## Verification

- Type-check clean.
- 16 omnibus + 9 account-mapping unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)