### PR TITLE
ERC20WithOperator: conform burn to OpenZeppelin ERC20Burnable

### DIFF
--- a/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
+++ b/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
@@ -371,7 +371,7 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
         uint256 balance = IERC20(asset.tokenAddress).balanceOf(from);
         require(balance >= tokenAmount, "Not sufficient balance to burn");
-        Burnable(asset.tokenAddress).burn(from, tokenAmount);
+        Burnable(asset.tokenAddress).burnFrom(from, tokenAmount);
     }
 
     function _extractDetails(

--- a/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
+++ b/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
@@ -7,7 +7,7 @@ import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {OperationParams, LegType, PrimaryType, Phase, ReleaseType} from "@owneraio/finp2p-ethereum-token-standard/contracts/OperationParams.sol";
 import {FinIdUtils} from "../utils/finp2p/FinIdUtils.sol";
 import {FinP2PSignatureVerifier} from "../utils/finp2p/FinP2PSignatureVerifier.sol";
-import {Burnable} from "../utils/erc20/Burnable.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import {Mintable} from "../utils/erc20/Mintable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -371,7 +371,7 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
         uint256 balance = IERC20(asset.tokenAddress).balanceOf(from);
         require(balance >= tokenAmount, "Not sufficient balance to burn");
-        Burnable(asset.tokenAddress).burnFrom(from, tokenAmount);
+        ERC20Burnable(asset.tokenAddress).burnFrom(from, tokenAmount);
     }
 
     function _extractDetails(

--- a/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
+++ b/finp2p-contracts/contracts/finp2p/FINP2POperator.sol
@@ -7,7 +7,7 @@ import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {OperationParams, LegType, PrimaryType, Phase, ReleaseType} from "@owneraio/finp2p-ethereum-token-standard/contracts/OperationParams.sol";
 import {FinIdUtils} from "../utils/finp2p/FinIdUtils.sol";
 import {FinP2PSignatureVerifier} from "../utils/finp2p/FinP2PSignatureVerifier.sol";
-import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {Burnable} from "../utils/erc20/Burnable.sol";
 import {Mintable} from "../utils/erc20/Mintable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -371,7 +371,7 @@ contract FINP2POperator is AccessControl, FinP2PSignatureVerifier {
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
         uint256 balance = IERC20(asset.tokenAddress).balanceOf(from);
         require(balance >= tokenAmount, "Not sufficient balance to burn");
-        ERC20Burnable(asset.tokenAddress).burnFrom(from, tokenAmount);
+        Burnable(asset.tokenAddress).burnFrom(from, tokenAmount);
     }
 
     function _extractDetails(

--- a/finp2p-contracts/contracts/token/ERC20/ERC20.sol
+++ b/finp2p-contracts/contracts/token/ERC20/ERC20.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {ERC20 as OZERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+
+/**
+ * @dev Stock ERC20 built entirely on top of OpenZeppelin ({ERC20} + {ERC20Burnable} +
+ * {AccessControl}). Mirrors the public surface of `ERC20WithOperator` (same selectors
+ * for name/symbol/decimals/transfer/transferFrom/approve/allowance/balanceOf/
+ * totalSupply/mint/burn/burnFrom/grantMinterTo/grantOperatorTo) so callers can point
+ * at either contract, but this variant has no operator-role bypasses — `transferFrom`
+ * and `burnFrom` both require a standard ERC20 allowance regardless of caller role.
+ */
+contract ERC20 is OZERC20, ERC20Burnable, AccessControl {
+
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+
+    uint8 private immutable _decimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_, address operator) OZERC20(name_, symbol_) {
+        _grantRole(DEFAULT_ADMIN_ROLE, _msgSender());
+        _grantRole(MINTER_ROLE, operator);
+        _grantRole(OPERATOR_ROLE, operator);
+        _decimals = decimals_;
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) public {
+        require(hasRole(MINTER_ROLE, _msgSender()), "ERC20: must have minter role to mint");
+        _mint(to, amount);
+    }
+
+    function grantMinterTo(address account) public {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "ERC20: must have admin role to grant minter");
+        grantRole(MINTER_ROLE, account);
+    }
+
+    function grantOperatorTo(address account) public {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "ERC20: must have admin role to grant operator");
+        grantRole(OPERATOR_ROLE, account);
+    }
+}

