### PR TITLE
Harden GasPrefundingOption (follow-ups to #308: Fireblocks local-submit, best-effort, CI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf dist",
     "prebuild": "eslint ./src --ext .ts --fix",
     "build": "tsc",
-    "test": "jest && jest --config jest.account-mapping.config.js && jest --config jest.omnibus.config.js && jest --config jest.legacy-migration.config.js",
+    "test": "jest && jest --config jest.account-mapping.config.js && jest --config jest.omnibus.config.js && jest --config jest.legacy-migration.config.js && jest --config jest.plan-approval.config.js",
     "test:fireblocks": "jest --config jest.fireblocks.config.js",
     "test:dfns": "jest --config jest.dfns.config.js",
     "test:account-mapping": "jest --config jest.account-mapping.config.js",

--- a/src/services/direct/gas-prefunding-option.ts
+++ b/src/services/direct/gas-prefunding-option.ts
@@ -32,21 +32,30 @@ export class GasPrefundingOption implements PlanApprovalOption {
     const gasStation = this.custodyProvider.gasStation;
     if (!gasStation) return;
 
-    // the issuer/escrow addresses are fixed for the whole plan — resolve once
-    // rather than re-querying the signer per instruction
-    const issuerAddress = await this.custodyProvider.issuer.signer.getAddress();
-    const escrowAddress = await this.custodyProvider.escrow.signer.getAddress();
-
     // the same wallet may sign several instructions of one plan — count them so
     // the top-up covers the whole plan rather than a single tx
     const walletTxCounts = new Map<string, number>();
     const bump = (address: string) => walletTxCounts.set(address, (walletTxCounts.get(address) ?? 0) + 1);
 
+    // Fixed issuer/escrow addresses are resolved lazily and only for the
+    // instruction types that need them, and cached per apply(). Fireblocks
+    // local-submit mode uses a JsonRpcProvider placeholder (no getAddress) for
+    // unconfigured issuer/escrow vaults, so a wallet whose address can't be
+    // resolved is skipped best-effort rather than aborting approval.
+    const fixedAddressCache = new Map<"issuer" | "escrow", string | undefined>();
+    const bumpFixedWallet = async (which: "issuer" | "escrow"): Promise<void> => {
+      if (!fixedAddressCache.has(which)) {
+        fixedAddressCache.set(which, await this.tryResolveFixedAddress(which, plan.planId));
+      }
+      const address = fixedAddressCache.get(which);
+      if (address) bump(address);
+    };
+
     for (const instruction of plan.instructions) {
       if (!instruction.local) continue; // executes on another ledger — not our wallets
       switch (instruction.type) {
         case "issue":
-          bump(issuerAddress);
+          await bumpFixedWallet("issuer");
           break;
         case "transfer":
         case "hold":
@@ -55,12 +64,12 @@ export class GasPrefundingOption implements PlanApprovalOption {
         case "redeem":
           // redeem of escrowed funds burns from the escrow wallet; a standalone
           // redeem self-burns from the investor — fund both
-          bump(escrowAddress);
+          await bumpFixedWallet("escrow");
           await this.bumpInvestorWallet(bump, instruction.sourceFinId, plan.planId, instruction.sequence);
           break;
         case "release":
         case "revertHoldInstruction":
-          bump(escrowAddress);
+          await bumpFixedWallet("escrow");
           break;
       }
     }
@@ -86,11 +95,37 @@ export class GasPrefundingOption implements PlanApprovalOption {
     bump: (address: string) => void, finId: string | undefined, planId: string, sequence?: number
   ): Promise<void> {
     if (!finId) return;
-    const address = await this.accountMapping.resolveAccount(finId);
-    if (address) {
-      bump(address);
-    } else {
-      logger.warning(`Gas prefunding: cannot resolve source finId ${finId} of plan ${planId} instruction ${sequence}`);
+    try {
+      const address = await this.accountMapping.resolveAccount(finId);
+      if (address) {
+        bump(address);
+      } else {
+        logger.warning(`Gas prefunding: cannot resolve source finId ${finId} of plan ${planId} instruction ${sequence}`);
+      }
+    } catch (e) {
+      // best-effort: a transient mapping failure (e.g. DB error) must not abort
+      // an already-approved plan — skip this wallet, it funds lazily at execution
+      logger.warning(`Gas prefunding: resolving source finId ${finId} of plan ${planId} instruction ${sequence} failed, skipping: ${e}`);
+    }
+  }
+
+  /**
+   * Resolve a fixed (issuer/escrow) wallet address, tolerating unavailable
+   * wallets. In Fireblocks local-submit mode an unconfigured vault is a
+   * JsonRpcProvider placeholder with no getAddress(); such a wallet is skipped
+   * rather than throwing out of approval.
+   */
+  private async tryResolveFixedAddress(which: "issuer" | "escrow", planId: string): Promise<string | undefined> {
+    try {
+      const signer = this.custodyProvider[which]?.signer as { getAddress?: () => Promise<string> } | undefined;
+      if (!signer || typeof signer.getAddress !== "function") {
+        logger.warning(`Gas prefunding: ${which} wallet has no resolvable address (placeholder?), skipping for plan ${planId}`);
+        return undefined;
+      }
+      return await signer.getAddress();
+    } catch (e) {
+      logger.warning(`Gas prefunding: resolving ${which} wallet address for plan ${planId} failed, skipping: ${e}`);
+      return undefined;
     }
   }
 }

--- a/tests/plan-approval.test.ts
+++ b/tests/plan-approval.test.ts
@@ -131,20 +131,27 @@ describe("ConfigurablePlanApprovalService", () => {
 
 describe("GasPrefundingOption", () => {
 
-  function buildOption(opts: { gasStation?: boolean } = {}) {
+  function buildOption(opts: { gasStation?: boolean, placeholderFixed?: boolean, mappingThrows?: boolean } = {}) {
     const funded: string[] = [];
     const fundedCounts = new Map<string, number>();
     const gasStation = opts.gasStation === false ? undefined : {
       ensureGas: async (address: string, txCount: number = 1) => { funded.push(address); fundedCounts.set(address, txCount); }
     };
+    // placeholderFixed mimics Fireblocks local-submit: issuer/escrow are a
+    // JsonRpcProvider placeholder whose signer has no getAddress()
+    const fixedWallet = opts.placeholderFixed
+      ? { signer: {} }
+      : undefined;
     const custodyProvider = {
       gasStation,
-      issuer: { signer: { getAddress: async () => ISSUER_ADDRESS } },
-      escrow: { signer: { getAddress: async () => ESCROW_ADDRESS } }
+      issuer: fixedWallet ?? { signer: { getAddress: async () => ISSUER_ADDRESS } },
+      escrow: fixedWallet ?? { signer: { getAddress: async () => ESCROW_ADDRESS } }
     } as any;
     const accountMapping = {
-      resolveAccount: async (finId: string) =>
-        finId === ALICE_FIN_ID ? ALICE_ADDRESS : finId === BOB_FIN_ID ? BOB_ADDRESS : undefined
+      resolveAccount: async (finId: string) => {
+        if (opts.mappingThrows) throw new Error("transient DB error");
+        return finId === ALICE_FIN_ID ? ALICE_ADDRESS : finId === BOB_FIN_ID ? BOB_ADDRESS : undefined;
+      }
     } as any;
     return { option: new GasPrefundingOption(custodyProvider, accountMapping), custodyProvider, funded, fundedCounts };
   }
@@ -218,5 +225,33 @@ describe("GasPrefundingOption", () => {
       instruction(2, "release")
     ]));
     expect(funded).toEqual([ESCROW_ADDRESS]);
+  });
+
+  test("placeholder issuer/escrow wallet (Fireblocks local-submit) does not abort — investor still funded", async () => {
+    const { option, funded } = buildOption({ placeholderFixed: true });
+    // a transfer-only plan must not touch the (unavailable) fixed wallets
+    await expect(option.apply(introspect([
+      instruction(1, "transfer", ALICE_FIN_ID)
+    ]))).resolves.toBeUndefined();
+    expect(funded).toEqual([ALICE_ADDRESS]);
+
+    // a plan that would use the escrow wallet skips it (unresolvable) instead of throwing
+    const b = buildOption({ placeholderFixed: true });
+    await expect(b.option.apply(introspect([
+      instruction(1, "hold", ALICE_FIN_ID),
+      instruction(2, "release")
+    ]))).resolves.toBeUndefined();
+    expect(b.funded).toEqual([ALICE_ADDRESS]); // escrow skipped, investor funded
+  });
+
+  test("account-mapping failure is swallowed (best-effort), does not throw", async () => {
+    const { option, funded } = buildOption({ mappingThrows: true });
+    await expect(option.apply(introspect([
+      instruction(1, "issue"),
+      instruction(2, "hold", ALICE_FIN_ID),
+      instruction(3, "release")
+    ]))).resolves.toBeUndefined();
+    // investor skipped (mapping threw); fixed issuer/escrow still funded
+    expect(funded.sort()).toEqual([ISSUER_ADDRESS, ESCROW_ADDRESS].sort());
   });
 });


### PR DESCRIPTION
## Follow-ups to #308 — GasPrefundingOption robustness

Addresses three issues found in review of #308. All three pre-existed in #308 as merged on master (verified: the option file was byte-identical on the backport), so this fixes them at the source. The release-line backport (#310) is intentionally left as a faithful cherry-pick of #308 and can pick this up separately.

### P1 — Fireblocks local-submit regression (live on master)
`apply()` resolved the issuer **and** escrow addresses unconditionally at the top. In Fireblocks local-submit mode an unconfigured issuer/escrow vault is a `JsonRpcProvider` placeholder (`config.provider as any`) with no `getAddress()`, so `apply()` threw — and `ConfigurablePlanApprovalService` does not wrap non-gating `option.apply()` in try/catch, so **every plan, even transfer-only, failed `approvePlan` after the base already approved**. This came from the "cache addresses once" optimization added late in #308.

Fix: fixed issuer/escrow addresses are now resolved **lazily**, only for the instruction types that use them (issue → issuer; release/redeem/revertHold → escrow), cached per `apply()`, and **skipped best-effort** when the wallet has no resolvable address.

### P2a — account-mapping errors escaped the best-effort contract
`resolveAccount()` throwing (e.g. transient DB error) propagated out of `apply()` → `approvePlan` → server error. Now caught per wallet: logs and skips, funding that wallet lazily at execution.

### P2b — suite not run by CI
`test:plan-approval` existed but `npm test` didn't invoke it (CI runs `npm test`). Added it to the `npm test` chain.

### Tests
Two regression tests added: a placeholder issuer/escrow wallet still funds the investor without aborting; a mapping failure is swallowed while fixed wallets still fund. `npm run test:plan-approval` → 16/16, `tsc` + eslint clean.
