### PR TITLE
Add FinP2PContract.hasAssetRegistry() variant detector

### DIFF
--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.13",
+  "version": "0.28.14",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-contracts/src/finp2p.ts
+++ b/finp2p-contracts/src/finp2p.ts
@@ -1,4 +1,4 @@
-import { ContractFactory, Provider, Signer, TransactionReceipt } from "ethers";
+import { ContractFactory, Interface, Provider, Signer, TransactionReceipt } from "ethers";
 import { Logger } from "./adapter-types";
 import FINP2P from "../artifacts/contracts/finp2p/FINP2POperator.sol/FINP2POperator.json";
 import { FINP2POperator } from "../typechain-types";
@@ -41,6 +41,30 @@ export class FinP2PContract extends ContractsManager {
 
   async getVersion() {
     return this.mapErrors(async () => this.finP2P.getVersion())
+  }
+
+  /**
+   * True iff the deployed contract is `FINP2POperatorWithRegistry` (rather than
+   * the basic `FINP2POperator`). The two variants share the same name and
+   * VERSION constant but the WithRegistry variant exposes a unique
+   * `getAssetRegistry() returns (address)` method — probe for it via a raw
+   * eth_call. Success → WithRegistry; revert/empty data → basic operator.
+   *
+   * Use at startup to gate code paths that differ between the two
+   * (credential management, associateAsset arity).
+   */
+  async hasAssetRegistry(): Promise<boolean> {
+    const probe = new Interface(["function getAssetRegistry() view returns (address)"]);
+    try {
+      const result = await this.provider.call({
+        to: this.finP2PContractAddress,
+        data: probe.encodeFunctionData("getAssetRegistry", []),
+      });
+      probe.decodeFunctionResult("getAssetRegistry", result);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async eip712Domain(): Promise<EIP712Domain> {

--- a/finp2p-contracts/test/has-asset-registry.ts
+++ b/finp2p-contracts/test/has-asset-registry.ts
@@ -1,0 +1,45 @@
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { expect } from "chai";
+// @ts-ignore
+import { ethers } from "hardhat";
+import { FinP2PContract } from "../src/finp2p";
+import winston from "winston";
+
+const silentLogger = winston.createLogger({
+  level: "error",
+  transports: [new winston.transports.Console({ silent: true })],
+});
+
+describe("FinP2PContract.hasAssetRegistry", function () {
+  async function deployBasicOperator() {
+    const [admin] = await ethers.getSigners();
+    const factory = await ethers.getContractFactory("FINP2POperator");
+    const contract = await factory.deploy(admin.address);
+    await contract.waitForDeployment();
+    return { address: await contract.getAddress(), signer: admin };
+  }
+
+  async function deployWithRegistry() {
+    const [admin] = await ethers.getSigners();
+    const registryFactory = await ethers.getContractFactory("AssetRegistry");
+    const registry = await registryFactory.deploy();
+    await registry.waitForDeployment();
+
+    const factory = await ethers.getContractFactory("FINP2POperatorWithRegistry");
+    const contract = await factory.deploy(admin.address, await registry.getAddress());
+    await contract.waitForDeployment();
+    return { address: await contract.getAddress(), signer: admin };
+  }
+
+  it("returns false for the basic FINP2POperator", async () => {
+    const { address, signer } = await loadFixture(deployBasicOperator);
+    const wrapper = new FinP2PContract(ethers.provider, signer, address, silentLogger);
+    expect(await wrapper.hasAssetRegistry()).to.equal(false);
+  });
+
+  it("returns true for FINP2POperatorWithRegistry", async () => {
+    const { address, signer } = await loadFixture(deployWithRegistry);
+    const wrapper = new FinP2PContract(ethers.provider, signer, address, silentLogger);
+    expect(await wrapper.hasAssetRegistry()).to.equal(true);
+  });
+});

--- a/finp2p-contracts/test/has-asset-registry.ts
+++ b/finp2p-contracts/test/has-asset-registry.ts
@@ -3,12 +3,14 @@ import { expect } from "chai";
 // @ts-ignore
 import { ethers } from "hardhat";
 import { FinP2PContract } from "../src/finp2p";
-import winston from "winston";
+import { Logger } from "../src/adapter-types";
 
-const silentLogger = winston.createLogger({
-  level: "error",
-  transports: [new winston.transports.Console({ silent: true })],
-});
+const silentLogger: Logger = {
+  info: () => {},
+  warning: () => {},
+  error: () => {},
+  debug: () => {},
+};
 
 describe("FinP2PContract.hasAssetRegistry", function () {
   async function deployBasicOperator() {


### PR DESCRIPTION
## Why
`FINP2POperator` and `FINP2POperatorWithRegistry` are **not** API-compatible:
- WithRegistry has **no** `addCredential` / `removeCredential` / `getCredentialAddress`.
- `associateAsset` becomes 3-arg on WithRegistry (extra `bytes32 assetStandard`).

Both contracts return `"0.28.0"` from `getVersion()`, so the adapter can't tell them apart from version alone. A misconfigured deployment shows up at runtime as a cryptic empty-revert error like `"Owner mapping failed: execution reverted (no data present; likely require(false) occurred)"` — which is actually the fallback rejecting a non-existent function selector.

## What
- Adds `FinP2PContract.hasAssetRegistry(): Promise<boolean>` that probes the unique `getAssetRegistry()` selector via a raw `eth_call`. Success → WithRegistry; revert/empty → basic.
- Adds Hardhat coverage: `test/has-asset-registry.ts` deploys both variants and asserts the detector.
- Bumps `@owneraio/finp2p-contracts` 0.28.13 → 0.28.14.

## Follow-up
Once this publishes, the adapter can call `hasAssetRegistry()` at boot and either:
1. Fail loudly if the deployed variant doesn't match what's wired (preferable for now), or
2. Switch code paths to support both (larger change).

## Test plan
- [ ] CI green (new Hardhat tests pass locally: 2 passing)