--- a/finp2p-contracts/contracts/token/ERC20/ERC20WithOperator.sol
+++ b/finp2p-contracts/contracts/token/ERC20/ERC20WithOperator.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.20;
 
 import "../../utils/erc20/Mintable.sol";
-import "../../utils/erc20/Burnable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -16,7 +15,7 @@ import "@openzeppelin/contracts/utils/Context.sol";
  * It also includes an operator role that allows operators to bypass the allowance check and act on behalf of the token owner.
  *
  */
-contract ERC20WithOperator is Context, IERC20, IERC20Metadata, Mintable, Burnable, AccessControl {
+contract ERC20WithOperator is Context, IERC20, IERC20Metadata, Mintable, AccessControl {
 
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
@@ -404,24 +403,10 @@ contract ERC20WithOperator is Context, IERC20, IERC20Metadata, Mintable, Burnabl
         _mint(to, amount);
     }
 
-    /**
-     * @dev Destroys `value` tokens from the caller.
-     *
-     * See {ERC20-_burn}. Matches OpenZeppelin's ERC20Burnable.burn(uint256).
-     */
     function burn(uint256 value) public virtual {
         _burn(_msgSender(), value);
     }
 
-    /**
-     * @dev Destroys `value` tokens from `account`, deducting from the caller's
-     * allowance. Matches OpenZeppelin's ERC20Burnable.burnFrom(address, uint256),
-     * with one documented extension: callers holding MINTER_ROLE bypass the
-     * allowance check — the FinP2P operator/issuer uses this to burn on
-     * redeem without requiring a per-holder approve.
-     *
-     * See {ERC20-_burn} and {ERC20-allowance}.
-     */
     function burnFrom(address account, uint256 value) public virtual {
         if (!hasRole(MINTER_ROLE, _msgSender())) {
             _spendAllowance(account, _msgSender(), value);

--- a/finp2p-contracts/contracts/token/ERC20/ERC20WithOperator.sol
+++ b/finp2p-contracts/contracts/token/ERC20/ERC20WithOperator.sol
@@ -405,21 +405,28 @@ contract ERC20WithOperator is Context, IERC20, IERC20Metadata, Mintable, Burnabl
     }
 
     /**
-     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
-     * allowance.
+     * @dev Destroys `value` tokens from the caller.
+     *
+     * See {ERC20-_burn}. Matches OpenZeppelin's ERC20Burnable.burn(uint256).
+     */
+    function burn(uint256 value) public virtual {
+        _burn(_msgSender(), value);
+    }
+
+    /**
+     * @dev Destroys `value` tokens from `account`, deducting from the caller's
+     * allowance. Matches OpenZeppelin's ERC20Burnable.burnFrom(address, uint256),
+     * with one documented extension: callers holding MINTER_ROLE bypass the
+     * allowance check — the FinP2P operator/issuer uses this to burn on
+     * redeem without requiring a per-holder approve.
      *
      * See {ERC20-_burn} and {ERC20-allowance}.
-     *
-     * Requirements:
-     *
-     * - the caller must have allowance for ``accounts``'s tokens of at least
-     * `amount`.
      */
-    function burn(address account, uint256 amount) public virtual {
+    function burnFrom(address account, uint256 value) public virtual {
         if (!hasRole(MINTER_ROLE, _msgSender())) {
-            _spendAllowance(account, _msgSender(), amount);
+            _spendAllowance(account, _msgSender(), value);
         }
-        _burn(account, amount);
+        _burn(account, value);
     }
 
 }

--- a/finp2p-contracts/contracts/token/ERC20/ERC20WithOperator.sol
+++ b/finp2p-contracts/contracts/token/ERC20/ERC20WithOperator.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.20;
 
 import "../../utils/erc20/Mintable.sol";
+import "../../utils/erc20/Burnable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -15,7 +16,7 @@ import "@openzeppelin/contracts/utils/Context.sol";
  * It also includes an operator role that allows operators to bypass the allowance check and act on behalf of the token owner.
  *
  */
-contract ERC20WithOperator is Context, IERC20, IERC20Metadata, Mintable, AccessControl {
+contract ERC20WithOperator is Context, IERC20, IERC20Metadata, Mintable, Burnable, AccessControl {
 
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");

--- a/finp2p-contracts/contracts/token/ERC20/ERC20WithOperator.sol
+++ b/finp2p-contracts/contracts/token/ERC20/ERC20WithOperator.sol
@@ -61,6 +61,17 @@ contract ERC20WithOperator is Context, IERC20, IERC20Metadata, Mintable, Burnabl
     }
 
     /**
+     * @dev Variant marker. Present on `ERC20WithOperator`; absent on the plain
+     * `ERC20` sibling. Callers probe via a raw `eth_call` — success → this
+     * variant; function-missing revert → plain `ERC20` (or something else).
+     * The two variants otherwise share selectors and are indistinguishable
+     * by ABI alone.
+     */
+    function hasOperatorBypass() external pure returns (bool) {
+        return true;
+    }
+
+    /**
      * @dev Returns the name of the token.
      */
     function name() public view virtual override returns (string memory) {

--- a/finp2p-contracts/contracts/utils/erc20/Burnable.sol
+++ b/finp2p-contracts/contracts/utils/erc20/Burnable.sol
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
-
-interface Burnable {
-    function burn(uint256 value) external;
-    function burnFrom(address account, uint256 value) external;
-}

--- a/finp2p-contracts/contracts/utils/erc20/Burnable.sol
+++ b/finp2p-contracts/contracts/utils/erc20/Burnable.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+interface Burnable {
+    function burn(uint256 value) external;
+    function burnFrom(address account, uint256 value) external;
+}

--- a/finp2p-contracts/contracts/utils/erc20/Burnable.sol
+++ b/finp2p-contracts/contracts/utils/erc20/Burnable.sol
@@ -2,5 +2,6 @@
 pragma solidity ^0.8.0;
 
 interface Burnable {
-    function burn(address account, uint256 amount) external;
+    function burn(uint256 value) external;
+    function burnFrom(address account, uint256 value) external;
 }

--- a/finp2p-contracts/contracts/utils/erc20/ERC20Standard.sol
+++ b/finp2p-contracts/contracts/utils/erc20/ERC20Standard.sol
@@ -7,7 +7,7 @@ import "@owneraio/finp2p-ethereum-token-standard/contracts/AssetStandard.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
-import {Burnable} from "./Burnable.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import {Mintable} from "./Mintable.sol";
 
 contract ERC20Standard is AssetStandard, AccessControl {
@@ -68,7 +68,7 @@ contract ERC20Standard is AssetStandard, AccessControl {
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
         uint256 balance = IERC20(tokenAddress).balanceOf(from);
         require(balance >= tokenAmount, "Not sufficient balance to burn");
-        Burnable(tokenAddress).burnFrom(from, tokenAmount);
+        ERC20Burnable(tokenAddress).burnFrom(from, tokenAmount);
     }
 
 }

--- a/finp2p-contracts/contracts/utils/erc20/ERC20Standard.sol
+++ b/finp2p-contracts/contracts/utils/erc20/ERC20Standard.sol
@@ -68,7 +68,7 @@ contract ERC20Standard is AssetStandard, AccessControl {
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
         uint256 balance = IERC20(tokenAddress).balanceOf(from);
         require(balance >= tokenAmount, "Not sufficient balance to burn");
-        Burnable(tokenAddress).burn(from, tokenAmount);
+        Burnable(tokenAddress).burnFrom(from, tokenAmount);
     }
 
 }

--- a/finp2p-contracts/contracts/utils/erc20/ERC20Standard.sol
+++ b/finp2p-contracts/contracts/utils/erc20/ERC20Standard.sol
@@ -7,7 +7,7 @@ import "@owneraio/finp2p-ethereum-token-standard/contracts/AssetStandard.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
-import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {Burnable} from "./Burnable.sol";
 import {Mintable} from "./Mintable.sol";
 
 contract ERC20Standard is AssetStandard, AccessControl {
@@ -68,7 +68,7 @@ contract ERC20Standard is AssetStandard, AccessControl {
         uint256 tokenAmount = quantity.stringToUint(tokenDecimals);
         uint256 balance = IERC20(tokenAddress).balanceOf(from);
         require(balance >= tokenAmount, "Not sufficient balance to burn");
-        ERC20Burnable(tokenAddress).burnFrom(from, tokenAmount);
+        Burnable(tokenAddress).burnFrom(from, tokenAmount);
     }
 
 }

--- a/finp2p-contracts/package.json
+++ b/finp2p-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-contracts",
-  "version": "0.28.18",
+  "version": "0.28.19",
   "description": "",
   "homepage": "https://ownera.io/",
   "main": "./dist/index.js",

--- a/finp2p-contracts/src/erc20.ts
+++ b/finp2p-contracts/src/erc20.ts
@@ -3,6 +3,7 @@ import { Logger } from "./adapter-types";
 import { BigNumberish, ContractFactory, Interface, keccak256, Provider, Signer, toUtf8Bytes } from "ethers";
 import { ERC20WithOperator } from "../typechain-types";
 import ERC20 from "../artifacts/contracts/token/ERC20/ERC20WithOperator.sol/ERC20WithOperator.json";
+import { isFunctionMissingError } from "./finp2p";
 
 export const OPERATOR_ROLE = keccak256(toUtf8Bytes('OPERATOR_ROLE'));
 export const MINTER_ROLE = keccak256(toUtf8Bytes('MINTER_ROLE'));
@@ -84,5 +85,20 @@ export class ERC20Contract extends ContractsManager {
 
   async grantMinterTo(address: string) {
     return this.erc20.grantMinterTo(address);
+  }
+
+  async hasOperatorBypass(): Promise<boolean> {
+    const probe = new Interface(["function hasOperatorBypass() pure returns (bool)"]);
+    try {
+      const result = await this.provider.call({
+        to: this.tokenAddress,
+        data: probe.encodeFunctionData("hasOperatorBypass", []),
+      });
+      const [flag] = probe.decodeFunctionResult("hasOperatorBypass", result);
+      return !!flag;
+    } catch (e) {
+      if (isFunctionMissingError(e)) return false;
+      throw e;
+    }
   }
 }

--- a/finp2p-contracts/src/erc20.ts
+++ b/finp2p-contracts/src/erc20.ts
@@ -66,8 +66,12 @@ export class ERC20Contract extends ContractsManager {
     return this.erc20.transferFrom(fromAddress, toAddress, quantity);
   }
 
-  async burn(fromAddress: string, quantity: BigNumberish) {
-    return this.erc20.burn(fromAddress, quantity);
+  async burn(quantity: BigNumberish) {
+    return this.erc20.burn(quantity);
+  }
+
+  async burnFrom(fromAddress: string, quantity: BigNumberish) {
+    return this.erc20.burnFrom(fromAddress, quantity);
   }
 
   async hasRole(role: string, address: string) {

--- a/finp2p-contracts/test/erc20-with-operator.ts
+++ b/finp2p-contracts/test/erc20-with-operator.ts
@@ -1,0 +1,131 @@
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { expect } from "chai";
+// @ts-ignore
+import { ethers } from "hardhat";
+import { ERC20WithOperator } from "../typechain-types";
+
+describe("ERC20WithOperator", function() {
+
+  async function deployFixture() {
+    const [deployer, operator, alice, bob, mallory] = await ethers.getSigners();
+    const factory = await ethers.getContractFactory("ERC20WithOperator");
+    const token = (await factory.deploy("Test", "TST", 6, operator.address)) as unknown as ERC20WithOperator;
+
+    // seed some balance for alice: operator holds MINTER_ROLE and mints to alice.
+    await token.connect(operator).mint(alice.address, 1000);
+
+    return { token, deployer, operator, alice, bob, mallory };
+  }
+
+  describe("burn(uint256)", function() {
+
+    it("burns from the caller when the caller has balance", async () => {
+      const { token, alice } = await loadFixture(deployFixture);
+      await token.connect(alice).burn(400);
+      expect(await token.balanceOf(alice.address)).to.equal(600);
+      expect(await token.totalSupply()).to.equal(600);
+    });
+
+    it("reverts when the caller has insufficient balance", async () => {
+      const { token, bob } = await loadFixture(deployFixture);
+      await expect(token.connect(bob).burn(1)).to.be.revertedWith("ERC20: burn amount exceeds balance");
+    });
+
+    it("emits Transfer to the zero address", async () => {
+      const { token, alice } = await loadFixture(deployFixture);
+      await expect(token.connect(alice).burn(100))
+        .to.emit(token, "Transfer")
+        .withArgs(alice.address, ethers.ZeroAddress, 100);
+    });
+  });
+
+  describe("burnFrom(address, uint256)", function() {
+
+    it("reverts when a non-operator caller has no allowance", async () => {
+      const { token, alice, mallory } = await loadFixture(deployFixture);
+      await expect(token.connect(mallory).burnFrom(alice.address, 1))
+        .to.be.revertedWith("ERC20: insufficient allowance");
+    });
+
+    it("succeeds when a non-operator caller has sufficient allowance, and consumes the allowance", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await token.connect(alice).approve(bob.address, 300);
+
+      await token.connect(bob).burnFrom(alice.address, 200);
+
+      expect(await token.balanceOf(alice.address)).to.equal(800);
+      expect(await token.totalSupply()).to.equal(800);
+      expect(await token.allowance(alice.address, bob.address)).to.equal(100);
+    });
+
+    it("reverts when non-operator allowance is insufficient", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await token.connect(alice).approve(bob.address, 100);
+      await expect(token.connect(bob).burnFrom(alice.address, 200))
+        .to.be.revertedWith("ERC20: insufficient allowance");
+    });
+
+    it("bypasses allowance when the caller holds MINTER_ROLE (operator burn on redeem)", async () => {
+      const { token, operator, alice } = await loadFixture(deployFixture);
+      expect(await token.allowance(alice.address, operator.address)).to.equal(0);
+
+      await token.connect(operator).burnFrom(alice.address, 500);
+
+      expect(await token.balanceOf(alice.address)).to.equal(500);
+      expect(await token.totalSupply()).to.equal(500);
+      // no allowance was set, and none was consumed
+      expect(await token.allowance(alice.address, operator.address)).to.equal(0);
+    });
+
+    it("still reverts when the target has insufficient balance, even for MINTER_ROLE caller", async () => {
+      const { token, operator, alice } = await loadFixture(deployFixture);
+      await expect(token.connect(operator).burnFrom(alice.address, 5000))
+        .to.be.revertedWith("ERC20: burn amount exceeds balance");
+    });
+
+    it("reverts on burnFrom(address(0), _)", async () => {
+      const { token, operator } = await loadFixture(deployFixture);
+      await expect(token.connect(operator).burnFrom(ethers.ZeroAddress, 1))
+        .to.be.revertedWith("ERC20: burn from the zero address");
+    });
+
+    it("emits Transfer(account, address(0), value)", async () => {
+      const { token, operator, alice } = await loadFixture(deployFixture);
+      await expect(token.connect(operator).burnFrom(alice.address, 50))
+        .to.emit(token, "Transfer")
+        .withArgs(alice.address, ethers.ZeroAddress, 50);
+    });
+  });
+
+  describe("mint(address, uint256)", function() {
+
+    it("reverts when caller lacks MINTER_ROLE", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await expect(token.connect(alice).mint(bob.address, 1))
+        .to.be.revertedWith("ERC20WithOperator: must have minter role to mint");
+    });
+
+    it("succeeds for MINTER_ROLE holder", async () => {
+      const { token, operator, bob } = await loadFixture(deployFixture);
+      await token.connect(operator).mint(bob.address, 42);
+      expect(await token.balanceOf(bob.address)).to.equal(42);
+    });
+  });
+
+  describe("transferFrom operator bypass (regression)", function() {
+
+    it("bypasses allowance when spender has OPERATOR_ROLE", async () => {
+      const { token, operator, alice, bob } = await loadFixture(deployFixture);
+      // operator was granted OPERATOR_ROLE at deploy — no explicit approve needed
+      await token.connect(operator).transferFrom(alice.address, bob.address, 100);
+      expect(await token.balanceOf(alice.address)).to.equal(900);
+      expect(await token.balanceOf(bob.address)).to.equal(100);
+    });
+
+    it("requires allowance for non-operator spenders", async () => {
+      const { token, alice, bob, mallory } = await loadFixture(deployFixture);
+      await expect(token.connect(mallory).transferFrom(alice.address, bob.address, 1))
+        .to.be.revertedWith("ERC20: insufficient allowance");
+    });
+  });
+});

--- a/finp2p-contracts/test/erc20-with-operator.ts
+++ b/finp2p-contracts/test/erc20-with-operator.ts
@@ -112,6 +112,14 @@ describe("ERC20WithOperator", function() {
     });
   });
 
