### PR TITLE
integrations: register Ethereum token standards (TREX/CMTAT/BENJI/HEDERA_ATS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,13 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.6",
         "@owneraio/finp2p-contracts": "^0.28.20",
+        "@owneraio/finp2p-ethereum-benji-plugin": "^0.28.1",
+        "@owneraio/finp2p-ethereum-cmtat-plugin": "^0.28.1",
         "@owneraio/finp2p-ethereum-collateral": "^0.28.23",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.6",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.1",
         "@owneraio/finp2p-ethereum-token-standard": "^0.28.2",
+        "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.1",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
         "@owneraio/finp2p-vanilla-service": "^0.28.6",
         "@types/node": "^24.10.1",
@@ -1699,9 +1703,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-client": {
-      "version": "0.28.12",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.12/24845c014328dc66358a33c890a7c7c0cf91b629",
-      "integrity": "sha512-ReaXR7zbrtlBECm+N+ZL/QUB3H5ptCyz3k+9Qz4uvsgKBVr3Q8NCvf3ikdbAb1f8JsM45feBiz3YdnV7GSmtrg==",
+      "version": "0.28.22",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-client/0.28.22/dcc20fa57426f112da194855269382211fc98441",
+      "integrity": "sha512-dZ7DaEPen5cu2RtZlg43eeB1V9SOxpSFOrIQeq5xBYx+DWzLDOHJPVfBJrsGImQy3z4JlXeV2KNz2wOTGkREjg==",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
@@ -1732,6 +1736,37 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12"
       }
     },
+    "node_modules/@owneraio/finp2p-ethereum-benji-plugin": {
+      "version": "0.28.1",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-benji-plugin/0.28.1/8577ea42eadf7aee270dbccc4609016c4fdc2d21",
+      "integrity": "sha512-lDH/WOWMrs9Ua+P07Oqf/fZ9wiPy83X4ryxZEgc7KPSui1E7jPLqtgKeY9RTtErx8KHIyP3lR/lU8LMynNf20g==",
+      "license": "ISC",
+      "dependencies": {
+        "ethers": "^6.11.1"
+      },
+      "peerDependencies": {
+        "@owneraio/finp2p-contracts": "^0.28.20",
+        "@owneraio/finp2p-ethereum-ownera": "^0.28.3",
+        "secp256k1": "^3.7.1",
+        "winston": "^3.3.3"
+      }
+    },
+    "node_modules/@owneraio/finp2p-ethereum-cmtat-plugin": {
+      "version": "0.28.1",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-cmtat-plugin/0.28.1/7edaefbcfdcb9cbc5ce9569cf522ec83f286f166",
+      "integrity": "sha512-U+AzL2Hz8oSbUJIc8tRTRldxQcqXrZ+SBZuMdeho2in3cnFqarL+wpcxrfN1VFO5Ol5E7gHHpkg0xVLrqUrbKQ==",
+      "license": "ISC",
+      "dependencies": {
+        "ethers": "^6.11.1"
+      },
+      "peerDependencies": {
+        "@owneraio/finp2p-contracts": "^0.28.20",
+        "@owneraio/finp2p-ethereum-ownera": "^0.28.3",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
+        "secp256k1": "^3.7.1",
+        "winston": "^3.3.3"
+      }
+    },
     "node_modules/@owneraio/finp2p-ethereum-collateral": {
       "version": "0.28.23",
       "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-collateral/0.28.23/412f3525b84c97cac40e0d25c54fa846fe5afbea",
@@ -1760,6 +1795,24 @@
         "winston": "^3.3.3"
       }
     },
