### PR TITLE
FinP2PContract shim: variant-aware constructor + associateAsset routing

### DIFF
--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.14",
+  "version": "0.28.15",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-contracts/scripts/associate.ts
+++ b/finp2p-contracts/scripts/associate.ts
@@ -10,13 +10,19 @@ const associateAsset = async (
   finp2pContractAddress: string,
   assetId: string,
   erc20Address: string,
+  assetStandard: string | undefined,
 ) => {
   logger.info(`Associating asset ${assetId} with token ${erc20Address} on finP2P contract ${finp2pContractAddress}`);
 
   const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
 
-  const finP2P = new FinP2PContract(provider, signer, finp2pContractAddress, logger);
-  await finP2P.associateAsset(assetId, erc20Address);
+  const finP2P = await FinP2PContract.create(provider, signer, finp2pContractAddress, logger);
+  if (finP2P.variant === "with-registry" && !assetStandard) {
+    throw new Error(
+      "FINP2POperatorWithRegistry deployment detected — pass --asset_standard (bytes32 hex) for this contract variant.",
+    );
+  }
+  await finP2P.associateAsset(assetId, erc20Address, assetStandard);
   logger.info("Asset associated successfully");
 };
 
@@ -50,9 +56,15 @@ const config = parseConfig([
     envVar: "TOKEN_ADDRESS",
     description: "Token address to associate",
     required: true
+  },
+  {
+    name: "asset_standard",
+    envVar: "ASSET_STANDARD",
+    description: "bytes32 assetStandard id (required for FINP2POperatorWithRegistry; ignored on basic FINP2POperator)",
+    required: false,
   }
 ]);
 
-associateAsset(config.operator_pk!, config.rpc_url!, config.finp2p_contract_address!, config.asset_id!, config.token_address!)
+associateAsset(config.operator_pk!, config.rpc_url!, config.finp2p_contract_address!, config.asset_id!, config.token_address!, config.asset_standard)
   .then(() => {
   }).catch(console.error);

--- a/finp2p-contracts/src/finp2p.ts
+++ b/finp2p-contracts/src/finp2p.ts
@@ -80,10 +80,9 @@ export class FinP2PContract extends ContractsManager {
    * the basic `FINP2POperator`). The two variants share the same name and
    * VERSION constant but the WithRegistry variant exposes a unique
    * `getAssetRegistry() returns (address)` method — probe for it via a raw
-   * eth_call. Success → WithRegistry; revert/empty data → basic operator.
-   *
-   * Use at startup to gate code paths that differ between the two
-   * (credential management, associateAsset arity).
+   * eth_call. Function-missing reverts → basic operator. Transport failures
+   * (RPC down, network timeout, unauthenticated, etc.) re-throw so we don't
+   * silently misclassify a WithRegistry deployment during a startup blip.
    */
   async hasAssetRegistry(): Promise<boolean> {
     const probe = new Interface(["function getAssetRegistry() view returns (address)"]);
@@ -94,8 +93,9 @@ export class FinP2PContract extends ContractsManager {
       });
       probe.decodeFunctionResult("getAssetRegistry", result);
       return true;
-    } catch {
-      return false;
+    } catch (e) {
+      if (isFunctionMissingError(e)) return false;
+      throw e;
     }
   }
 
@@ -288,4 +288,27 @@ export class FinP2PContract extends ContractsManager {
     };
   }
 
+}
+
+/**
+ * Distinguish "function doesn't exist on the deployed contract" (the signal we
+ * want from a probe) from real transport failures (RPC down, timeout, network
+ * unauthenticated, etc.) that should propagate instead of being swallowed as
+ * "function missing → variant is basic".
+ *
+ * Real RPC nodes surface a missing function as ethers v6 CALL_EXCEPTION with
+ * empty (`0x`) return data. Hardhat-EDR (in-process devnode) instead throws
+ * with the literal message "function selector was not recognized". Match both;
+ * everything else (NETWORK_ERROR, TIMEOUT, UNCONFIGURED_NAME, auth, …) re-throws.
+ */
+export function isFunctionMissingError(e: unknown): boolean {
+  if (typeof e !== 'object' || e === null) return false;
+  const err = e as { code?: string; data?: string; message?: string };
+  if (err.code === 'CALL_EXCEPTION' && (err.data === '0x' || err.data === undefined || err.data === null)) {
+    return true;
+  }
+  if (typeof err.message === 'string' && /function selector was not recognized/i.test(err.message)) {
+    return true;
+  }
+  return false;
 }