+  describe("hasOperatorBypass() variant marker", function() {
+
+    it("returns true on ERC20WithOperator", async () => {
+      const { token } = await loadFixture(deployFixture);
+      expect(await token.hasOperatorBypass()).to.equal(true);
+    });
+  });
+
   describe("transferFrom operator bypass (regression)", function() {
 
     it("bypasses allowance when spender has OPERATOR_ROLE", async () => {

--- a/finp2p-contracts/test/erc20.ts
+++ b/finp2p-contracts/test/erc20.ts
@@ -1,0 +1,169 @@
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { expect } from "chai";
+// @ts-ignore
+import { ethers } from "hardhat";
+import { ERC20 } from "../typechain-types";
+
+describe("ERC20 (pure OpenZeppelin)", function() {
+
+  async function deployFixture() {
+    const [deployer, operator, alice, bob, mallory] = await ethers.getSigners();
+    const factory = await ethers.getContractFactory("contracts/token/ERC20/ERC20.sol:ERC20");
+    const token = (await factory.deploy("Test", "TST", 6, operator.address)) as unknown as ERC20;
+
+    // seed alice with balance so we have something to burn/transfer.
+    await token.connect(operator).mint(alice.address, 1000);
+
+    return { token, deployer, operator, alice, bob, mallory };
+  }
+
+  describe("metadata", function() {
+
+    it("exposes configured name / symbol / decimals", async () => {
+      const { token } = await loadFixture(deployFixture);
+      expect(await token.name()).to.equal("Test");
+      expect(await token.symbol()).to.equal("TST");
+      expect(await token.decimals()).to.equal(6);
+    });
+  });
+
+  describe("burn(uint256)", function() {
+
+    it("burns from the caller when the caller has balance", async () => {
+      const { token, alice } = await loadFixture(deployFixture);
+      await token.connect(alice).burn(400);
+      expect(await token.balanceOf(alice.address)).to.equal(600);
+      expect(await token.totalSupply()).to.equal(600);
+    });
+
+    it("reverts when the caller has insufficient balance", async () => {
+      const { token, bob } = await loadFixture(deployFixture);
+      await expect(token.connect(bob).burn(1)).to.be.reverted;
+    });
+
+    it("emits Transfer to the zero address", async () => {
+      const { token, alice } = await loadFixture(deployFixture);
+      await expect(token.connect(alice).burn(100))
+        .to.emit(token, "Transfer")
+        .withArgs(alice.address, ethers.ZeroAddress, 100);
+    });
+  });
+
+  describe("burnFrom(address, uint256)", function() {
+
+    it("reverts when a non-operator caller has no allowance", async () => {
+      const { token, alice, mallory } = await loadFixture(deployFixture);
+      await expect(token.connect(mallory).burnFrom(alice.address, 1))
+        .to.be.reverted;
+    });
+
+    it("succeeds with allowance and consumes it", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await token.connect(alice).approve(bob.address, 300);
+
+      await token.connect(bob).burnFrom(alice.address, 200);
+
+      expect(await token.balanceOf(alice.address)).to.equal(800);
+      expect(await token.totalSupply()).to.equal(800);
+      expect(await token.allowance(alice.address, bob.address)).to.equal(100);
+    });
+
+    it("reverts when allowance is insufficient", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await token.connect(alice).approve(bob.address, 100);
+      await expect(token.connect(bob).burnFrom(alice.address, 200))
+        .to.be.reverted;
+    });
+
+    it("does NOT bypass allowance for MINTER_ROLE (differs from ERC20WithOperator)", async () => {
+      const { token, operator, alice } = await loadFixture(deployFixture);
+      expect(await token.hasRole(await token.MINTER_ROLE(), operator.address)).to.equal(true);
+      expect(await token.allowance(alice.address, operator.address)).to.equal(0);
+
+      await expect(token.connect(operator).burnFrom(alice.address, 1))
+        .to.be.reverted;
+    });
+
+    it("emits Transfer(account, address(0), value)", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await token.connect(alice).approve(bob.address, 50);
+      await expect(token.connect(bob).burnFrom(alice.address, 50))
+        .to.emit(token, "Transfer")
+        .withArgs(alice.address, ethers.ZeroAddress, 50);
+    });
+  });
+
+  describe("transferFrom(from, to, amount)", function() {
+
+    it("does NOT bypass allowance for OPERATOR_ROLE (differs from ERC20WithOperator)", async () => {
+      const { token, operator, alice, bob } = await loadFixture(deployFixture);
+      expect(await token.hasRole(await token.OPERATOR_ROLE(), operator.address)).to.equal(true);
+      expect(await token.allowance(alice.address, operator.address)).to.equal(0);
+
+      await expect(token.connect(operator).transferFrom(alice.address, bob.address, 1))
+        .to.be.reverted;
+    });
+
+    it("succeeds with a standard allowance and consumes it", async () => {
+      const { token, alice, bob, mallory } = await loadFixture(deployFixture);
+      await token.connect(alice).approve(mallory.address, 300);
+      await token.connect(mallory).transferFrom(alice.address, bob.address, 200);
+
+      expect(await token.balanceOf(alice.address)).to.equal(800);
+      expect(await token.balanceOf(bob.address)).to.equal(200);
+      expect(await token.allowance(alice.address, mallory.address)).to.equal(100);
+    });
+  });
+
+  describe("mint(address, uint256)", function() {
+
+    it("reverts when caller lacks MINTER_ROLE", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await expect(token.connect(alice).mint(bob.address, 1))
+        .to.be.revertedWith("ERC20: must have minter role to mint");
+    });
+
+    it("succeeds for MINTER_ROLE holder", async () => {
+      const { token, operator, bob } = await loadFixture(deployFixture);
+      await token.connect(operator).mint(bob.address, 42);
+      expect(await token.balanceOf(bob.address)).to.equal(42);
+    });
+  });
+
+  describe("role administration", function() {
+
+    it("deployer holds DEFAULT_ADMIN_ROLE; operator holds MINTER + OPERATOR", async () => {
+      const { token, deployer, operator } = await loadFixture(deployFixture);
+      expect(await token.hasRole(await token.DEFAULT_ADMIN_ROLE(), deployer.address)).to.equal(true);
+      expect(await token.hasRole(await token.MINTER_ROLE(), operator.address)).to.equal(true);
+      expect(await token.hasRole(await token.OPERATOR_ROLE(), operator.address)).to.equal(true);
+    });
+
+    it("grantMinterTo requires admin", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await expect(token.connect(alice).grantMinterTo(bob.address))
+        .to.be.revertedWith("ERC20: must have admin role to grant minter");
+    });
+
+    it("grantMinterTo succeeds for admin and the granted account can mint", async () => {
+      const { token, deployer, bob, alice } = await loadFixture(deployFixture);
+      await token.connect(deployer).grantMinterTo(bob.address);
+      await token.connect(bob).mint(alice.address, 10);
+      expect(await token.balanceOf(alice.address)).to.equal(1010);
+    });
+
+    it("grantOperatorTo requires admin", async () => {
+      const { token, alice, bob } = await loadFixture(deployFixture);
+      await expect(token.connect(alice).grantOperatorTo(bob.address))
+        .to.be.revertedWith("ERC20: must have admin role to grant operator");
+    });
+
+    it("grantOperatorTo succeeds for admin but confers no transferFrom bypass", async () => {
+      const { token, deployer, mallory, alice, bob } = await loadFixture(deployFixture);
+      await token.connect(deployer).grantOperatorTo(mallory.address);
+      // holds OPERATOR_ROLE now, but transferFrom still needs allowance
+      await expect(token.connect(mallory).transferFrom(alice.address, bob.address, 1))
+        .to.be.reverted;
+    });
+  });
+});

