### PR TITLE
ERC20Contract: allow provider-only (signer optional) construction

### DIFF
--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.17",
+  "version": "0.28.18",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-contracts/src/erc20.ts
+++ b/finp2p-contracts/src/erc20.ts
@@ -15,11 +15,11 @@ export class ERC20Contract extends ContractsManager {
 
   tokenAddress: string;
 
-  constructor(provider: Provider, signer: Signer, tokenAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier) {
-    super(provider, signer, logger, confirmationTimeoutMs, gasTier);
+  constructor(provider: Provider, signer: Signer | undefined, tokenAddress: string, logger: Logger, confirmationTimeoutMs?: number, gasTier?: GasTier) {
+    super(provider, (signer ?? provider) as unknown as Signer, logger, confirmationTimeoutMs, gasTier);
     this.tokenAddress = tokenAddress;
     const factory = new ContractFactory<any[], ERC20WithOperator>(
-      ERC20.abi, ERC20.bytecode, this.signer
+      ERC20.abi, ERC20.bytecode, signer ?? provider
     );
     const contract = factory.attach(tokenAddress);
     this.contractInterface = contract.interface;


### PR DESCRIPTION
## Summary
- `ERC20Contract`'s constructor now takes `signer: Signer | undefined`. When omitted, the underlying `ContractFactory` uses `provider` as its runner so read-only calls (`decimals`, `name`, `symbol`, `balanceOf`, `allowance`, `totalSupply`) work without a signer.
- Bumps `@owneraio/finp2p-contracts` to `0.28.18`.

## Why
Callers that only need to read ERC20 metadata (e.g. `DirectTokenService.createAsset` bind path reading `decimals()`) previously had to pass the issuer wallet's signer. In Fireblocks-standard mode that signer is an EIP-1193 provider — every view call round-trips the Fireblocks REST API, which requires JWT signing and can fail for reasons unrelated to the read itself. Making the signer optional lets those call sites use the plain RPC provider directly.

Write methods still require a signer and will fail at runtime if it's missing — surface is unchanged for existing callers.

## Test plan
- [x] `npx hardhat compile` clean
- [x] `npx hardhat test` — 161 passing
- [ ] Adapter follow-up bumps `@owneraio/finp2p-contracts` to `^0.28.18` and switches the bind-path decimals read to `new ERC20Contract(rpcProvider, undefined, ...)`