### PR TITLE
DirectTokenService.redeem: burn from source finId's mapped address

### DIFF
--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -218,13 +218,13 @@ export class DirectTokenService implements TokenService, EscrowService {
     try {
       const asset = await getAssetFromDb(this.assetStore, ast.assetId);
       const standard = tokenStandardRegistry.resolve(asset.tokenStandard);
-      const escrowAddress = await this.custodyProvider.escrow.signer.getAddress();
+      const sourceAddress = await this.resolveAddress(sourceFinId);
       const wallet = this.custodyProvider.issuer;
       const amount = parseUnits(quantity, asset.decimals);
 
       await this.ensureGas(wallet);
       const opCtx = buildOperationContext(ast, signature, exCtx, operationId);
-      const result = await standard.burn(wallet, asset, escrowAddress, amount, this.logger, opCtx);
+      const result = await standard.burn(wallet, asset, sourceAddress, amount, this.logger, opCtx);
       const source: Source = { finId: sourceFinId };
       return resultToReceipt(result, ast, "redeem", quantity, source, undefined, exCtx, operationId);
     } catch (e) {


### PR DESCRIPTION
## Summary
- `DirectTokenService.redeem` now resolves the burn source via `accountMapping.resolveAccount(sourceFinId)` instead of the env-hardcoded `custodyProvider.escrow` address.

## Why
Live failure on `sandbox-mt1/hedera-integration/testneterc20-0` for plan `hedera:106:2851026b-cda1-4d1b-a4d3-4f6da9e3c5f8`. The router sent `POST /api/assets/redeem` with `source.finId=02f6aa12…5cd00` (mapped in `testneterc20.account_mappings` to vault 230 / `0x542dfa…f928`). The old redeem code path burned from `custodyProvider.escrow.signer.getAddress()` — which is `ASSET_ESCROW_CUSTODY_ACCOUNT_ID=1` on that pod — and blew up with `No deposit address found for vault 1 asset ETH_TEST5` at `FireblocksRawSigner.getAddress`. The mapping row for the actual source was never consulted.

The `hold`/`release` flows for held-then-released tokens live in the separate `release`/`rollback` methods, which continue to use `custodyProvider.escrow`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Re-run the failing plan against a rebuilt image — expect `standard.burn` to target `0x542dfa…f928` (the mapped source address) instead of the escrow deposit address, so the Fireblocks pre-lookup on vault 1 no longer fires
- [ ] Existing plans where the redeem follows a `hold` on the same adapter's asset — those use `/assets/release`, not `/assets/redeem`, so this change doesn't touch them