### PR TITLE
Observability: token standard resolution + plan-approval pipeline logging

### DIFF
--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -94,12 +94,17 @@ export class DirectTokenService implements TokenService, EscrowService {
     assetMetadata: any, assetName: string | undefined, issuerId: string | undefined,
     assetDenomination: AssetDenomination | undefined,
   ): Promise<AssetCreationStatus> {
-    const requestedStandard = assetBind?.tokenIdentifier?.standard ?? ERC20_TOKEN_STANDARD;
+    const explicitStandard = assetBind?.tokenIdentifier?.standard;
+    const requestedStandard = explicitStandard ?? ERC20_TOKEN_STANDARD;
+    if (!tokenStandardRegistry.has(requestedStandard)) {
+      this.logger.error(`createAsset: assetId=${assetId} requested token standard '${requestedStandard}' is not registered; available: ${tokenStandardRegistry.availableStandards.join(', ')}`);
+    }
     const standard = tokenStandardRegistry.resolve(requestedStandard);
     // ERC20-compatible standards (ERC20, TREX, CMTAT, BENJI, HEDERA_ATS, ...)
     // expose IERC20Metadata: read decimals on bind and register with custody.
     // Non-compatible ones (collateral registries) keep decimals=0 and skip both.
     const isErc20 = tokenStandardRegistry.isErc20Compatible(requestedStandard);
+    this.logger.info(`createAsset: assetId=${assetId} token standard '${requestedStandard}'${explicitStandard === undefined ? ' (defaulted, none requested)' : ''} resolved to ${standard.constructor.name} (erc20Compatible=${isErc20})`);
 
     const { chainId } = await this.custodyProvider.rpcProvider.getNetwork();
     const defaultNetwork = `eip155:${chainId}`;

--- a/src/services/direct/token-whitelisting-option.ts
+++ b/src/services/direct/token-whitelisting-option.ts
@@ -66,22 +66,33 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
 
   async apply(plan: IntrospectedPlan): Promise<ReturnType<typeof rejectedPlan> | void> {
     const work = new Map<string, AssetWork>();
+    const foreignAssets = new Set<string>();
     let escrowAddress: string | undefined;
     let escrowResolved = false;
 
     for (const instruction of plan.instructions) {
       if (!instruction.local || !instruction.assetId) continue;
       if (instruction.type === "await") continue;
+      if (foreignAssets.has(instruction.assetId)) continue;
 
       let entry = work.get(instruction.assetId);
       if (!entry) {
         const dbAsset = await this.assetStore.getAsset(instruction.assetId);
-        if (dbAsset === undefined) continue; // not kept in this adapter
+        if (dbAsset === undefined) {
+          foreignAssets.add(instruction.assetId);
+          logger.debug(`Plan ${plan.planId}: asset ${instruction.assetId} is not kept in this adapter — skipping whitelisting`);
+          continue;
+        }
         const standardName = dbAsset.token_standard;
         if (!tokenStandardRegistry.has(standardName)) {
+          logger.warning(`Plan ${plan.planId}: token standard '${standardName}' of asset ${instruction.assetId} is not registered (available: ${tokenStandardRegistry.availableStandards.join(", ")}) — rejecting`);
           return rejectedPlan(1, `Plan ${plan.planId}: token standard '${standardName}' of asset ${instruction.assetId} is not registered`);
         }
         const standard = tokenStandardRegistry.resolve(standardName);
+        const whitelisting = supportsWhitelisting(standard) ? standard : undefined;
+        if (!whitelisting) {
+          logger.info(`Plan ${plan.planId}: asset ${instruction.assetId} standard '${standardName}' has no whitelisting capability — skipping`);
+        }
         entry = {
           assetId: instruction.assetId,
           asset: {
@@ -89,7 +100,7 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
             decimals: dbAsset.decimals,
             tokenStandard: standardName
           },
-          whitelisting: supportsWhitelisting(standard) ? standard : undefined,
+          whitelisting,
           parties: new Map()
         };
         work.set(instruction.assetId, entry);
@@ -105,6 +116,7 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
           if (!escrowAddress) {
             // hold/release execution needs this wallet — approving without
             // whitelisting the actual endpoint would just defer the failure
+            logger.warning(`Plan ${plan.planId}: escrow wallet address is unavailable but asset ${entry.assetId} needs its escrow endpoint whitelisted — rejecting`);
             return rejectedPlan(1, `Plan ${plan.planId}: escrow wallet address is unavailable; cannot whitelist the escrow endpoint of asset ${entry.assetId}`);
           }
           entry.parties.set(`escrow|${escrowAddress}`, { address: escrowAddress, role: "escrow" });
@@ -146,6 +158,7 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
     const address = (finId ? await this.accountMapping.resolveAccount(finId) : undefined) ?? explicitAddress;
     if (!address) {
       // execution would fail on the unresolvable account anyway — fail early
+      logger.warning(`Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId} — rejecting`);
       return rejectedPlan(1, `Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId}`);
     }
     entry.parties.set(key, { finId, address, role });

--- a/src/services/direct/wallet-activation-option.ts
+++ b/src/services/direct/wallet-activation-option.ts
@@ -55,14 +55,18 @@ export class WalletActivationOption implements PlanApprovalOption {
       // sequential on purpose: activation sends from the single funding
       // wallet, so parallel touches would race its nonce
       try {
-        await activator.ensureActivated(address);
-        activated++;
+        if (await activator.ensureActivated(address)) {
+          activated++;
+          logger.info(`Wallet activation: sent ${this.activationAmount} to ${address} (plan ${plan.planId})`);
+        } else {
+          logger.debug(`Wallet activation: ${address} is already active (plan ${plan.planId})`);
+        }
       } catch (e) {
         logger.warning(`Wallet activation: touch of ${address} for plan ${plan.planId} failed: ${e}`);
       }
     }
-    if (activated > 0) {
-      logger.info(`Wallet activation: ensured ${activated}/${seen.size} destination wallet(s) of plan ${plan.planId}`);
+    if (seen.size > 0) {
+      logger.info(`Wallet activation: ${seen.size} destination wallet(s) checked, ${activated} activated for plan ${plan.planId}`);
     }
   }
 

--- a/src/services/direct/wallet-activation.ts
+++ b/src/services/direct/wallet-activation.ts
@@ -62,9 +62,10 @@ export class WalletActivator {
     private readonly amount: string,
   ) {}
 
-  async ensureActivated(address: string): Promise<void> {
+  /** @returns true when an activation transfer was sent, false when the address was already active */
+  async ensureActivated(address: string): Promise<boolean> {
     let balance = await this.fundingWallet.provider.getBalance(address);
-    if (balance > 0n) return;
+    if (balance > 0n) return false;
 
     await this.fundingWallet.signer.sendTransaction({
       to: address,
@@ -75,7 +76,7 @@ export class WalletActivator {
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
       balance = await this.fundingWallet.provider.getBalance(address);
-      if (balance > 0n) return;
+      if (balance > 0n) return true;
     }
     throw new Error(`Activation transfer to ${address} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms`);
   }

--- a/src/services/plan-approval/configurable-plan-approval-service.ts
+++ b/src/services/plan-approval/configurable-plan-approval-service.ts
@@ -46,6 +46,7 @@ export class ConfigurablePlanApprovalService implements PlanApprovalService {
       return result;
     }
 
+    logger.info(`Plan ${planId}: running approval option(s) [${this.options.map(o => o.name).join(", ")}] over ${plan.instructions.length} instruction(s)`);
     for (const option of this.options) {
       let veto;
       try {
@@ -62,10 +63,12 @@ export class ConfigurablePlanApprovalService implements PlanApprovalService {
         continue;
       }
       if (veto && veto.type === "rejected") {
-        logger.info(`Plan ${planId} rejected by approval option '${option.name}'`);
+        const reason = (veto as { error?: { message?: string } }).error?.message;
+        logger.info(`Plan ${planId} rejected by approval option '${option.name}'${reason ? `: ${reason}` : ""}`);
         return veto;
       }
     }
+    logger.info(`Plan ${planId}: all approval options passed`);
     return result;
   }
 

--- a/src/services/plan-approval/configurable-plan-approval-service.ts
+++ b/src/services/plan-approval/configurable-plan-approval-service.ts
@@ -47,6 +47,7 @@ export class ConfigurablePlanApprovalService implements PlanApprovalService {
     }
 
     logger.info(`Plan ${planId}: running approval option(s) [${this.options.map(o => o.name).join(", ")}] over ${plan.instructions.length} instruction(s)`);
+    const skippedAfterFailure: string[] = [];
     for (const option of this.options) {
       let veto;
       try {
@@ -60,6 +61,7 @@ export class ConfigurablePlanApprovalService implements PlanApprovalService {
           return rejectedPlan(1, `Approval option '${option.name}' failed for plan ${planId}: ${e}`);
         }
         logger.warning(`Plan ${planId}: approval option '${option.name}' failed, skipping: ${e}`);
+        skippedAfterFailure.push(option.name);
         continue;
       }
       if (veto && veto.type === "rejected") {
@@ -68,7 +70,9 @@ export class ConfigurablePlanApprovalService implements PlanApprovalService {
         return veto;
       }
     }
-    logger.info(`Plan ${planId}: all approval options passed`);
+    logger.info(skippedAfterFailure.length > 0
+      ? `Plan ${planId}: approval options completed without a gating rejection (skipped after failure: ${skippedAfterFailure.join(", ")})`
+      : `Plan ${planId}: all approval options passed`);
     return result;
   }
 

--- a/tests/plan-approval.test.ts
+++ b/tests/plan-approval.test.ts
@@ -133,17 +133,27 @@ describe("ConfigurablePlanApprovalService", () => {
   });
 
   test("a non-gating option that throws is skipped; later options still run", async () => {
-    const log: string[] = [];
-    const base = { approvePlan: async () => approved() } as any;
-    const throwing: PlanApprovalOption = {
-      name: "gas", gating: false, apply: async () => { throw new Error("gas station down"); }
-    };
-    const service = new ConfigurablePlanApprovalService(
-      ORG, planClient([instruction(1, "hold", ALICE_FIN_ID)]), base, [throwing, recordingOption(log)]);
+    const { logger } = require("@owneraio/finp2p-nodejs-skeleton-adapter");
+    const infoSpy = jest.spyOn(logger, "info");
+    try {
+      const log: string[] = [];
+      const base = { approvePlan: async () => approved() } as any;
+      const throwing: PlanApprovalOption = {
+        name: "gas", gating: false, apply: async () => { throw new Error("gas station down"); }
+      };
+      const service = new ConfigurablePlanApprovalService(
+        ORG, planClient([instruction(1, "hold", ALICE_FIN_ID)]), base, [throwing, recordingOption(log)]);
 
-    const result = await service.approvePlan("ik", "plan-7");
-    expect(result.type).toBe("approved");
-    expect(log).toEqual(["plan-7:1"]);
+      const result = await service.approvePlan("ik", "plan-7");
+      expect(result.type).toBe("approved");
+      expect(log).toEqual(["plan-7:1"]);
+      // the completion line must not claim the skipped option passed
+      const infoLines = infoSpy.mock.calls.map(c => String(c[0]));
+      expect(infoLines).toContainEqual(expect.stringContaining("completed without a gating rejection (skipped after failure: gas)"));
+      expect(infoLines).not.toContainEqual(expect.stringContaining("all approval options passed"));
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 
   test("with no options, it is a thin pass-through to the base", async () => {


### PR DESCRIPTION
Small observability gap: in `DirectTokenService.createAsset` the token-standard registry `resolve()` ran **before** the first log line, so:

- an unregistered standard threw with no createAsset-context log line (no assetId, no hint of what was requested), and
- a successful resolution never recorded what the requested standard actually resolved to.

Now, before resolution:
- an **error** line when the requested standard is not registered, including the available registry contents (`createAsset: assetId=… requested token standard 'X' is not registered; available: ERC20, TREX, …`) — the resolve still throws as before, behavior unchanged;
- an **info** line on success recording the resolution: requested name, whether it was defaulted (no `tokenIdentifier.standard` in the request → ERC20), the implementation class it resolved to, and the `erc20Compatible` flag that drives the decimals/custody-registration branching (`createAsset: assetId=… token standard 'HEDERA_ATS' resolved to AtsTokenStandard (erc20Compatible=true)`).

Logging only — no behavior change. tsc + eslint + unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)