### PR TITLE
Bump @owneraio/finp2p-ethereum-collateral 0.28.12 → 0.28.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.13",
-        "@owneraio/finp2p-ethereum-collateral": "^0.28.12",
+        "@owneraio/finp2p-ethereum-collateral": "^0.28.13",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-collateral": {
-      "version": "0.28.12",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.12/c342914a7db23673a691cb265c3ad833397479fa",
-      "integrity": "sha512-iSDB48WrOtlrnMDzNwqy/+si/h0XdNIcIxzLjtkLyQ7UVP+uxr6IeUa9TIablthNPU7KJnkq0f3HwvDYQ1mkOQ==",
+      "version": "0.28.13",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.13/ffe366d5473d847eba6254e6411ba01cc42aba83",
+      "integrity": "sha512-Ww0/iyUqbSdftytPOECsUfZL6KREPBVE7HdFL9BD3DLDu5ejSmUjsOgMgEieNGaYQTguic4HrlcmukvDGDsvUQ==",
       "license": "ISC",
       "peerDependencies": {
         "@owneraio/finp2p-client": "^0.28.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.13",
-        "@owneraio/finp2p-ethereum-collateral": "^0.28.13",
+        "@owneraio/finp2p-ethereum-collateral": "^0.28.15",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-collateral": {
-      "version": "0.28.13",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.13/ffe366d5473d847eba6254e6411ba01cc42aba83",
-      "integrity": "sha512-Ww0/iyUqbSdftytPOECsUfZL6KREPBVE7HdFL9BD3DLDu5ejSmUjsOgMgEieNGaYQTguic4HrlcmukvDGDsvUQ==",
+      "version": "0.28.15",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.15/efbd3ec16d965182a7f75fea5d1603ba5e6e55cc",
+      "integrity": "sha512-DZYIMStVVAlsbR5KWYP93rCkev9ukB6SwfiLRWMguEfqQVEdHBPu8K+u68E2n45WPCi+Y/B+zvn3mSKWOXnSCg==",
       "license": "ISC",
       "peerDependencies": {
         "@owneraio/finp2p-client": "^0.28.12",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
     "@owneraio/finp2p-contracts": "^0.28.13",
-    "@owneraio/finp2p-ethereum-collateral": "^0.28.12",
+    "@owneraio/finp2p-ethereum-collateral": "^0.28.13",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
     "@owneraio/finp2p-contracts": "^0.28.13",
-    "@owneraio/finp2p-ethereum-collateral": "^0.28.13",
+    "@owneraio/finp2p-ethereum-collateral": "^0.28.15",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",


### PR DESCRIPTION
## Summary
- Bumps `@owneraio/finp2p-ethereum-collateral` from `^0.28.12` to `^0.28.13`.
- Constructor signature unchanged; no adapter code changes.

## Test plan
- [ ] CI green