### PR TITLE
Bump finp2p-contracts 0.28.14, fail-fast on WithRegistry variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
-        "@owneraio/finp2p-contracts": "^0.28.13",
+        "@owneraio/finp2p-contracts": "^0.28.14",
         "@owneraio/finp2p-ethereum-collateral": "^0.28.15",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.13",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.13/62ee0053114891c762c3b6b7a38caefb1b798494",
-      "integrity": "sha512-CYxfvvouEApCNrLukY574dax5bHhEp/IgceMJJegzjUyQq71dEiSJwXHdCBGDOjDq7D/0kC3OC+NhvEJkS+t8w==",
+      "version": "0.28.14",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.14/8bacb087ca2e6a84086f25e0cb194b3c575bc665",
+      "integrity": "sha512-d6M7aNgY9W7KNvac6Twz7QX6hGjHsGec/JqASdt018yoWrpvsoVtawE0F16Y5qbb7ZNDDIQa/8J3x2FpvEghGg==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "0.28.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
-    "@owneraio/finp2p-contracts": "^0.28.13",
+    "@owneraio/finp2p-contracts": "^0.28.14",
     "@owneraio/finp2p-ethereum-collateral": "^0.28.15",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -163,6 +163,15 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
 
       const contractVersion = await finP2PContract.getVersion();
       logger.info(`FinP2P contract version: ${contractVersion}`);
+      // FINP2POperatorWithRegistry shares the same name and VERSION constant but
+      // drops credential management and bumps associateAsset to 3 args — the
+      // adapter doesn't support it yet. Fail loudly at boot rather than emit
+      // a cryptic empty-revert at the first mapping/asset call.
+      if (await finP2PContract.hasAssetRegistry()) {
+        throw new Error(
+          `FinP2P contract at ${finP2PContractAddress} is a FINP2POperatorWithRegistry — not supported by this adapter. Deploy the basic FINP2POperator (or a version of the adapter that supports the with-registry variant).`,
+        );
+      }
       const { name, version, chainId, verifyingContract } =
         await finP2PContract.eip712Domain();
       logger.info(


### PR DESCRIPTION
## Summary
- Bumps `@owneraio/finp2p-contracts` from `^0.28.13` to `^0.28.14`.
- Uses the new `FinP2PContract.hasAssetRegistry()` probe at boot to detect whether the deployed contract is `FINP2POperatorWithRegistry`. If so, throws with a clear error before any mapping/asset call.

## Why
Both `FINP2POperator` and `FINP2POperatorWithRegistry` return `"0.28.0"` from `getVersion()`, so we can't tell them apart from version alone. A misconfigured deployment currently produces `"Owner mapping failed: execution reverted (no data present)"` — empty revert from the fallback rejecting non-existent function selectors. The boot-time probe surfaces the real cause immediately.

## Follow-up (not in scope)
Adapter-side support for `FINP2POperatorWithRegistry` (handling 3-arg `associateAsset`, finding credentials elsewhere) is a separate larger change.

## Test plan
- [ ] CI green
- [ ] Manual: deploy basic `FINP2POperator` against test env → adapter boots fine
- [ ] Manual: point at `FINP2POperatorWithRegistry` → adapter exits at boot with the new error message