### PR TITLE
Bump @owneraio/finp2p-ethereum-dtcc-plugin 0.28.0 → 0.28.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.13",
-        "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
+        "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.2",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.21",
         "@owneraio/finp2p-vanilla-service": "^0.28.6",
@@ -1730,15 +1730,15 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-dtcc-plugin": {
-      "version": "0.28.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-dtcc-plugin/0.28.0/191626cb15d9fda248854b7aeb6297eb510ffd7b",
-      "integrity": "sha512-4NWv3n12l3sQmaWr8Or+QZP6Az+3Yq4bPT2CT39QyKDII8fl6X+V8x952TRdrQA34VoGREJSyLkC2ze6ee+sZQ==",
+      "version": "0.28.2",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-dtcc-plugin/0.28.2/3ad0718005597dc6534d180726b4de0fa89bfa9a",
+      "integrity": "sha512-V78tTNJ6krTeNCyrsAkSEqMPqK9fuD6w0NC9Md/iEzTAsiUjFKNMYbka+0psnqbFV2YNOJ1QR2ixofGI3ZoU2g==",
       "license": "ISC",
       "peerDependencies": {
-        "@owneraio/finp2p-client": "^0.28.0",
+        "@owneraio/finp2p-client": "^0.28.7",
         "@owneraio/finp2p-contracts": "^0.28.0",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.0",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.11",
         "ethers": "^6.11.1",
         "secp256k1": "^3.7.1",
         "winston": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
     "@owneraio/finp2p-contracts": "^0.28.13",
-    "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.0",
+    "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.2",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.21",
     "@owneraio/finp2p-vanilla-service": "^0.28.6",


### PR DESCRIPTION
## Summary
- Bumps `@owneraio/finp2p-ethereum-dtcc-plugin` from `^0.28.0` to `^0.28.2`.

## Test plan
- [ ] CI green