### PR TITLE
DirectTokenService: skip custody onAssetRegistered in localSubmit mode

### DIFF
--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -11,7 +11,7 @@ export class FireblocksCustodyProvider implements CustodyProvider {
   readonly omnibus?: CustodyWallet;
   readonly rpcProvider;
   readonly gasStation?: GasStation;
-  readonly localSubmit: boolean;
+  readonly keySigningOnly: boolean;
 
   private fireblocksSdk: FireblocksSDK;
   private vaultManagement: ReturnType<typeof createVaultManagementFunctions>;
@@ -32,7 +32,7 @@ export class FireblocksCustodyProvider implements CustodyProvider {
     this.fireblocksSdk = fireblocksSdk;
     this.vaultManagement = vaultManagement;
     this.gasStation = gasStation;
-    this.localSubmit = !!config.localSubmit;
+    this.keySigningOnly = !!config.localSubmit;
   }
 
   static async create(config: FireblocksAppConfig): Promise<FireblocksCustodyProvider> {

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -11,6 +11,7 @@ export class FireblocksCustodyProvider implements CustodyProvider {
   readonly omnibus?: CustodyWallet;
   readonly rpcProvider;
   readonly gasStation?: GasStation;
+  readonly localSubmit: boolean;
 
   private fireblocksSdk: FireblocksSDK;
   private vaultManagement: ReturnType<typeof createVaultManagementFunctions>;
@@ -31,6 +32,7 @@ export class FireblocksCustodyProvider implements CustodyProvider {
     this.fireblocksSdk = fireblocksSdk;
     this.vaultManagement = vaultManagement;
     this.gasStation = gasStation;
+    this.localSubmit = !!config.localSubmit;
   }
 
   static async create(config: FireblocksAppConfig): Promise<FireblocksCustodyProvider> {

--- a/src/services/direct/custody-provider.ts
+++ b/src/services/direct/custody-provider.ts
@@ -12,7 +12,7 @@ export interface CustodyProvider {
   readonly omnibus?: CustodyWallet;
   readonly rpcProvider: Provider;
   readonly gasStation?: GasStation;
-  readonly localSubmit?: boolean;
+  readonly keySigningOnly?: boolean;
 
   resolveWallet(account: string): Promise<CustodyWallet | undefined>;
   /** Create a wallet directly from custody account ID (vault ID / wallet ID). No reverse scan needed. */

--- a/src/services/direct/custody-provider.ts
+++ b/src/services/direct/custody-provider.ts
@@ -12,6 +12,7 @@ export interface CustodyProvider {
   readonly omnibus?: CustodyWallet;
   readonly rpcProvider: Provider;
   readonly gasStation?: GasStation;
+  readonly localSubmit?: boolean;
 
   resolveWallet(account: string): Promise<CustodyWallet | undefined>;
   /** Create a wallet directly from custody account ID (vault ID / wallet ID). No reverse scan needed. */

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -102,8 +102,8 @@ export class DirectTokenService implements TokenService, EscrowService {
         token_standard: result.tokenStandard,
         id: assetId,
       });
-      if (this.custodyProvider.localSubmit) {
-        this.logger.info(`createAsset: skipping custody onAssetRegistered in localSubmit mode (${result.contractAddress})`);
+      if (this.custodyProvider.keySigningOnly) {
+        this.logger.info(`createAsset: skipping custody onAssetRegistered in keySigningOnly mode (${result.contractAddress})`);
       } else {
         await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);
       }
@@ -134,8 +134,8 @@ export class DirectTokenService implements TokenService, EscrowService {
         id: assetId,
       });
 
-      if (this.custodyProvider.localSubmit) {
-        this.logger.info(`createAsset: skipping custody onAssetRegistered in localSubmit mode (${tokenAddress})`);
+      if (this.custodyProvider.keySigningOnly) {
+        this.logger.info(`createAsset: skipping custody onAssetRegistered in keySigningOnly mode (${tokenAddress})`);
       } else if (isErc20) {
         this.logger.info(`createAsset: registering ERC20 token with custody provider (${tokenAddress})`);
         await this.custodyProvider.onAssetRegistered?.(tokenAddress);

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -102,7 +102,11 @@ export class DirectTokenService implements TokenService, EscrowService {
         token_standard: result.tokenStandard,
         id: assetId,
       });
-      await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);
+      if (this.custodyProvider.localSubmit) {
+        this.logger.info(`createAsset: skipping custody onAssetRegistered in localSubmit mode (${result.contractAddress})`);
+      } else {
+        await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);
+      }
 
       return {
         operation: "createAsset",
@@ -130,10 +134,9 @@ export class DirectTokenService implements TokenService, EscrowService {
         id: assetId,
       });
 
-      // onAssetRegistered is custody-side ERC20 whitelisting (Fireblocks/Dfns introspect IERC20Metadata
-      // — name/symbol/decimals — on the contract). Skip it for non-ERC20 standards whose bound
-      // contracts (e.g. CollateralAgreementRegistry) don't implement IERC20Metadata.
-      if (isErc20) {
+      if (this.custodyProvider.localSubmit) {
+        this.logger.info(`createAsset: skipping custody onAssetRegistered in localSubmit mode (${tokenAddress})`);
+      } else if (isErc20) {
         this.logger.info(`createAsset: registering ERC20 token with custody provider (${tokenAddress})`);
         await this.custodyProvider.onAssetRegistered?.(tokenAddress);
       } else {

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -102,11 +102,7 @@ export class DirectTokenService implements TokenService, EscrowService {
         token_standard: result.tokenStandard,
         id: assetId,
       });
-      if (this.custodyProvider.keySigningOnly) {
-        this.logger.info(`createAsset: skipping custody onAssetRegistered in keySigningOnly mode (${result.contractAddress})`);
-      } else {
-        await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);
-      }
+      if (!this.custodyProvider.keySigningOnly) await this.custodyProvider.onAssetRegistered?.(result.contractAddress, symbol);
 
       return {
         operation: "createAsset",
@@ -134,11 +130,9 @@ export class DirectTokenService implements TokenService, EscrowService {
         id: assetId,
       });
 
-      if (this.custodyProvider.keySigningOnly) {
-        this.logger.info(`createAsset: skipping custody onAssetRegistered in keySigningOnly mode (${tokenAddress})`);
-      } else if (isErc20) {
+      if (isErc20) {
         this.logger.info(`createAsset: registering ERC20 token with custody provider (${tokenAddress})`);
-        await this.custodyProvider.onAssetRegistered?.(tokenAddress);
+        if (!this.custodyProvider.keySigningOnly) await this.custodyProvider.onAssetRegistered?.(tokenAddress);
       } else {
         this.logger.info(`createAsset: skipping custody onAssetRegistered for non-ERC20 standard '${requestedStandard}' (${tokenAddress})`);
       }


### PR DESCRIPTION
## Summary
- Adds `localSubmit?: boolean` to the `CustodyProvider` interface and surfaces it from `FireblocksCustodyProvider`.
- Gates `DirectTokenService.createAsset` (both deploy and bind paths) on `custodyProvider.localSubmit` so `onAssetRegistered` is never invoked in localSubmit mode.

## Why
In localSubmit mode the custody provider is intentionally reduced to low-level key-signing APIs; the higher-level services (e.g. Fireblocks `registerNewAsset`) are unavailable. Even though `FireblocksCustodyProvider.onAssetRegistered` already returns early in localSubmit mode, callers should not invoke higher-level flows at all — defense in depth for future providers and clearer intent at the call site.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Deploy path exercised in localSubmit mode: log "skipping custody onAssetRegistered in localSubmit mode" appears; no Fireblocks `registerNewAsset` call
- [ ] Bind path (ERC20) exercised in localSubmit mode: same log, no higher-level call
- [ ] Standard-mode (localSubmit off) preserves prior behavior for both paths