### PR TITLE
Promote FinP2PVariant from union to string enum

### DIFF
--- a/finp2p-contracts/contracts/finp2p/FINP2POperatorWithRegistry.sol
+++ b/finp2p-contracts/contracts/finp2p/FINP2POperatorWithRegistry.sol
@@ -93,6 +93,7 @@ contract FINP2POperatorWithRegistry is AccessControl, FinP2PSignatureVerifier {
     address private escrowWalletAddress;
     mapping(string => Asset) private assets;
     mapping(string => Lock) private locks;
+    mapping(string => address) private credentials;
     address private assetRegistry;
 
     constructor(address admin, address _assetRegistry) {
@@ -130,6 +131,39 @@ contract FINP2POperatorWithRegistry is AccessControl, FinP2PSignatureVerifier {
         require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "FINP2POperatorERC20: must have admin role to set escrow wallet address");
         escrowWalletAddress = _escrowWalletAddress;
     }
+
+    // ---- Credential management ----
+
+    /// @notice Add a credential mapping from finId to wallet address
+    /// @param finId The FinP2P identity
+    /// @param addr The wallet address to associate
+    function addCredential(string calldata finId, address addr) external {
+        require(hasRole(ASSET_MANAGER, _msgSender()), "FINP2POperator: must have asset manager role to add credential");
+        require(addr != address(0), "Wallet address cannot be zero");
+        credentials[finId] = addr;
+    }
+
+    /// @notice Remove a credential mapping
+    /// @param finId The FinP2P identity to remove
+    function removeCredential(string calldata finId) external {
+        require(hasRole(ASSET_MANAGER, _msgSender()), "FINP2POperator: must have asset manager role to remove credential");
+        require(_haveCredential(finId), "Credential not found");
+        delete credentials[finId];
+    }
+
+    /// @notice Get the wallet address for a finId
+    /// @param finId The FinP2P identity
+    /// @return The mapped wallet address
+    function getCredentialAddress(string calldata finId) external view returns (address) {
+        require(_haveCredential(finId), "Credential not found");
+        return credentials[finId];
+    }
+
+    function _haveCredential(string memory finId) internal view returns (bool) {
+        return credentials[finId] != address(0);
+    }
+
+    // ---- Asset management ----
 
     /// @notice Associate an asset with a token address
     /// @param assetId The asset id

--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.15",
+  "version": "0.28.16",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-contracts/src/finp2p.ts
+++ b/finp2p-contracts/src/finp2p.ts
@@ -20,7 +20,10 @@ import { assetTypeToService } from "./mappers";
 
 const ETH_COMPLETED_TRANSACTION_STATUS = 1;
 
-export type FinP2PVariant = 'basic' | 'with-registry';
+export enum FinP2PVariant {
+  Basic = 'basic',
+  WithRegistry = 'with-registry',
+}
 
 /**
  * 3-arg `associateAsset` call data for `FINP2POperatorWithRegistry`. The basic
@@ -47,7 +50,7 @@ export class FinP2PContract extends ContractsManager {
    */
   variant: FinP2PVariant;
 
-  constructor(provider: Provider, signer: Signer, finP2PContractAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier, variant: FinP2PVariant = 'basic') {
+  constructor(provider: Provider, signer: Signer, finP2PContractAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier, variant: FinP2PVariant = FinP2PVariant.Basic) {
     super(provider, signer, logger, confirmationTimeoutMs, gasTier);
     const factory = new ContractFactory<any[], FINP2POperator>(
       FINP2P.abi, FINP2P.bytecode, this.signer
@@ -66,7 +69,7 @@ export class FinP2PContract extends ContractsManager {
    */
   static async create(provider: Provider, signer: Signer, finP2PContractAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier): Promise<FinP2PContract> {
     const c = new FinP2PContract(provider, signer, finP2PContractAddress, logger, confirmationTimeoutMs, gasTier);
-    c.variant = (await c.hasAssetRegistry()) ? 'with-registry' : 'basic';
+    c.variant = (await c.hasAssetRegistry()) ? FinP2PVariant.WithRegistry : FinP2PVariant.Basic;
     logger.info(`FinP2PContract variant detected: ${c.variant} at ${finP2PContractAddress}`);
     return c;
   }
@@ -119,7 +122,7 @@ export class FinP2PContract extends ContractsManager {
   }
 
   async associateAsset(assetId: string, tokenAddress: string, assetStandard?: string) {
-    if (this.variant === 'with-registry') {
+    if (this.variant === FinP2PVariant.WithRegistry) {
       if (!assetStandard) {
         throw new Error(`FINP2POperatorWithRegistry.associateAsset requires a bytes32 assetStandard at ${this.finP2PContractAddress}`);
       }

--- a/finp2p-contracts/test/has-asset-registry.ts
+++ b/finp2p-contracts/test/has-asset-registry.ts
@@ -2,7 +2,7 @@ import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 import { expect } from "chai";
 // @ts-ignore
 import { ethers } from "hardhat";
-import { FinP2PContract, isFunctionMissingError } from "../src/finp2p";
+import { FinP2PContract, FinP2PVariant, isFunctionMissingError } from "../src/finp2p";
 import { Logger } from "../src/adapter-types";
 
 const silentLogger: Logger = {
@@ -48,13 +48,13 @@ describe("FinP2PContract.hasAssetRegistry", function () {
   it("FinP2PContract.create() detects 'basic' variant", async () => {
     const { address, signer } = await loadFixture(deployBasicOperator);
     const wrapper = await FinP2PContract.create(ethers.provider, signer, address, silentLogger);
-    expect(wrapper.variant).to.equal("basic");
+    expect(wrapper.variant).to.equal(FinP2PVariant.Basic);
   });
 
   it("FinP2PContract.create() detects 'with-registry' variant", async () => {
     const { address, signer } = await loadFixture(deployWithRegistry);
     const wrapper = await FinP2PContract.create(ethers.provider, signer, address, silentLogger);
-    expect(wrapper.variant).to.equal("with-registry");
+    expect(wrapper.variant).to.equal(FinP2PVariant.WithRegistry);
   });
 
   it("associateAsset on with-registry requires an assetStandard arg", async () => {

--- a/finp2p-contracts/test/has-asset-registry.ts
+++ b/finp2p-contracts/test/has-asset-registry.ts
@@ -64,6 +64,20 @@ describe("FinP2PContract.hasAssetRegistry", function () {
       /requires a bytes32 assetStandard/,
     );
   });
+
+  it("with-registry supports addCredential / getCredentialAddress / removeCredential", async () => {
+    const { address, signer } = await loadFixture(deployWithRegistry);
+    const wrapper = await FinP2PContract.create(ethers.provider, signer, address, silentLogger);
+    const finId = "test-fin-id-001";
+    const walletAddress = "0x617644165869a17309c3bfcbd05526ae1870e01d";
+
+    await wrapper.addCredential(finId, walletAddress);
+    const resolved = await wrapper.getCredentialAddress(finId);
+    expect(resolved.toLowerCase()).to.equal(walletAddress.toLowerCase());
+
+    await wrapper.removeCredential(finId);
+    await expect(wrapper.getCredentialAddress(finId)).to.be.rejectedWith(/Credential not found/);
+  });
 });
 
 describe("isFunctionMissingError", function () {


### PR DESCRIPTION
## What
Converts \`FinP2PVariant\` in \`@owneraio/finp2p-contracts\` from a string-literal union into a proper string enum.

\`\`\`ts
// Before
export type FinP2PVariant = 'basic' | 'with-registry';

// After
export enum FinP2PVariant {
  Basic = 'basic',
  WithRegistry = 'with-registry',
}
\`\`\`

Bumps the package 0.28.15 → 0.28.16.

## Why
Callers comparing \`variant === 'with-registry'\` against magic strings is brittle (typo-prone, no jump-to-def). A string enum gives type-safe members (\`FinP2PVariant.WithRegistry\`) while keeping the same wire values, so existing \`=== 'basic'\` comparisons still evaluate equal at runtime.

## Follow-up
The adapter PR #288 will bump to \`^0.28.16\` and switch its remaining \`=== 'with-registry'\` comparisons (src/config.ts, scripts/migration.ts, scripts/sync-balances.ts) to use \`FinP2PVariant.WithRegistry\`.

## Test plan
- [ ] CI green
- 10 Hardhat tests pass locally; \`variant\` assertions updated to use enum members.