### PR TITLE
Bump @owneraio/finp2p-ethereum-collateral 0.28.8 → 0.28.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.13",
-        "@owneraio/finp2p-ethereum-collateral": "^0.28.8",
+        "@owneraio/finp2p-ethereum-collateral": "^0.28.9",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.21",
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-collateral": {
-      "version": "0.28.8",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.8/d29fa73afc5ac4967745f94e4ff6d981d047854f",
-      "integrity": "sha512-2aK1aUZUG4kgG3woBJ7mXrrIgUlQ05sR0AMkIKNtikJFwrFkcLqJ4NKPFsputeyF4Ktw5GTRC0gNC1K4JGcFiA==",
+      "version": "0.28.9",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.9/018c19ee32b0e15cd65918e1efcce181f95754ff",
+      "integrity": "sha512-F6QOkzfJU4jCU1fcCrcUTVS/u+gFKPAlp7g32G0c9BpbvdjiNVskRxl2s5HHLwC1j2j8Is16aookb2XbjER3Iw==",
       "license": "ISC",
       "peerDependencies": {
         "@owneraio/finp2p-client": "^0.28.12",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
     "@owneraio/finp2p-contracts": "^0.28.13",
-    "@owneraio/finp2p-ethereum-collateral": "^0.28.8",
+    "@owneraio/finp2p-ethereum-collateral": "^0.28.9",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.21",


### PR DESCRIPTION
## Summary
- Bumps `@owneraio/finp2p-ethereum-collateral` from `^0.28.8` to `^0.28.9`.
- Constructor signature unchanged (`OwneraCollateralPlugin` + `OwneraCollateralTokenStandard`); no adapter code changes needed.

## Test plan
- [ ] CI green