+    "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
+      "version": "0.28.1",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.1/ec8db5add964e5d691839d9e104171e0e2a673d7",
+      "integrity": "sha512-CG8ZMVdoY56ZkQsS5lhtbYJcsrLW7CI4GuViyNgPP2UagH84wC+ARZ4vQZLBj7OhmpXJbIMwBSGvj9OX3GqORQ==",
+      "dependencies": {
+        "ethers": "^6.11.1"
+      }
+    },
+    "node_modules/@owneraio/finp2p-ethereum-ownera": {
+      "version": "0.28.3",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-ownera/0.28.3/b74a157e75c3035fc8bcf0ca8b4488234d70797a",
+      "integrity": "sha512-Diiu07RUK+kqez6dDA70MHVDbcP0F2tpFlbAe+zIk0TtFr4es8wqAxZYWfAb9moyqGz35WInAESYhz91dbDfcg==",
+      "license": "TBD",
+      "peer": true,
+      "dependencies": {
+        "ethers": "^6.11.1"
+      }
+    },
     "node_modules/@owneraio/finp2p-ethereum-token-standard": {
       "version": "0.28.2",
       "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-token-standard/0.28.2/a3ff7ac4dbc78327eabdabd5e520e8d15e637849",
@@ -1778,6 +1831,23 @@
       "dependencies": {
         "@owneraio/finp2p-ethereum-token-standard": "^0.27.5",
         "ethers": "^6.11.1"
+      }
+    },
+    "node_modules/@owneraio/finp2p-ethereum-trex-plugin": {
+      "version": "0.28.1",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-trex-plugin/0.28.1/67bd57f02611089f959dbb14f2c640476af365b1",
+      "integrity": "sha512-eHIZzqON6+CeSDL7feQNob8vkj0wb4/hHzLWEK8E17cvn1ymYkIc/RLdDqa1XxbiFBrh7oMS2/0c5djohOt+jw==",
+      "license": "ISC",
+      "dependencies": {
+        "ethers": "^6.11.1"
+      },
+      "peerDependencies": {
+        "@owneraio/finp2p-client": "^0.28.22",
+        "@owneraio/finp2p-contracts": "^0.28.20",
+        "@owneraio/finp2p-ethereum-ownera": "^0.28.3",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
+        "secp256k1": "^3.7.1",
+        "winston": "^3.3.3"
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,11 @@
     "pg": "^8.22.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.2.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.1",
+    "@owneraio/finp2p-ethereum-cmtat-plugin": "^0.28.1",
+    "@owneraio/finp2p-ethereum-benji-plugin": "^0.28.1",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.1"
   },
   "devDependencies": {
     "@owneraio/adapter-tests": "^0.28.8",

--- a/src/integrations/ethereum-standards/index.ts
+++ b/src/integrations/ethereum-standards/index.ts
@@ -1,0 +1,52 @@
+import { JsonRpcProvider, Wallet, NonceManager } from "ethers";
+import { TrexTokenStandard, TokenStandardName as TREX_STANDARD } from "@owneraio/finp2p-ethereum-trex-plugin";
+import { CmtatTokenStandard, TokenStandardName as CMTAT_STANDARD } from "@owneraio/finp2p-ethereum-cmtat-plugin";
+import { BenjiTokenStandard, TokenStandardName as BENJI_STANDARD } from "@owneraio/finp2p-ethereum-benji-plugin";
+import { AtsTokenStandard, TokenStandardName as HEDERA_ATS_STANDARD } from "@owneraio/finp2p-ethereum-hedera-plugin";
+import { tokenStandardRegistry } from "../../services/direct";
+import { IntegrationContext } from "../registry";
+
+/**
+ * Registers the provisioned Ethereum token standards (TREX, CMTAT, BENJI,
+ * HEDERA_ATS) in the direct-mode token-standard registry.
+ *
+ * These register the value-op standard only — no PaymentsPlugin, no
+ * plan-approval — so they are wired unconditionally (support-all, not
+ * feature-flagged) and never contend for the single PaymentsPlugin slot.
+ * Onboarding / plan-approval, where a standard needs it, is a separate concern.
+ *
+ * Needs NETWORK_HOST (rpc) + an agent key. issuer/controller default to
+ * OPERATOR_PRIVATE_KEY; override per role with
+ * TOKEN_STANDARD_ISSUER_PRIVATE_KEY / TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY.
+ */
+export function registerEthereumTokenStandards(ctx: IntegrationContext): void {
+  const { logger, rpcUrl } = ctx;
+  const operatorKey = process.env.OPERATOR_PRIVATE_KEY;
+  const issuerKey = process.env.TOKEN_STANDARD_ISSUER_PRIVATE_KEY ?? operatorKey;
+  const controllerKey = process.env.TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY ?? operatorKey;
+
+  const names = [TREX_STANDARD, CMTAT_STANDARD, BENJI_STANDARD, HEDERA_ATS_STANDARD];
+  if (!rpcUrl || !issuerKey || !controllerKey) {
+    logger.warn(`Ethereum token standards (${names.join(", ")}) not registered: set NETWORK_HOST + OPERATOR_PRIVATE_KEY (or TOKEN_STANDARD_ISSUER/CONTROLLER_PRIVATE_KEY)`);
+    return;
+  }
+
+  const provider = new JsonRpcProvider(rpcUrl);
+  const issuer = new NonceManager(new Wallet(issuerKey, provider));
+  const controller = controllerKey === issuerKey ? issuer : new NonceManager(new Wallet(controllerKey, provider));
+
+  const standards: Array<[string, unknown]> = [
+    [TREX_STANDARD, new TrexTokenStandard(provider, issuer, controller)],
+    [CMTAT_STANDARD, new CmtatTokenStandard(provider, issuer, controller)],
+    [BENJI_STANDARD, new BenjiTokenStandard(provider, issuer, controller)],
+    [HEDERA_ATS_STANDARD, new AtsTokenStandard(provider, issuer, controller)],
+  ];
+
+  const registered: string[] = [];
+  for (const [name, impl] of standards) {
+    if (tokenStandardRegistry.has(name)) continue;
+    tokenStandardRegistry.register(name, impl as any);
+    registered.push(name);
+  }
+  logger.info(`Ethereum token standards registered: ${registered.join(", ")}`);
+}

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -12,6 +12,7 @@ import { registerCollateralPlugin } from "./collateral";
 import { registerWalletDeposit } from "./deposits/wallet-deposit";
 import { registerPullDeposit } from "./deposits/pull-deposit";
 import { registerOtaDeposit } from "./deposits/ota-deposit";
+import { registerEthereumTokenStandards } from "./ethereum-standards";
 
 /** True when another integration (DTCC, collateral, …) already owns the single PaymentsPlugin slot. */
 export function paymentsSlotClaimedExternally(): boolean {
@@ -43,6 +44,7 @@ export function registerCustodyIntegrations(): void {
 }
 
 const integrations: IntegrationRegistrar[] = [
+  registerEthereumTokenStandards,
   registerWalletDeposit,
   registerPullDeposit,
   registerOtaDeposit,


### PR DESCRIPTION
## Problem

The four Ethereum token-standard plugins published from [`finp2p-ethereum-tools`](https://github.com/owneraio/finp2p-ethereum-tools) — `TREX`, `CMTAT`, `BENJI`, `HEDERA_ATS` — were **not wired into this adapter's `tokenStandardRegistry`**. Only `ERC20` (always), `DTCC_COLLATERAL_ACCOUNT` (flagged) and `OWNERA_COLLATERAL_REGISTRY` (flagged) were registered. So an asset created/bound with any of the four failed with *"Unknown token standard"* at create (and every op) — the resolve-by-name control flow had no implementation to resolve to.

Surfaced while validating the umbrella [owneraio/finp2p-ethereum-tools#90](https://github.com/owneraio/finp2p-ethereum-tools/issues/90).

## Change

New `src/integrations/ethereum-standards` registrar that registers all four **value-op** standards:

- **Unconditional / support-all** — not behind a per-plugin feature flag, and independent of the DTCC ⇄ Collateral mutual exclusion (those contend for the single `PaymentsPlugin` slot; these register the value-op standard only, no payments/plan-approval).
- Runs **first** in `registerIntegrations`, so the standards exist before the deposit/plan-approval plugins.
- Signers: `issuer`/`controller` default to `OPERATOR_PRIVATE_KEY`, overridable per role via `TOKEN_STANDARD_ISSUER_PRIVATE_KEY` / `TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY`; a shared `NonceManager` when they're the same key. Warn-and-skip if `NETWORK_HOST` or the key is missing (ERC20-only deployments still boot).
- Deps: `@owneraio/finp2p-ethereum-{trex,cmtat,benji,hedera}-plugin@^0.28.1` (pull `@owneraio/finp2p-ethereum-ownera` transitively).

## Verification

- `tsc` clean.
- Runtime smoke: after `registerEthereumTokenStandards`, `tokenStandardRegistry.availableStandards` = `['TREX','CMTAT','BENJI','HEDERA_ATS']`, all four `resolve()` OK.

## Notes / follow-ups (not in this PR)
- This addresses gaps 1–4 for the four **provisioned** standards (value ops). Any **plan-approval/onboarding** each needs (e.g. CMTAT whitelist, HEDERA_ATS allowlist) is a separate wiring — deliberately decoupled here.
- The adapter still imports `TokenStandard` from `@owneraio/finp2p-ethereum-token-standard` in the registry type (bridged via `as any`); consolidating onto `@owneraio/finp2p-ethereum-ownera` is tracked in #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
