### PR TITLE
Bump @owneraio/finp2p-ethereum-collateral 0.28.9 → 0.28.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.13",
-        "@owneraio/finp2p-ethereum-collateral": "^0.28.9",
+        "@owneraio/finp2p-ethereum-collateral": "^0.28.10",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.21",
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-collateral": {
-      "version": "0.28.9",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.9/018c19ee32b0e15cd65918e1efcce181f95754ff",
-      "integrity": "sha512-F6QOkzfJU4jCU1fcCrcUTVS/u+gFKPAlp7g32G0c9BpbvdjiNVskRxl2s5HHLwC1j2j8Is16aookb2XbjER3Iw==",
+      "version": "0.28.10",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.10/6c8e3a76d2f278b05efb9bd43a16fdb48133c304",
+      "integrity": "sha512-iodELOPvnJv3OW8oYI89rWRgwvZoGIIOLoBmtiZXVlIwuZnej1M59TzA4EG4e+Xce6bNodiCMQS2C8DHwrzfXA==",
       "license": "ISC",
       "peerDependencies": {
         "@owneraio/finp2p-client": "^0.28.12",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
     "@owneraio/finp2p-contracts": "^0.28.13",
-    "@owneraio/finp2p-ethereum-collateral": "^0.28.9",
+    "@owneraio/finp2p-ethereum-collateral": "^0.28.10",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.21",


### PR DESCRIPTION
## Summary
- Bumps `@owneraio/finp2p-ethereum-collateral` from `^0.28.9` to `^0.28.10`.
- Constructor signature unchanged; no adapter code changes.

## Test plan
- [ ] CI green