### PR TITLE
DirectTokenService.createAsset: read ERC20 decimals via rpcProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
-        "@owneraio/finp2p-contracts": "^0.28.15",
+        "@owneraio/finp2p-contracts": "^0.28.18",
         "@owneraio/finp2p-ethereum-collateral": "^0.28.21",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.15",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.15/156632473a311791eefa378673d0d80080cb8f70",
-      "integrity": "sha512-s0Z6arons28cYCO6jlqCVIgMTlOOV8L8ZkMzGjp0fmR0JQIdCIJ2ME/OATB389myw1U9KGpEH9agW+WhxHGcFA==",
+      "version": "0.28.18",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.18/c736ac87b43ddeb537062103e21c49fd9168152a",
+      "integrity": "sha512-9FNYRQDOBE0lYEhZmO0zuI8ODgwR7l4y+a3ZMlsNzo/Y4WKqBhxHmoLbERrIhTMFLvm19/QXZSlIy2kVu6Iz3A==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "0.28.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
-    "@owneraio/finp2p-contracts": "^0.28.15",
+    "@owneraio/finp2p-contracts": "^0.28.18",
     "@owneraio/finp2p-ethereum-collateral": "^0.28.21",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",

--- a/src/integrations/dfns/provider.ts
+++ b/src/integrations/dfns/provider.ts
@@ -27,7 +27,7 @@ export class DfnsCustodyProvider implements CustodyProvider {
     this.issuer = issuer;
     this.escrow = escrow;
     this.omnibus = omnibus;
-    this.rpcProvider = config.provider;
+    this.rpcProvider = this.issuer.provider;
     this.dfnsClient = dfnsClient;
     this.addressToWalletId = addressToWalletId;
     this.gasStation = gasStation;

--- a/src/integrations/fireblocks/provider.ts
+++ b/src/integrations/fireblocks/provider.ts
@@ -27,7 +27,7 @@ export class FireblocksCustodyProvider implements CustodyProvider {
     this.issuer = issuer;
     this.escrow = escrow;
     this.omnibus = omnibus;
-    this.rpcProvider = config.provider;
+    this.rpcProvider = this.issuer.provider;
     this.fireblocksSdk = fireblocksSdk;
     this.vaultManagement = vaultManagement;
     this.gasStation = gasStation;

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -111,13 +111,12 @@ export class DirectTokenService implements TokenService, EscrowService {
       };
     } else {
       const tokenAddress = assetBind.tokenIdentifier.tokenId;
-      const wallet = this.custodyProvider.issuer;
       this.logger.info(`createAsset: bind path — assetId=${assetId} standard=${requestedStandard} tokenAddress=${tokenAddress} network=${assetBind.tokenIdentifier.network ?? defaultNetwork}`);
 
       let decimals = 0;
       if (isErc20) {
         this.logger.info(`createAsset: reading ERC20 decimals from ${tokenAddress}`);
-        const erc20 = new ERC20Contract(wallet.provider, wallet.signer, tokenAddress, this.logger);
+        const erc20 = new ERC20Contract(this.custodyProvider.rpcProvider, undefined, tokenAddress, this.logger);
         decimals = Number(await erc20.decimals());
         this.logger.info(`createAsset: ERC20 decimals=${decimals} for ${tokenAddress}`);
       } else {


### PR DESCRIPTION
## Summary
- Bind-path `decimals()` read in `DirectTokenService.createAsset` now goes through `custodyProvider.rpcProvider` with **no signer**, using the optional-signer `ERC20Contract` shipped in `@owneraio/finp2p-contracts@0.28.18` (#299).
- `CustodyProvider.rpcProvider` is now derived from the issuer wallet's provider inside each concrete implementation, not from raw `config.provider`. Callers treat it as a read-only view provider and don't need to know about `LOCAL_SUBMIT`.
- Bumps `@owneraio/finp2p-contracts` to `^0.28.18`.

## Why
Asset binding is metadata + a `decimals()` read — no signing surface. The old call site used the issuer wallet's `signer` as the runner; ethers v6 populates `from` on view calls by calling `signer.getAddress()`, which on `FireblocksRawSigner` hits `getDepositAddresses` and requires Fireblocks JWT signing. On `sandbox-mt1/hedera-integration/testneterc20-0` (`LOCAL_SUBMIT=true`) that surfaced the credential-shape failure — `secretOrPrivateKey must be an asymmetric key when using RS256` inside `ApiTokenProvider.signJwt` — during `createAsset`, even though LOCAL_SUBMIT mode is supposed to keep Fireblocks out of view calls. Dropping the signer breaks that path.

For standard-mode Fireblocks (`LOCAL_SUBMIT=false`), `rpcProvider` is still the issuer wallet's EIP-1193 provider — `decimals()` still routes through the Fireblocks REST bridge, which is fine there because standard-mode creds work. This PR does **not** move Fireblocks off the stack in standard mode; it removes the signer-triggered auth call that fires spuriously in LOCAL_SUBMIT.

## Related
- Depends on #299 (`ERC20Contract` signer optional) — merged, `finp2p-contracts@0.28.18` published
- Sister PR #300 adds the Fireblocks credentials probe that pinpointed the mangled-PEM defect on the affected pod

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Redeploy `testneterc20-0` with this image + valid Fireblocks creds — expect `createAsset` bind path to succeed without Fireblocks signing being invoked
- [ ] Standard-mode Fireblocks (non-LOCAL_SUBMIT) — behavior unchanged; view calls continue routing through the wallet's EIP-1193 provider