### PR TITLE
Direct mode: deploy plain ERC20 and self-burn from investor wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
-        "@owneraio/finp2p-contracts": "^0.28.18",
+        "@owneraio/finp2p-contracts": "^0.28.19",
         "@owneraio/finp2p-ethereum-collateral": "^0.28.23",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.18",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.18/c736ac87b43ddeb537062103e21c49fd9168152a",
-      "integrity": "sha512-9FNYRQDOBE0lYEhZmO0zuI8ODgwR7l4y+a3ZMlsNzo/Y4WKqBhxHmoLbERrIhTMFLvm19/QXZSlIy2kVu6Iz3A==",
+      "version": "0.28.19",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.19/16e606b4b0e2eea0e5a178db0748bc7910fc62b7",
+      "integrity": "sha512-mEGCgLv3wM/oVbyIundpYDQTsHSeY29cST7LyueHXNDARjfSwX60z0NZoUE46+/V9Ps8bjnnaulJLbF0nFZoQQ==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "0.28.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.6",
-    "@owneraio/finp2p-contracts": "^0.28.18",
+    "@owneraio/finp2p-contracts": "^0.28.19",
     "@owneraio/finp2p-ethereum-collateral": "^0.28.23",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-token-standard": "^0.28.0",

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -218,12 +218,18 @@ export class DirectTokenService implements TokenService, EscrowService {
     try {
       const asset = await getAssetFromDb(this.assetStore, ast.assetId);
       const standard = tokenStandardRegistry.resolve(asset.tokenStandard);
-      // When operationId is set the tokens were previously moved to escrow via `hold`,
-      // so burn from the escrow address; otherwise burn directly from the source's address.
-      const burnFromAddress = operationId
-        ? await this.custodyProvider.escrow.signer.getAddress()
-        : await this.resolveAddress(sourceFinId);
-      const wallet = this.custodyProvider.issuer;
+
+      let wallet: CustodyWallet;
+      let burnFromAddress: string;
+      if (operationId) {
+        wallet = this.custodyProvider.escrow;
+        burnFromAddress = await wallet.signer.getAddress();
+      } else {
+        const resolved = await this.resolveSourceWallet(sourceFinId);
+        if (!resolved) return failedReceiptOperation(1, 'Source address cannot be resolved to a custody wallet');
+        wallet = resolved.wallet;
+        burnFromAddress = resolved.address;
+      }
       const amount = parseUnits(quantity, asset.decimals);
 
       await this.ensureGas(wallet);

--- a/src/services/direct/token-standards/erc20.ts
+++ b/src/services/direct/token-standards/erc20.ts
@@ -1,5 +1,6 @@
-import { Provider, Signer, formatUnits } from 'ethers';
-import { ContractsManager, ERC20Contract } from '@owneraio/finp2p-contracts';
+import { ContractFactory, Provider, Signer, formatUnits } from 'ethers';
+import { ERC20Contract } from '@owneraio/finp2p-contracts';
+import ERC20Artifact from '@owneraio/finp2p-contracts/dist/artifacts/contracts/token/ERC20/ERC20.sol/ERC20.json';
 import winston from 'winston';
 import {
   TokenStandard, TokenWallet, AssetRecord, DeployResult,
@@ -17,8 +18,11 @@ export const DEFAULT_NEW_ERC20_DECIMALS = 2;
 export class ERC20TokenStandard implements TokenStandard {
 
   async deploy(wallet: TokenWallet, name: string, symbol: string, decimals: number, logger: winston.Logger): Promise<DeployResult> {
-    const cm = new ContractsManager(wallet.provider, wallet.signer, logger);
-    const contractAddress = await cm.deployERC20(name, symbol, decimals, await wallet.signer.getAddress());
+    const factory = new ContractFactory(ERC20Artifact.abi, ERC20Artifact.bytecode, wallet.signer);
+    const operatorAddress = await wallet.signer.getAddress();
+    const contract = await factory.deploy(name, symbol, decimals, operatorAddress);
+    await contract.waitForDeployment();
+    const contractAddress = await contract.getAddress();
     return { contractAddress, decimals, tokenStandard: ERC20_TOKEN_STANDARD };
   }
 
@@ -47,8 +51,12 @@ export class ERC20TokenStandard implements TokenStandard {
   }
 
   async burn(wallet: TokenWallet, asset: AssetRecord, from: string, amount: bigint, logger: winston.Logger): Promise<TokenOperationResult> {
+    const signerAddress = await wallet.signer.getAddress();
+    if (signerAddress.toLowerCase() !== from.toLowerCase()) {
+      return failedTokenOp(`burn requires wallet.signer to be ${from}, got ${signerAddress}`);
+    }
     const c = new ERC20Contract(wallet.provider, wallet.signer, asset.contractAddress, logger);
-    return this.execAndWait(c.burn(from, amount));
+    return this.execAndWait(c.burn(amount));
   }
 
   async hold(sourceWallet: TokenWallet, escrowWallet: TokenWallet, asset: AssetRecord, amount: bigint, logger: winston.Logger): Promise<TokenOperationResult> {

--- a/tests/omnibus-delegate.test.ts
+++ b/tests/omnibus-delegate.test.ts
@@ -10,17 +10,25 @@ tokenStandardRegistry.register(ERC20_TOKEN_STANDARD, new ERC20TokenStandard());
 const mockBalanceOf = jest.fn();
 const mockTransfer = jest.fn();
 const mockDecimals = jest.fn();
-const mockDeployERC20Detached = jest.fn();
 jest.mock('@owneraio/finp2p-contracts', () => ({
   ERC20Contract: jest.fn().mockImplementation(() => ({
     balanceOf: mockBalanceOf,
     transfer: mockTransfer,
     decimals: mockDecimals,
   })),
-  ContractsManager: jest.fn().mockImplementation(() => ({
-    deployERC20: mockDeployERC20Detached,
-  })),
 }));
+
+// Mock ethers ContractFactory so ERC20TokenStandard.deploy doesn't try to hit an RPC.
+const mockContractFactoryDeploy = jest.fn();
+jest.mock('ethers', () => {
+  const actual = jest.requireActual('ethers');
+  return {
+    ...actual,
+    ContractFactory: jest.fn().mockImplementation(() => ({
+      deploy: mockContractFactoryDeploy,
+    })),
+  };
+});
 
 // Mock asset store
 const mockGetAsset = jest.fn();
@@ -273,7 +281,10 @@ describe('OmnibusDelegate', () => {
   describe('createAsset', () => {
     it('should deploy ERC20 when no tokenIdentifier provided', async () => {
       const deployedAddress = '0xNEW_TOKEN';
-      mockDeployERC20Detached.mockResolvedValue(deployedAddress);
+      mockContractFactoryDeploy.mockResolvedValue({
+        waitForDeployment: jest.fn().mockResolvedValue(undefined),
+        getAddress: jest.fn().mockResolvedValue(deployedAddress),
+      });
 
       const result = await delegate.createAsset(
         'idem-create', TEST_ASSET.assetId, undefined,
@@ -300,7 +311,7 @@ describe('OmnibusDelegate', () => {
 
       expect(result.ledgerIdentifier.tokenId).toBe(existingAddress);
       expect(result.ledgerIdentifier.network).toBe('eip155:42161');
-      expect(mockDeployERC20Detached).not.toHaveBeenCalled();
+      expect(mockContractFactoryDeploy).not.toHaveBeenCalled();
       expect(mockSaveAsset).toHaveBeenCalledWith(expect.objectContaining({
         contract_address: existingAddress,
         decimals: 8,


### PR DESCRIPTION
## Summary
Consumes `@owneraio/finp2p-contracts@0.28.19` and switches the direct-mode redeem/deploy flow to the plain OpenZeppelin ERC20 with investor self-burn.

- **`package.json`** — bump `@owneraio/finp2p-contracts` to `^0.28.19`.
- **`ERC20TokenStandard.deploy`** — deploy the new plain `ERC20` (pure OZ, no OPERATOR/MINTER-role bypass) via its bundled artifact from `@owneraio/finp2p-contracts/dist/artifacts/contracts/token/ERC20/ERC20.sol/ERC20.json`, not `ERC20WithOperator`.
- **`ERC20TokenStandard.burn`** — self-burn: assert `wallet.signer.getAddress() == from`, then call OZ's `burn(uint256)` on the underlying token. Caller must pass a wallet whose signer *is* the address being burned.
- **`DirectTokenService.redeem`** — direct-redeem path (no `operationId`) now resolves the source finId's custody wallet via `resolveSourceWallet(sourceFinId)` and uses it as the burn signer. The investor's own custody wallet signs the burn tx, the investor pays gas, and `msg.sender` on-chain is the investor. Release-and-redeem path (`operationId` present) uses the escrow wallet the same way.

## Why
Per the design settled in #304: direct mode doesn't touch allowances at all. Any bypass on the ERC20 (issuer-signed `burnFrom`, operator-signed `transferFrom`) implies a custodial power the direct-mode adapter should not exercise. Investor signs their own redeem — matches the semantic of "the tokens sit in the investor's own wallet; only the investor can move them." `ERC20WithOperator` with its role-based bypasses stays reserved for finp2p-contract mode, where the `FINP2POperator` earmark/hold flow provides the compensating discipline.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Redeploy a direct-mode adapter, mint some balance via existing operator MINTER_ROLE, then redeem — expect the investor's wallet (per `resolveSourceWallet`) to sign the burn tx, on-chain `msg.sender` == source finId's mapped address
- [ ] Sandbox pod `sandbox-mt1/hedera-integration/testneterc20` — once redeployed with this image, the plan-`2851026b`-shaped failure ("No deposit address found for vault 1 asset ETH_TEST5") shouldn't recur, since the redeem path no longer routes through the escrow vault at all when no `operationId` is present

## Related
- Consumes #304 (`ERC20WithOperator` OZ-aligned burn split + new plain `ERC20` sibling + `hasOperatorBypass()` variant marker; published as `finp2p-contracts@0.28.19`)
- finp2p-contract mode (`src/services/finp2p-contract/tokens.ts`) is deliberately untouched