--- a/finp2p-contracts/src/finp2p.ts
+++ b/finp2p-contracts/src/finp2p.ts
@@ -1,4 +1,4 @@
-import { ContractFactory, Interface, Provider, Signer, TransactionReceipt } from "ethers";
+import { ContractFactory, ContractTransactionResponse, Interface, Provider, Signer, TransactionReceipt } from "ethers";
 import { Logger } from "./adapter-types";
 import FINP2P from "../artifacts/contracts/finp2p/FINP2POperator.sol/FINP2POperator.json";
 import { FINP2POperator } from "../typechain-types";
@@ -20,6 +20,17 @@ import { assetTypeToService } from "./mappers";
 
 const ETH_COMPLETED_TRANSACTION_STATUS = 1;
 
+export type FinP2PVariant = 'basic' | 'with-registry';
+
+/**
+ * 3-arg `associateAsset` call data for `FINP2POperatorWithRegistry`. The basic
+ * variant only has the 2-arg form (typed via typechain). For the 3-arg form we
+ * encode the call manually so we don't need to drag in a second contract type.
+ */
+const WITH_REGISTRY_IFACE = new Interface([
+  "function associateAsset(string assetId, address tokenAddress, bytes32 assetStandard)",
+]);
+
 export class FinP2PContract extends ContractsManager {
 
   contractInterface: FINP2POperatorInterface;
@@ -28,7 +39,15 @@ export class FinP2PContract extends ContractsManager {
 
   finP2PContractAddress: string;
 
-  constructor(provider: Provider, signer: Signer, finP2PContractAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier) {
+  /**
+   * Which on-chain operator variant we're talking to. Set explicitly by the
+   * `create()` factory (which probes via `hasAssetRegistry()`). Callers that
+   * construct via `new` get `'basic'` by default — fine for the common case
+   * but explicit detection is preferred for production code paths.
+   */
+  variant: FinP2PVariant;
+
+  constructor(provider: Provider, signer: Signer, finP2PContractAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier, variant: FinP2PVariant = 'basic') {
     super(provider, signer, logger, confirmationTimeoutMs, gasTier);
     const factory = new ContractFactory<any[], FINP2POperator>(
       FINP2P.abi, FINP2P.bytecode, this.signer
@@ -37,6 +56,19 @@ export class FinP2PContract extends ContractsManager {
     this.contractInterface = contract.interface as FINP2POperatorInterface;
     this.finP2P = contract as FINP2POperator;
     this.finP2PContractAddress = finP2PContractAddress;
+    this.variant = variant;
+  }
+
+  /**
+   * Async factory: constructs a FinP2PContract and probes the deployed variant
+   * via `hasAssetRegistry()`. Preferred over `new FinP2PContract(...)` whenever
+   * the adapter doesn't know up-front which variant it's talking to.
+   */
+  static async create(provider: Provider, signer: Signer, finP2PContractAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier): Promise<FinP2PContract> {
+    const c = new FinP2PContract(provider, signer, finP2PContractAddress, logger, confirmationTimeoutMs, gasTier);
+    c.variant = (await c.hasAssetRegistry()) ? 'with-registry' : 'basic';
+    logger.info(`FinP2PContract variant detected: ${c.variant} at ${finP2PContractAddress}`);
+    return c;
   }
 
   async getVersion() {
@@ -86,7 +118,21 @@ export class FinP2PContract extends ContractsManager {
     return this.finP2P.getAssetAddress(assetId);
   }
 
-  async associateAsset(assetId: string, tokenAddress: string) {
+  async associateAsset(assetId: string, tokenAddress: string, assetStandard?: string) {
+    if (this.variant === 'with-registry') {
+      if (!assetStandard) {
+        throw new Error(`FINP2POperatorWithRegistry.associateAsset requires a bytes32 assetStandard at ${this.finP2PContractAddress}`);
+      }
+      const data = WITH_REGISTRY_IFACE.encodeFunctionData("associateAsset", [assetId, tokenAddress, assetStandard]);
+      return this.safeExecuteTransaction(this.finP2P, async (_: FINP2POperator, txParams: PayableOverrides) => {
+        // signer.sendTransaction returns TransactionResponse; safeExecuteTransaction wants
+        // ContractTransactionResponse — same wire object, the extra surface is unused here.
+        return this.signer.sendTransaction({ to: this.finP2PContractAddress, data, ...txParams }) as unknown as Promise<ContractTransactionResponse>;
+      });
+    }
+    if (assetStandard) {
+      this.logger.warning(`assetStandard supplied to associateAsset but contract variant is 'basic' — ignored`);
+    }
     return this.safeExecuteTransaction(this.finP2P, async (finP2P: FINP2POperator, txParams: PayableOverrides) => {
       return finP2P.associateAsset(assetId, tokenAddress, txParams);
     });

--- a/finp2p-contracts/test/has-asset-registry.ts
+++ b/finp2p-contracts/test/has-asset-registry.ts
@@ -2,7 +2,7 @@ import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 import { expect } from "chai";
 // @ts-ignore
 import { ethers } from "hardhat";
-import { FinP2PContract } from "../src/finp2p";
+import { FinP2PContract, isFunctionMissingError } from "../src/finp2p";
 import { Logger } from "../src/adapter-types";
 
 const silentLogger: Logger = {
@@ -63,5 +63,32 @@ describe("FinP2PContract.hasAssetRegistry", function () {
     await expect(wrapper.associateAsset("asset-1", "0x0000000000000000000000000000000000000001")).to.be.rejectedWith(
       /requires a bytes32 assetStandard/,
     );
+  });
+});
+
+describe("isFunctionMissingError", function () {
+  it("returns true for ethers v6 CALL_EXCEPTION with empty data", () => {
+    expect(isFunctionMissingError({ code: "CALL_EXCEPTION", data: "0x" })).to.equal(true);
+    expect(isFunctionMissingError({ code: "CALL_EXCEPTION" })).to.equal(true);
+  });
+
+  it("returns true for Hardhat-EDR's function-selector message", () => {
+    expect(isFunctionMissingError(new Error("Transaction reverted: function selector was not recognized and there's no fallback function"))).to.equal(true);
+  });
+
+  it("returns false for transport failures (NETWORK_ERROR, TIMEOUT, unauthenticated)", () => {
+    expect(isFunctionMissingError({ code: "NETWORK_ERROR", message: "could not connect" })).to.equal(false);
+    expect(isFunctionMissingError({ code: "TIMEOUT" })).to.equal(false);
+    expect(isFunctionMissingError(new Error("401 Unauthorized"))).to.equal(false);
+  });
+
+  it("returns false for CALL_EXCEPTION with non-empty revert data", () => {
+    expect(isFunctionMissingError({ code: "CALL_EXCEPTION", data: "0x08c379a0..." })).to.equal(false);
+  });
+
+  it("returns false for nullish input", () => {
+    expect(isFunctionMissingError(undefined)).to.equal(false);
+    expect(isFunctionMissingError(null)).to.equal(false);
+    expect(isFunctionMissingError("string error")).to.equal(false);
   });
 });

--- a/finp2p-contracts/test/has-asset-registry.ts
+++ b/finp2p-contracts/test/has-asset-registry.ts
@@ -44,4 +44,24 @@ describe("FinP2PContract.hasAssetRegistry", function () {
     const wrapper = new FinP2PContract(ethers.provider, signer, address, silentLogger);
     expect(await wrapper.hasAssetRegistry()).to.equal(true);
   });
+
+  it("FinP2PContract.create() detects 'basic' variant", async () => {
+    const { address, signer } = await loadFixture(deployBasicOperator);
+    const wrapper = await FinP2PContract.create(ethers.provider, signer, address, silentLogger);
+    expect(wrapper.variant).to.equal("basic");
+  });
+
+  it("FinP2PContract.create() detects 'with-registry' variant", async () => {
+    const { address, signer } = await loadFixture(deployWithRegistry);
+    const wrapper = await FinP2PContract.create(ethers.provider, signer, address, silentLogger);
+    expect(wrapper.variant).to.equal("with-registry");
+  });
+
+  it("associateAsset on with-registry requires an assetStandard arg", async () => {
+    const { address, signer } = await loadFixture(deployWithRegistry);
+    const wrapper = await FinP2PContract.create(ethers.provider, signer, address, silentLogger);
+    await expect(wrapper.associateAsset("asset-1", "0x0000000000000000000000000000000000000001")).to.be.rejectedWith(
+      /requires a bytes32 assetStandard/,
+    );
+  });
 });


### PR DESCRIPTION
## What
Adds variant-aware support to `FinP2PContract` (the TypeScript wrapper around the FinP2P operator contract) so the adapter does not need to know whether the deployed on-chain contract is `FINP2POperator` or `FINP2POperatorWithRegistry`.

Concrete changes:
- `FinP2PContract` gains a `variant: 'basic' | 'with-registry'` field.
- New static async factory `FinP2PContract.create(...)` probes the deployed contract via the existing `hasAssetRegistry()` method and stamps the right variant on the wrapper.
- `associateAsset(id, token, assetStandard?)` routes based on the variant:
  - `'with-registry'` path: requires `assetStandard` (bytes32); encodes the 3-arg call via `Interface` and sends through `safeExecuteTransaction` (so nonce-retry and confirmation-timeout handling apply uniformly).
  - `'basic'` path: ignores `assetStandard` if supplied (logs a warning); calls the 2-arg typechain method as before.
- All other methods (issue/transfer/redeem/hold/releaseTo/releaseAndRedeem/releaseBack/addCredential/getCredentialAddress/setEscrowWalletAddress/eip712Domain/getAssetAddress/balance/hasRole/verifyInvestmentSignature/hashInvestment/getLockInfo/getReceipt*/getOperationStatus) pass through unchanged — both variants are expected to expose the same surface.
- Bumps `@owneraio/finp2p-contracts` 0.28.14 → 0.28.15.

## Why
`FINP2POperator` and `FINP2POperatorWithRegistry` are not API-compatible but share the same name and `VERSION` constant ("0.28.0"), so `getVersion()` cannot tell them apart. Two surface differences matter:

1. **`associateAsset` arity changed.** WithRegistry takes an extra `bytes32 assetStandard` argument selecting which registered token-standard implementation to use. The adapter currently calls the 2-arg form, which on WithRegistry hits the fallback and reverts with no data — the cryptic `execution reverted (no data present; likely require(false) occurred)` we just chased down on k3d-local6.
2. **Credentials.** Both variants are expected to expose on-chain credential methods; whether to use on-chain or DB-backed credentials remains a 100% adapter-side decision (segregated by `PROVIDER_TYPE`). The shim does not try to fake credentials in one variant when the other has them.

Without this shim, the adapter has to know which variant is deployed and call the right shape — a leak of contract internals into adapter code and a guaranteed misconfiguration trap. With it, the adapter just calls `FinP2PContract.create(...)` and uses the wrapper as before.

## Follow-up
A small adapter PR (refresh of #286) will:
- Bump the dep to `^0.28.15`.
- Switch construction in `src/config.ts` to `await FinP2PContract.create(...)`.
- Drop the fail-fast `hasAssetRegistry()` guard added in #286 — now unnecessary.

## Test plan
- [ ] CI green
- 5 Hardhat tests in `finp2p-contracts/test/has-asset-registry.ts` pass locally — covering `hasAssetRegistry()`, `FinP2PContract.create()` variant detection (both modes), and `associateAsset` on WithRegistry rejecting when `assetStandard` is missing.