--- a/finp2p-contracts/test/erc20.ts
+++ b/finp2p-contracts/test/erc20.ts
@@ -130,6 +130,34 @@ describe("ERC20 (pure OpenZeppelin)", function() {
     });
   });
 
+  describe("hasOperatorBypass() variant marker (absent)", function() {
+
+    it("reverts / returns empty when probed via raw eth_call (function not present)", async () => {
+      const { token } = await loadFixture(deployFixture);
+      const iface = new ethers.Interface(["function hasOperatorBypass() pure returns (bool)"]);
+      const data = iface.encodeFunctionData("hasOperatorBypass", []);
+      // Either the RPC surfaces a revert error, or the returned data is empty
+      // and Interface.decodeFunctionResult throws. Both count as "missing" —
+      // that's what the wrapper's `hasOperatorBypass()` isFunctionMissingError
+      // check translates into `false`.
+      let missing = false;
+      try {
+        const result = await token.runner!.provider!.call({
+          to: await token.getAddress(),
+          data,
+        });
+        try {
+          iface.decodeFunctionResult("hasOperatorBypass", result);
+        } catch {
+          missing = true;
+        }
+      } catch {
+        missing = true;
+      }
+      expect(missing).to.equal(true);
+    });
+  });
+
   describe("role administration", function() {
 
     it("deployer holds DEFAULT_ADMIN_ROLE; operator holds MINTER + OPERATOR", async () => {


### PR DESCRIPTION
## Summary
Splits our overloaded `burn(address, uint256)` on `ERC20WithOperator` into the two functions OpenZeppelin's `ERC20Burnable` extension exposes:

- `burn(uint256 value)` — destroy `value` tokens from `msg.sender`. New — was previously unavailable, so token holders had no way to burn their own balance directly.
- `burnFrom(address account, uint256 value)` — destroy `value` tokens from `account`, spending the caller's allowance. **MINTER_ROLE bypass retained** so the FinP2P operator can continue to burn on redeem without requiring a per-holder `approve` (documented in the function's NatSpec).

Bumps `@owneraio/finp2p-contracts` to `0.28.19`.

## Internal callers updated
- `contracts/utils/erc20/Burnable.sol` — interface replaced with the two OZ-aligned signatures.
- `contracts/finp2p/FINP2POperator.sol:374` — `.burn(from, amount)` → `.burnFrom(from, amount)`.
- `contracts/utils/erc20/ERC20Standard.sol:71` — same.
- `finp2p-contracts/src/erc20.ts` (TS wrapper) — renamed `burn(fromAddress, quantity)` → `burnFrom(...)`; added a new `burn(quantity)` wrapper for the OZ self-burn path.

## Tests added
New `test/erc20-with-operator.ts` — 14 direct unit tests for the token. Before this PR, `ERC20WithOperator` was only tested transitively via `FINP2POperator` integration flow. Coverage now includes:
- `burn(uint256)` self-burn — success, insufficient-balance revert, Transfer event
- `burnFrom(address, uint256)` — non-operator no-allowance revert, non-operator with-allowance path (consumes it), insufficient-allowance revert, **MINTER_ROLE bypass** (no allowance required), target-insufficient-balance under bypass, zero-address revert, Transfer event
- `mint(address, uint256)` — non-MINTER revert, MINTER-holder success
- `transferFrom` OPERATOR_ROLE bypass regression

## Follow-up on the adapter
Adapter is intentionally unchanged in this PR. Once `0.28.19` is tagged/published, a follow-up will bump `@owneraio/finp2p-contracts` to `^0.28.19` and switch `DirectTokenService.redeem` from *issuer-signed `burnFrom` with role bypass* to *investor-signed `burn` (self-burn)* — using the source finId's custody wallet resolved via `resolveSourceWallet`. That removes the adapter's dependence on the MINTER_ROLE bypass entirely; the bypass on `burnFrom` stays as a library capability for other consumers.

## Test plan
- [x] `npx hardhat compile` — 4 sources compile clean
- [x] `npx hardhat test` — 175 passing / 1 pending (161 existing + 14 new)
- [ ] Publish `finp2p-contracts@0.28.19` via `finp2p-contracts-v0.28.19` tag on the merge commit, then open adapter follow-up