### PR TITLE
Bump @owneraio/finp2p-ethereum-collateral 0.28.11 → 0.28.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.13",
-        "@owneraio/finp2p-ethereum-collateral": "^0.28.11",
+        "@owneraio/finp2p-ethereum-collateral": "^0.28.12",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-collateral": {
-      "version": "0.28.11",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.11/c6b86023110235663fefb51c31cf52fe5943bede",
-      "integrity": "sha512-b4XKOqg1O19QjF3OsxxeuQYG1eIKfrYf0QpxPMgurHb+D//YYzOvnilOveZmqxMgdNOI6LvI3I+DYXwfoQXJnw==",
+      "version": "0.28.12",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.12/c342914a7db23673a691cb265c3ad833397479fa",
+      "integrity": "sha512-iSDB48WrOtlrnMDzNwqy/+si/h0XdNIcIxzLjtkLyQ7UVP+uxr6IeUa9TIablthNPU7KJnkq0f3HwvDYQ1mkOQ==",
       "license": "ISC",
       "peerDependencies": {
         "@owneraio/finp2p-client": "^0.28.12",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
     "@owneraio/finp2p-contracts": "^0.28.13",
-    "@owneraio/finp2p-ethereum-collateral": "^0.28.11",
+    "@owneraio/finp2p-ethereum-collateral": "^0.28.12",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",

--- a/src/integrations/collateral/index.ts
+++ b/src/integrations/collateral/index.ts
@@ -51,7 +51,10 @@ export function registerCollateralPlugin(ctx: IntegrationContext): void {
   const agentAddress = agentWallet.address;
   const agentSigner = new NonceManager(agentWallet);
 
-  const ledgerName = process.env.NETWORK_NAME ?? 'ethereum';
+  // `ledgerName` is the logical name the FinP2P router uses to identify this
+  // adapter — not the chain (use NETWORK_NAME for that). Defaults to 'ethereum'
+  // for back-compat with existing router configurations.
+  const ledgerName = process.env.LEDGER_NAME ?? 'ethereum';
   const collateralWalletResolver = buildCollateralWalletResolver(walletResolver, finP2PContract);
 
   tokenStandardRegistry.register(

--- a/src/integrations/collateral/index.ts
+++ b/src/integrations/collateral/index.ts
@@ -51,6 +51,7 @@ export function registerCollateralPlugin(ctx: IntegrationContext): void {
   const agentAddress = agentWallet.address;
   const agentSigner = new NonceManager(agentWallet);
 
+  const ledgerName = process.env.NETWORK_NAME ?? 'ethereum';
   const collateralWalletResolver = buildCollateralWalletResolver(walletResolver, finP2PContract);
 
   tokenStandardRegistry.register(
@@ -59,11 +60,11 @@ export function registerCollateralPlugin(ctx: IntegrationContext): void {
   );
 
   const plugin = new OwneraCollateralPlugin(
-    orgId, provider, agentSigner, finP2PClient, logger, collateralWalletResolver, registryAddress,
+    orgId, provider, agentSigner, finP2PClient, logger, collateralWalletResolver, registryAddress, ledgerName,
   );
   pluginManager.registerPaymentsPlugin(plugin);
 
-  logger.info(`Collateral plugin activated: token standard '${COLLATERAL_TOKEN_STANDARD}', registry=${registryAddress}, agent=${agentAddress}`);
+  logger.info(`Collateral plugin activated: token standard '${COLLATERAL_TOKEN_STANDARD}', registry=${registryAddress}, agent=${agentAddress}, ledger=${ledgerName}`);
 }
 
 function buildCollateralWalletResolver(

--- a/src/integrations/collateral/index.ts
+++ b/src/integrations/collateral/index.ts
@@ -51,9 +51,6 @@ export function registerCollateralPlugin(ctx: IntegrationContext): void {
   const agentAddress = agentWallet.address;
   const agentSigner = new NonceManager(agentWallet);
 
-  // `ledgerName` is the logical name the FinP2P router uses to identify this
-  // adapter — not the chain (use NETWORK_NAME for that). Defaults to 'ethereum'
-  // for back-compat with existing router configurations.
   const ledgerName = process.env.LEDGER_NAME ?? 'ethereum';
   const collateralWalletResolver = buildCollateralWalletResolver(walletResolver, finP2PContract);
 


### PR DESCRIPTION
## Summary
- Bumps `@owneraio/finp2p-ethereum-collateral` from `^0.28.11` to `^0.28.12`.
- 0.28.12 adds a required `ledgerName: string` to `OwneraCollateralPlugin`'s constructor. Sourced from `NETWORK_NAME` env (default `'ethereum'`), matching the wallet/pull/ota deposit plugins' existing convention.

## Test plan
- [ ] CI green