### PR TITLE
[Fix] Echo bind.standard in createAsset response (finp2p-contract mode)

### DIFF
--- a/src/services/finp2p-contract/tokens.ts
+++ b/src/services/finp2p-contract/tokens.ts
@@ -58,18 +58,18 @@ export class TokenServiceImpl extends CommonServiceImpl implements TokenService 
       }
     }
 
-    // TODO: parse assetMetadata to determine token standard and other details
+    const responseStandard = assetBind?.tokenIdentifier?.standard ?? 'ERC20';
 
     const { chainId, name } = await this.finP2PContract.provider.getNetwork();
-    const network = `name: ${name}, chainId: ${chainId}`; // public or private network?
+    const network = `name: ${name}, chainId: ${chainId}`;
     const finP2POperatorContractAddress = this.finP2PContract.finP2PContractAddress;
     const result: AssetCreationResult = {
-      ledgerIdentifier: { assetIdentifierType: 'CAIP-19', network, tokenId: tokenAddress, standard: 'ERC20' },
+      ledgerIdentifier: { assetIdentifierType: 'CAIP-19', network, tokenId: tokenAddress, standard: responseStandard },
       reference: {
         type: "ledgerReference",
         network,
         address: tokenAddress,
-        tokenStandard: "ERC20",
+        tokenStandard: responseStandard,
         additionalContractDetails: {
           finP2POperatorContractAddress,
           allowanceRequired


### PR DESCRIPTION
## What
`TokenServiceImpl.createAsset` (finp2p-contract mode) was hardcoding `'ERC20'` for both `ledgerIdentifier.standard` and `reference.tokenStandard` in the response — overwriting whatever standard the caller passed in `ledgerAssetBinding.bind.standard`.

Now the response echoes the caller's standard, falling back to `'ERC20'` only when none was supplied.

## Why
OSS-side asset metadata was recording `tokenStandard: 'ERC20'` even when the caller (e.g. the collateral plugin's `depositCustom` flow) asked for `OWNERA_COLLATERAL_REGISTRY`. Downstream consumers reading the asset's `tokenStandard` got the wrong value, masking the actual asset type. Verified on k3d-local6 — caller payload had `standard: "OWNERA_COLLATERAL_REGISTRY"`, but both the OSS and the FinP2P node mapping stored `ERC20`.

## Scope
- Adapter response only — no on-chain change.
- Basic `FINP2POperator`'s `associateAsset` doesn't carry a standard field, so the on-chain side is unaffected.
- Surgical 4-line change in `src/services/finp2p-contract/tokens.ts`.

## Test plan
- [ ] CI green