### PR TITLE
Adapter support for FINP2POperatorWithRegistry contract variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.15",
-        "@owneraio/finp2p-ethereum-collateral": "^0.28.20",
+        "@owneraio/finp2p-ethereum-collateral": "^0.28.21",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1733,13 +1733,13 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-collateral": {
-      "version": "0.28.20",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.20/51bbc2a0a3e697a457378d8ded0ee77f4f0f41e5",
-      "integrity": "sha512-iiCjT8ES3ceFoqial0NdQwg9Mauo39vmxImnzm1ilVY0KLHvxIdCkk2LrIpUTXxjFcEsD2qEA/yu7PhwBBjblg==",
+      "version": "0.28.22",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.22/a49f6404eb6d19cbbd8957072934914a82f724f8",
+      "integrity": "sha512-G+yB7Fdd3pdDC3HNHceYnRbYzvLxJ92MqZh2hqzxhq2t+QWmSv2z/wz+jj54EJJ1VyN1ln9SGXoXy8G9q7FNOw==",
       "license": "ISC",
       "peerDependencies": {
         "@owneraio/finp2p-client": "^0.28.12",
-        "@owneraio/finp2p-contracts": "^0.28.0",
+        "@owneraio/finp2p-contracts": "^0.28.16",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.11",
         "ethers": "^6.11.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
-        "@owneraio/finp2p-contracts": "^0.28.13",
+        "@owneraio/finp2p-contracts": "^0.28.15",
         "@owneraio/finp2p-ethereum-collateral": "^0.28.20",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.13",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.13/62ee0053114891c762c3b6b7a38caefb1b798494",
-      "integrity": "sha512-CYxfvvouEApCNrLukY574dax5bHhEp/IgceMJJegzjUyQq71dEiSJwXHdCBGDOjDq7D/0kC3OC+NhvEJkS+t8w==",
+      "version": "0.28.15",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.15/156632473a311791eefa378673d0d80080cb8f70",
+      "integrity": "sha512-s0Z6arons28cYCO6jlqCVIgMTlOOV8L8ZkMzGjp0fmR0JQIdCIJ2ME/OATB389myw1U9KGpEH9agW+WhxHGcFA==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "0.28.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
-    "@owneraio/finp2p-contracts": "^0.28.13",
+    "@owneraio/finp2p-contracts": "^0.28.15",
     "@owneraio/finp2p-ethereum-collateral": "^0.28.20",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
     "@owneraio/finp2p-contracts": "^0.28.15",
-    "@owneraio/finp2p-ethereum-collateral": "^0.28.20",
+    "@owneraio/finp2p-ethereum-collateral": "^0.28.21",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",

--- a/scripts/migration.ts
+++ b/scripts/migration.ts
@@ -69,7 +69,11 @@ const startMigration = async (
   }
 
   const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
-  const finP2PContract = new FinP2PContract(provider, signer, finp2pContractAddress, logger);
+  const finP2PContract = await FinP2PContract.create(provider, signer, finp2pContractAddress, logger);
+  const assetStandard = process.env.DEFAULT_ASSET_STANDARD;
+  if (finP2PContract.variant === 'with-registry' && !assetStandard) {
+    throw new Error('FINP2POperatorWithRegistry detected — set DEFAULT_ASSET_STANDARD (0x-prefixed bytes32) before running this script.');
+  }
 
   let migrated = 0;
   let skipped = 0;
@@ -101,7 +105,7 @@ const startMigration = async (
 
     try {
       logger.info(`Migrating asset ${assetId} with token address ${tokenAddress}`);
-      await finP2PContract.associateAsset(assetId, tokenAddress);
+      await finP2PContract.associateAsset(assetId, tokenAddress, assetStandard);
       logger.info("       asset association [done]");
       await whitelistERC20(provider, signer, tokenAddress, logger, finp2pContractAddress);
       migrated++;

--- a/scripts/migration.ts
+++ b/scripts/migration.ts
@@ -10,7 +10,7 @@ import {
   OPERATOR_ROLE,
   isEthereumAddress
 } from "@owneraio/finp2p-contracts";
-import { createJsonProvider, parseConfig } from "../src/config";
+import { createJsonProvider, parseConfig, verifyAssetStandardRegistered } from "../src/config";
 import { Provider, Signer } from "ethers";
 import { Logger } from "@owneraio/finp2p-nodejs-skeleton-adapter";
 import { redactSecrets } from "../src/redact-secrets";
@@ -71,8 +71,11 @@ const startMigration = async (
   const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
   const finP2PContract = await FinP2PContract.create(provider, signer, finp2pContractAddress, logger);
   const assetStandard = process.env.DEFAULT_ASSET_STANDARD;
-  if (finP2PContract.variant === 'with-registry' && !assetStandard) {
-    throw new Error('FINP2POperatorWithRegistry detected — set DEFAULT_ASSET_STANDARD (0x-prefixed bytes32) before running this script.');
+  if (finP2PContract.variant === 'with-registry') {
+    if (!assetStandard) {
+      throw new Error('FINP2POperatorWithRegistry detected — set DEFAULT_ASSET_STANDARD (0x-prefixed bytes32) before running this script.');
+    }
+    await verifyAssetStandardRegistered(provider, finp2pContractAddress, assetStandard, logger);
   }
 
   let migrated = 0;

--- a/scripts/sync-balances.ts
+++ b/scripts/sync-balances.ts
@@ -30,7 +30,11 @@ const syncBalanceFromOssToEthereum = async (
   }
 
   const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
-  const contract = new FinP2PContract(provider, signer, finp2pContractAddress, logger);
+  const contract = await FinP2PContract.create(provider, signer, finp2pContractAddress, logger);
+  const assetStandard = process.env.DEFAULT_ASSET_STANDARD;
+  if (contract.variant === 'with-registry' && !assetStandard) {
+    throw new Error('FINP2POperatorWithRegistry detected — set DEFAULT_ASSET_STANDARD (0x-prefixed bytes32) before running this script.');
+  }
 
   for (const { id: assetId } of assets) {
     try {
@@ -41,7 +45,7 @@ const syncBalanceFromOssToEthereum = async (
         logger.info(`Deploying new token for asset ${assetId}`);
         const erc20Address = await contract.deployERC20(assetId, assetId, 0, finp2pContractAddress);
         logger.info(`Associating asset ${assetId} with token ${erc20Address}`);
-        await contract.associateAsset(assetId, erc20Address);
+        await contract.associateAsset(assetId, erc20Address, assetStandard);
       } else {
         logger.error(`Error migrating asset ${assetId}: ${e}`);
       }

--- a/scripts/sync-balances.ts
+++ b/scripts/sync-balances.ts
@@ -4,7 +4,7 @@ import winston, { format, transports } from "winston";
 import { FinP2PClient } from "@owneraio/finp2p-client";
 import { FinP2PContract, AssetType, term } from "@owneraio/finp2p-contracts";
 import { emptyOperationParams } from "../src/services/finp2p-contract/helpers";
-import { createJsonProvider, parseConfig } from "../src/config";
+import { createJsonProvider, parseConfig, verifyAssetStandardRegistered } from "../src/config";
 import { redactSecrets } from "../src/redact-secrets";
 
 
@@ -32,8 +32,11 @@ const syncBalanceFromOssToEthereum = async (
   const { provider, signer } = await createJsonProvider(operatorPrivateKey, ethereumRPCUrl);
   const contract = await FinP2PContract.create(provider, signer, finp2pContractAddress, logger);
   const assetStandard = process.env.DEFAULT_ASSET_STANDARD;
-  if (contract.variant === 'with-registry' && !assetStandard) {
-    throw new Error('FINP2POperatorWithRegistry detected — set DEFAULT_ASSET_STANDARD (0x-prefixed bytes32) before running this script.');
+  if (contract.variant === 'with-registry') {
+    if (!assetStandard) {
+      throw new Error('FINP2POperatorWithRegistry detected — set DEFAULT_ASSET_STANDARD (0x-prefixed bytes32) before running this script.');
+    }
+    await verifyAssetStandardRegistered(provider, finp2pContractAddress, assetStandard, logger);
   }
 
   for (const { id: assetId } of assets) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -137,7 +137,7 @@ function registerFinP2PContractServices(
   const workflowStorage = dbPool ? new workflows.WorkflowStorage(dbPool, ledgerSchema) : undefined;
   let planApprovalService = new PlanApprovalServiceImpl(contractConfig.orgId, pluginManager, contractConfig.finP2PClient);
   const escrowService = new EscrowServiceImpl(contractConfig.finP2PContract, contractConfig.finP2PClient, contractConfig.execDetailsStore, contractConfig.proofProvider, pluginManager);
-  const tokenService = new TokenServiceImpl(contractConfig.finP2PContract, contractConfig.finP2PClient, contractConfig.execDetailsStore, contractConfig.proofProvider, pluginManager);
+  const tokenService = new TokenServiceImpl(contractConfig.finP2PContract, contractConfig.finP2PClient, contractConfig.execDetailsStore, contractConfig.proofProvider, pluginManager, contractConfig.defaultAssetStandard);
   const mappingService = new CredentialsMappingService(contractConfig.finP2PContract);
   const mappingConfig = buildMappingConfig();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { Interface, JsonRpcProvider, NonceManager, Provider, Signer, Wallet, ZeroAddress } from "ethers";
+import { Interface, JsonRpcProvider, NonceManager, Provider, Signer, Wallet, ZeroAddress, keccak256, toUtf8Bytes } from "ethers";
 import process from "process";
 import { FinP2PContract } from '@owneraio/finp2p-contracts'
 import { FinP2PClient } from '@owneraio/finp2p-client'
@@ -8,6 +8,11 @@ import { Logger } from "@owneraio/finp2p-nodejs-skeleton-adapter";
 import { InMemoryExecDetailsStore } from './services/finp2p-contract/exec-details-store'
 import { FireblocksAppConfig, createFireblocksAppConfig } from './integrations/fireblocks/config'
 import { DfnsAppConfig, createDfnsAppConfig } from './integrations/dfns/config'
+
+/** keccak256("ERC20") — the default bytes32 `assetStandard` passed to associateAsset
+ *  when DEFAULT_ASSET_STANDARD env is unset. Matches the convention used by other
+ *  FinP2P deployments registering ERC20 as the baseline token standard. */
+export const DEFAULT_ASSET_STANDARD_ERC20 = keccak256(toUtf8Bytes("ERC20"));
 
 export type AccountMappingType = 'database'
 
@@ -165,16 +170,14 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
       const contractVersion = await finP2PContract.getVersion();
       logger.info(`FinP2P contract version: ${contractVersion} (variant: ${finP2PContract.variant})`);
 
-      const defaultAssetStandardRaw = process.env.DEFAULT_ASSET_STANDARD;
-      if (defaultAssetStandardRaw && !/^0x[0-9a-fA-F]{64}$/.test(defaultAssetStandardRaw)) {
+      const defaultAssetStandardRaw = process.env.DEFAULT_ASSET_STANDARD ?? DEFAULT_ASSET_STANDARD_ERC20;
+      if (!/^0x[0-9a-fA-F]{64}$/.test(defaultAssetStandardRaw)) {
         throw new Error(`Invalid DEFAULT_ASSET_STANDARD: must be a 0x-prefixed 32-byte hex string (66 chars), got ${defaultAssetStandardRaw}`);
       }
+      if (!process.env.DEFAULT_ASSET_STANDARD) {
+        logger.info(`DEFAULT_ASSET_STANDARD not set; defaulting to keccak256("ERC20") = ${DEFAULT_ASSET_STANDARD_ERC20}`);
+      }
       if (finP2PContract.variant === 'with-registry') {
-        if (!defaultAssetStandardRaw) {
-          throw new Error(
-            `FinP2P contract at ${finP2PContractAddress} is FINP2POperatorWithRegistry but DEFAULT_ASSET_STANDARD env is not set. Its associateAsset signature requires a bytes32 assetStandard; supply DEFAULT_ASSET_STANDARD=0x... before boot.`,
-          );
-        }
         await verifyAssetStandardRegistered(provider, finP2PContractAddress, defaultAssetStandardRaw, logger);
       }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,13 +45,6 @@ export type FinP2PContractAppConfig = BaseAppConfig & {
   type: 'finp2p-contract'
   finP2PContract: FinP2PContract
   execDetailsStore: ExecDetailsStore | undefined
-  /**
-   * Optional bytes32 hex passed to `associateAsset` when the deployed contract
-   * is `FINP2POperatorWithRegistry` (which requires a 3rd `bytes32 assetStandard`
-   * arg selecting a registered token-standard impl). Sourced from
-   * `DEFAULT_ASSET_STANDARD` env. Validated at boot; required when variant is
-   * `'with-registry'`; ignored by the shim when variant is `'basic'`.
-   */
   defaultAssetStandard: string | undefined
 }
 
@@ -182,9 +175,6 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
             `FinP2P contract at ${finP2PContractAddress} is FINP2POperatorWithRegistry but DEFAULT_ASSET_STANDARD env is not set. Its associateAsset signature requires a bytes32 assetStandard; supply DEFAULT_ASSET_STANDARD=0x... before boot.`,
           );
         }
-        // Verify the supplied standard is actually registered on-chain — a typo
-        // in DEFAULT_ASSET_STANDARD would otherwise pass boot and fail later
-        // with the contract's "Asset standard not found" revert.
         await verifyAssetStandardRegistered(provider, finP2PContractAddress, defaultAssetStandardRaw, logger);
       }
 
@@ -330,23 +320,10 @@ export function parseConfig(params: ParamDefinition[]): ParsedConfig {
 }
 
 /**
- * Validate the supplied DEFAULT_ASSET_STANDARD value and verify it's actually
- * registered on the FINP2POperatorWithRegistry's AssetRegistry. Fails fast at
- * boot if any check trips — without this a typo would pass startup and surface
- * as a cryptic on-chain revert at the first createAsset.
- *
- * Two checks:
- *   1. Shape: 0x-prefixed 32-byte hex (66 chars).
- *   2. Registration: lookup via getAssetRegistry → getAssetStandard(bytes32).
- *      AssetRegistry reverts with "Asset standard not found" for unknown ids
- *      (NOT zero address), so we catch that specific revert and translate it
- *      into a clear error.
- *
- * Inline raw calls (rather than a shim method) so we don't need another
- * @owneraio/finp2p-contracts release cycle just for this verification.
- *
- * Exported so the operational scripts (migration, sync-balances) can apply
- * the same validation when they detect a WithRegistry deployment.
+ * AssetRegistry reverts with "Asset standard not found" for unknown ids
+ * (NOT zero address) — we catch that specific revert and translate to a
+ * clear error so a typo'd DEFAULT_ASSET_STANDARD fails fast at boot
+ * instead of at the first createAsset call.
  */
 export async function verifyAssetStandardRegistered(
   provider: Provider,

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,14 @@ export type FinP2PContractAppConfig = BaseAppConfig & {
   type: 'finp2p-contract'
   finP2PContract: FinP2PContract
   execDetailsStore: ExecDetailsStore | undefined
+  /**
+   * Optional bytes32 hex passed to `associateAsset` when the deployed contract
+   * is `FINP2POperatorWithRegistry` (which requires a 3rd `bytes32 assetStandard`
+   * arg selecting a registered token-standard impl). Sourced from
+   * `DEFAULT_ASSET_STANDARD` env. Validated at boot; required when variant is
+   * `'with-registry'`; ignored by the shim when variant is `'basic'`.
+   */
+  defaultAssetStandard: string | undefined
 }
 
 export { FireblocksAppConfig } from './integrations/fireblocks/config'
@@ -149,7 +157,7 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
       }
       const txGasTier = txGasTierRaw as GasTier | undefined;
 
-      const finP2PContract = new FinP2PContract(
+      const finP2PContract = await FinP2PContract.create(
         provider,
         signer,
         finP2PContractAddress,
@@ -162,7 +170,18 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
       const proofProvider = new ProofProvider(orgId, finP2PClient, operatorPrivateKey)
 
       const contractVersion = await finP2PContract.getVersion();
-      logger.info(`FinP2P contract version: ${contractVersion}`);
+      logger.info(`FinP2P contract version: ${contractVersion} (variant: ${finP2PContract.variant})`);
+
+      const defaultAssetStandardRaw = process.env.DEFAULT_ASSET_STANDARD;
+      if (defaultAssetStandardRaw && !/^0x[0-9a-fA-F]{64}$/.test(defaultAssetStandardRaw)) {
+        throw new Error(`Invalid DEFAULT_ASSET_STANDARD: must be a 0x-prefixed 32-byte hex string (66 chars), got ${defaultAssetStandardRaw}`);
+      }
+      if (finP2PContract.variant === 'with-registry' && !defaultAssetStandardRaw) {
+        throw new Error(
+          `FinP2P contract at ${finP2PContractAddress} is FINP2POperatorWithRegistry but DEFAULT_ASSET_STANDARD env is not set. Its associateAsset signature requires a bytes32 assetStandard; supply DEFAULT_ASSET_STANDARD=0x... before boot.`,
+        );
+      }
+
       const { name, version, chainId, verifyingContract } =
         await finP2PContract.eip712Domain();
       logger.info(
@@ -180,6 +199,7 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
         accountModel,
         finP2PContract,
         execDetailsStore,
+        defaultAssetStandard: defaultAssetStandardRaw,
       }
     }
     case 'fireblocks': {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider, NonceManager, Provider, Signer, Wallet } from "ethers";
+import { Interface, JsonRpcProvider, NonceManager, Provider, Signer, Wallet, ZeroAddress } from "ethers";
 import process from "process";
 import { FinP2PContract } from '@owneraio/finp2p-contracts'
 import { FinP2PClient } from '@owneraio/finp2p-client'
@@ -176,10 +176,16 @@ export async function envVarsToAppConfig(logger: Logger): Promise<AppConfig> {
       if (defaultAssetStandardRaw && !/^0x[0-9a-fA-F]{64}$/.test(defaultAssetStandardRaw)) {
         throw new Error(`Invalid DEFAULT_ASSET_STANDARD: must be a 0x-prefixed 32-byte hex string (66 chars), got ${defaultAssetStandardRaw}`);
       }
-      if (finP2PContract.variant === 'with-registry' && !defaultAssetStandardRaw) {
-        throw new Error(
-          `FinP2P contract at ${finP2PContractAddress} is FINP2POperatorWithRegistry but DEFAULT_ASSET_STANDARD env is not set. Its associateAsset signature requires a bytes32 assetStandard; supply DEFAULT_ASSET_STANDARD=0x... before boot.`,
-        );
+      if (finP2PContract.variant === 'with-registry') {
+        if (!defaultAssetStandardRaw) {
+          throw new Error(
+            `FinP2P contract at ${finP2PContractAddress} is FINP2POperatorWithRegistry but DEFAULT_ASSET_STANDARD env is not set. Its associateAsset signature requires a bytes32 assetStandard; supply DEFAULT_ASSET_STANDARD=0x... before boot.`,
+          );
+        }
+        // Verify the supplied standard is actually registered on-chain — a typo
+        // in DEFAULT_ASSET_STANDARD would otherwise pass boot and fail later
+        // with the contract's "Asset standard not found" revert.
+        await verifyAssetStandardRegistered(provider, finP2PContractAddress, defaultAssetStandardRaw, logger);
       }
 
       const { name, version, chainId, verifyingContract } =
@@ -321,4 +327,43 @@ export function parseConfig(params: ParamDefinition[]): ParsedConfig {
   }
 
   return config;
+}
+
+/**
+ * Verify the configured assetStandard is registered on the FINP2POperatorWithRegistry's
+ * AssetRegistry. Fails the boot if not — without this check a typo in
+ * DEFAULT_ASSET_STANDARD would pass startup and surface as an `Asset standard
+ * not found` revert at the first createAsset call.
+ *
+ * Inline raw calls (rather than a shim method) so we don't need another
+ * @owneraio/finp2p-contracts release cycle just for this verification.
+ */
+async function verifyAssetStandardRegistered(
+  provider: Provider,
+  operatorAddress: string,
+  assetStandard: string,
+  logger: Logger,
+): Promise<void> {
+  const operatorIface = new Interface(["function getAssetRegistry() view returns (address)"]);
+  const registryIface = new Interface(["function getAssetStandard(bytes32) view returns (address)"]);
+
+  const registryResult = await provider.call({
+    to: operatorAddress,
+    data: operatorIface.encodeFunctionData("getAssetRegistry", []),
+  });
+  const [registryAddress] = operatorIface.decodeFunctionResult("getAssetRegistry", registryResult);
+  if (registryAddress === ZeroAddress) {
+    throw new Error(`FINP2POperatorWithRegistry at ${operatorAddress} returned zero address for its AssetRegistry — contract is misconfigured.`);
+  }
+
+  const standardResult = await provider.call({
+    to: registryAddress,
+    data: registryIface.encodeFunctionData("getAssetStandard", [assetStandard]),
+  });
+  const [standardImpl] = registryIface.decodeFunctionResult("getAssetStandard", standardResult);
+  if (standardImpl === ZeroAddress) {
+    throw new Error(`DEFAULT_ASSET_STANDARD ${assetStandard} is not registered on AssetRegistry ${registryAddress}. Register it on-chain first or set DEFAULT_ASSET_STANDARD to a known standard id.`);
+  }
+
+  logger.info(`DEFAULT_ASSET_STANDARD ${assetStandard} verified on AssetRegistry ${registryAddress} → impl ${standardImpl}`);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export type FinP2PContractAppConfig = BaseAppConfig & {
   type: 'finp2p-contract'
   finP2PContract: FinP2PContract
   execDetailsStore: ExecDetailsStore | undefined
-  defaultAssetStandard: string | undefined
+  defaultAssetStandard?: string
 }
 
 export { FireblocksAppConfig } from './integrations/fireblocks/config'

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,9 +9,6 @@ import { InMemoryExecDetailsStore } from './services/finp2p-contract/exec-detail
 import { FireblocksAppConfig, createFireblocksAppConfig } from './integrations/fireblocks/config'
 import { DfnsAppConfig, createDfnsAppConfig } from './integrations/dfns/config'
 
-/** keccak256("ERC20") — the default bytes32 `assetStandard` passed to associateAsset
- *  when DEFAULT_ASSET_STANDARD env is unset. Matches the convention used by other
- *  FinP2P deployments registering ERC20 as the baseline token standard. */
 export const DEFAULT_ASSET_STANDARD_ERC20 = keccak256(toUtf8Bytes("ERC20"));
 
 export type AccountMappingType = 'database'

--- a/src/config.ts
+++ b/src/config.ts
@@ -330,20 +330,34 @@ export function parseConfig(params: ParamDefinition[]): ParsedConfig {
 }
 
 /**
- * Verify the configured assetStandard is registered on the FINP2POperatorWithRegistry's
- * AssetRegistry. Fails the boot if not — without this check a typo in
- * DEFAULT_ASSET_STANDARD would pass startup and surface as an `Asset standard
- * not found` revert at the first createAsset call.
+ * Validate the supplied DEFAULT_ASSET_STANDARD value and verify it's actually
+ * registered on the FINP2POperatorWithRegistry's AssetRegistry. Fails fast at
+ * boot if any check trips — without this a typo would pass startup and surface
+ * as a cryptic on-chain revert at the first createAsset.
+ *
+ * Two checks:
+ *   1. Shape: 0x-prefixed 32-byte hex (66 chars).
+ *   2. Registration: lookup via getAssetRegistry → getAssetStandard(bytes32).
+ *      AssetRegistry reverts with "Asset standard not found" for unknown ids
+ *      (NOT zero address), so we catch that specific revert and translate it
+ *      into a clear error.
  *
  * Inline raw calls (rather than a shim method) so we don't need another
  * @owneraio/finp2p-contracts release cycle just for this verification.
+ *
+ * Exported so the operational scripts (migration, sync-balances) can apply
+ * the same validation when they detect a WithRegistry deployment.
  */
-async function verifyAssetStandardRegistered(
+export async function verifyAssetStandardRegistered(
   provider: Provider,
   operatorAddress: string,
   assetStandard: string,
   logger: Logger,
 ): Promise<void> {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(assetStandard)) {
+    throw new Error(`Invalid asset standard: must be a 0x-prefixed 32-byte hex string (66 chars), got ${assetStandard}`);
+  }
+
   const operatorIface = new Interface(["function getAssetRegistry() view returns (address)"]);
   const registryIface = new Interface(["function getAssetStandard(bytes32) view returns (address)"]);
 
@@ -356,14 +370,26 @@ async function verifyAssetStandardRegistered(
     throw new Error(`FINP2POperatorWithRegistry at ${operatorAddress} returned zero address for its AssetRegistry — contract is misconfigured.`);
   }
 
-  const standardResult = await provider.call({
-    to: registryAddress,
-    data: registryIface.encodeFunctionData("getAssetStandard", [assetStandard]),
-  });
-  const [standardImpl] = registryIface.decodeFunctionResult("getAssetStandard", standardResult);
-  if (standardImpl === ZeroAddress) {
-    throw new Error(`DEFAULT_ASSET_STANDARD ${assetStandard} is not registered on AssetRegistry ${registryAddress}. Register it on-chain first or set DEFAULT_ASSET_STANDARD to a known standard id.`);
+  let standardImpl: string;
+  try {
+    const standardResult = await provider.call({
+      to: registryAddress,
+      data: registryIface.encodeFunctionData("getAssetStandard", [assetStandard]),
+    });
+    [standardImpl] = registryIface.decodeFunctionResult("getAssetStandard", standardResult);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/Asset standard not found/.test(msg)) {
+      throw new Error(`Asset standard ${assetStandard} is not registered on AssetRegistry ${registryAddress}. Register it on-chain first or use a known standard id.`);
+    }
+    throw e;
   }
 
-  logger.info(`DEFAULT_ASSET_STANDARD ${assetStandard} verified on AssetRegistry ${registryAddress} → impl ${standardImpl}`);
+  if (standardImpl === ZeroAddress) {
+    // Defensive: shouldn't be reachable given the revert above, but keep the
+    // check in case the registry contract is ever changed to return zero.
+    throw new Error(`Asset standard ${assetStandard} resolves to zero address on AssetRegistry ${registryAddress}.`);
+  }
+
+  logger.info(`Asset standard ${assetStandard} verified on AssetRegistry ${registryAddress} → impl ${standardImpl}`);
 }

--- a/src/services/finp2p-contract/tokens.ts
+++ b/src/services/finp2p-contract/tokens.ts
@@ -5,6 +5,7 @@ import {
   AssetBind, AssetDenomination, AssetCreationResult, Destination, ExecutionContext,
   ReceiptOperation, Source, Signature, logger, ProofProvider, PluginManager,
 } from "@owneraio/finp2p-nodejs-skeleton-adapter";
+import { keccak256, toUtf8Bytes } from "ethers";
 import { ValidationError } from "@owneraio/finp2p-contracts";
 import { FinP2PClient } from "@owneraio/finp2p-client";
 import {
@@ -48,8 +49,17 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
       logger.debug(`Deployed new token ${tokenAddress} for asset ${assetId}`);
     }
 
+    const requestedStandard = assetBind?.tokenIdentifier?.standard;
+    const responseStandard = requestedStandard ?? this.defaultAssetStandard;
+    if (!responseStandard) {
+      return failedAssetCreation(1, 'No asset standard supplied and DEFAULT_ASSET_STANDARD env not set');
+    }
+    const assetStandardId = requestedStandard
+      ? keccak256(toUtf8Bytes(requestedStandard))
+      : this.defaultAssetStandard!;
+
     try {
-      const txHash = await this.finP2PContract.associateAsset(assetId, tokenAddress, this.defaultAssetStandard);
+      const txHash = await this.finP2PContract.associateAsset(assetId, tokenAddress, assetStandardId);
     } catch (e) {
       logger.error(`Error creating asset: ${e}`);
       if (e instanceof EthereumTransactionError) {
@@ -58,8 +68,6 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
         return failedAssetCreation(1, `${e}`);
       }
     }
-
-    const responseStandard = assetBind?.tokenIdentifier?.standard ?? 'ERC20';
 
     const { chainId, name } = await this.finP2PContract.provider.getNetwork();
     const network = `name: ${name}, chainId: ${chainId}`;

--- a/src/services/finp2p-contract/tokens.ts
+++ b/src/services/finp2p-contract/tokens.ts
@@ -54,9 +54,12 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
     if (!responseStandard) {
       return failedAssetCreation(1, 'No asset standard supplied and DEFAULT_ASSET_STANDARD env not set');
     }
-    const assetStandardId = requestedStandard
-      ? keccak256(toUtf8Bytes(requestedStandard))
-      : this.defaultAssetStandard!;
+    // The basic FINP2POperator's associateAsset takes 2 args; the WithRegistry
+    // variant takes 3 (extra bytes32 assetStandard). Only thread the standard
+    // through when the deployed variant needs it.
+    const assetStandardId = this.finP2PContract.variant === 'with-registry'
+      ? (requestedStandard ? keccak256(toUtf8Bytes(requestedStandard)) : this.defaultAssetStandard!)
+      : undefined;
 
     try {
       const txHash = await this.finP2PContract.associateAsset(assetId, tokenAddress, assetStandardId);

--- a/src/services/finp2p-contract/tokens.ts
+++ b/src/services/finp2p-contract/tokens.ts
@@ -28,7 +28,8 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
   constructor(finP2PContract: FinP2PContract, finP2PClient: FinP2PClient | undefined,
               execDetailsStore: ExecDetailsStore | undefined,
               proofProvider: ProofProvider | undefined,
-              pluginManager: PluginManager | undefined) {
+              pluginManager: PluginManager | undefined,
+              readonly defaultAssetStandard: string | undefined = undefined) {
     super(finP2PContract, finP2PClient, execDetailsStore, proofProvider, pluginManager);
   }
 
@@ -48,7 +49,7 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
     }
 
     try {
-      const txHash = await this.finP2PContract.associateAsset(assetId, tokenAddress);
+      const txHash = await this.finP2PContract.associateAsset(assetId, tokenAddress, this.defaultAssetStandard);
     } catch (e) {
       logger.error(`Error creating asset: ${e}`);
       if (e instanceof EthereumTransactionError) {


### PR DESCRIPTION
## What
Consumes the `FinP2PContract` shim shipped in #287 so the adapter actually benefits from variant detection at runtime.

- Switch construction in [src/config.ts](src/config.ts) from `new FinP2PContract(...)` to `await FinP2PContract.create(...)` — the wrapper now carries the detected variant (`'basic'` | `'with-registry'`).
- Add `DEFAULT_ASSET_STANDARD` env: validated at boot as a `0x`-prefixed bytes32 hex string. Required when the deployed contract is `FINP2POperatorWithRegistry` (its `associateAsset` takes a 3rd `bytes32 assetStandard` arg); ignored by the shim on basic deployments. Failing the validation, or detecting WithRegistry without the env, exits at boot with a clear message.
- Plumb the standard through `FinP2PContractAppConfig` → [src/app.ts:140](src/app.ts#L140) → `TokenServiceImpl` → the `associateAsset` call site in [src/services/finp2p-contract/tokens.ts:51](src/services/finp2p-contract/tokens.ts#L51). Adapter behavior on basic deployments is unchanged (no env set, `'basic'` variant, 2-arg path).

## Why
PR #287 added `FinP2PContract.create()` and routed `associateAsset` based on the detected variant, but the adapter never called the factory and never supplied `assetStandard`. So the published shim was a no-op for the real bug. This PR closes that loop:
- Variant detection now happens at boot, surfaced in logs (`(variant: with-registry)`).
- `associateAsset` calls in finp2p-contract mode pass the env-configured standard through to the contract for WithRegistry, or harmlessly drop it for basic.

## Test plan
- [ ] CI green
- [ ] Manual: basic `FINP2POperator` deployment, no `DEFAULT_ASSET_STANDARD` → adapter boots, asset creation works as before
- [ ] Manual: `FINP2POperatorWithRegistry` deployment, no `DEFAULT_ASSET_STANDARD` → adapter exits at boot with clear message
- [ ] Manual: `FINP2POperatorWithRegistry` deployment, `DEFAULT_ASSET_STANDARD=0x<keccak256("ERC20")>` → adapter boots, asset creation issues the 3-arg associateAsset call