### PR TITLE
Migrate internal SPI imports to adapter-contract (#325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Adapter communicated with a FinP2P proxy contract on Ethereum network which 
 
 ## Supported token standards
 
-The base `TokenStandard` interface is owned by the adapter and published as [`@owneraio/finp2p-ethereum-adapter-contract`](./adapter-contract) (#325; internal imports migrate there in a follow-up — currently still consumed via `@owneraio/finp2p-ethereum-ownera`); each standard below implements it and is resolved by name from the asset's `token_standard`:
+The base `TokenStandard` interface is owned by the adapter and published as [`@owneraio/finp2p-ethereum-adapter-contract`](./adapter-contract) (#325); each standard below implements it and is resolved by name from the asset's `token_standard`:
 
 | Standard | Package | Registration |
 | :--- | :--- | :--- |

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.22",
         "@owneraio/finp2p-contracts": "^0.28.20",
+        "@owneraio/finp2p-ethereum-adapter-contract": "^0.28.0",
         "@owneraio/finp2p-ethereum-benji-plugin": "^0.28.2",
         "@owneraio/finp2p-ethereum-cmtat-plugin": "^0.28.3",
         "@owneraio/finp2p-ethereum-collateral": "^0.28.24",
@@ -1734,6 +1735,15 @@
       },
       "peerDependencies": {
         "@fireblocks/fireblocks-web3-provider": "^1.3.12"
+      }
+    },
+    "node_modules/@owneraio/finp2p-ethereum-adapter-contract": {
+      "version": "0.28.0",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-adapter-contract/0.28.0/b5a58b6574d2733c723d5f397e86664d3d0720c4",
+      "integrity": "sha512-LuQiJbMvt4NKOF7lbA2vzYrNqGfH78ALhppG+qNIQW07ZTagz6eOGY8+RzuNCWTM/Au8RM8Lm7gVyJWJRZ220w==",
+      "license": "TBD",
+      "dependencies": {
+        "ethers": "^6.9.0"
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-benji-plugin": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.22",
     "@owneraio/finp2p-contracts": "^0.28.20",
+    "@owneraio/finp2p-ethereum-adapter-contract": "^0.28.0",
     "@owneraio/finp2p-ethereum-benji-plugin": "^0.28.2",
     "@owneraio/finp2p-ethereum-cmtat-plugin": "^0.28.3",
     "@owneraio/finp2p-ethereum-collateral": "^0.28.24",

--- a/src/integrations/ethereum-standards/index.ts
+++ b/src/integrations/ethereum-standards/index.ts
@@ -1,5 +1,5 @@
 import { VoidSigner, ZeroAddress } from "ethers";
-import { TokenStandard } from "@owneraio/finp2p-ethereum-ownera";
+import { TokenStandard } from "@owneraio/finp2p-ethereum-adapter-contract";
 import { TrexTokenStandard, TokenStandardName as TREX_STANDARD, TokenyClient, createTokenyQualifier, TrexInvestorQualifier } from "@owneraio/finp2p-ethereum-trex-plugin";
 import { CmtatTokenStandard, TokenStandardName as CMTAT_STANDARD } from "@owneraio/finp2p-ethereum-cmtat-plugin";
 import { BenjiTokenStandard, TokenStandardName as BENJI_STANDARD } from "@owneraio/finp2p-ethereum-benji-plugin";

--- a/src/services/direct/helpers.ts
+++ b/src/services/direct/helpers.ts
@@ -1,4 +1,4 @@
-import { AssetRecord } from '@owneraio/finp2p-ethereum-ownera';
+import { AssetRecord } from '@owneraio/finp2p-ethereum-adapter-contract';
 import { AssetStore } from './account-mapping';
 
 export async function getAssetFromDb(assetStore: AssetStore, assetId: string): Promise<AssetRecord> {

--- a/src/services/direct/operation-context.ts
+++ b/src/services/direct/operation-context.ts
@@ -1,6 +1,6 @@
 import {
   OperationContext, LegType, PrimaryType, Phase, ReleaseType,
-} from '@owneraio/finp2p-ethereum-ownera';
+} from '@owneraio/finp2p-ethereum-adapter-contract';
 import { Asset, ExecutionContext, Signature } from '@owneraio/finp2p-nodejs-skeleton-adapter';
 
 /**

--- a/src/services/direct/token-service.ts
+++ b/src/services/direct/token-service.ts
@@ -6,7 +6,7 @@ import {
 } from '@owneraio/finp2p-nodejs-skeleton-adapter';
 import winston from 'winston';
 import { parseUnits } from "ethers";
-import { TokenOperationResult } from '@owneraio/finp2p-ethereum-ownera';
+import { TokenOperationResult } from '@owneraio/finp2p-ethereum-adapter-contract';
 import { CustodyProvider, CustodyWallet } from './custody-provider';
 import { AccountMappingService, AssetStore } from './account-mapping';
 import { getAssetFromDb } from './helpers';

--- a/src/services/direct/token-standards/erc20.ts
+++ b/src/services/direct/token-standards/erc20.ts
@@ -5,7 +5,7 @@ import winston from 'winston';
 import {
   TokenStandard, TokenWallet, AssetRecord, DeployResult,
   TokenOperationResult, successfulTokenOp, failedTokenOp,
-} from '@owneraio/finp2p-ethereum-ownera';
+} from '@owneraio/finp2p-ethereum-adapter-contract';
 
 export const ERC20_TOKEN_STANDARD = 'ERC20';
 

--- a/src/services/direct/token-standards/interface.ts
+++ b/src/services/direct/token-standards/interface.ts
@@ -1,6 +1,6 @@
 /**
  * Re-export token standard interface and types from the standalone package.
- * Plugin packages depend on @owneraio/finp2p-ethereum-ownera directly,
+ * Plugin packages depend on @owneraio/finp2p-ethereum-adapter-contract directly,
  * not on the full adapter.
  */
-export { TokenStandard, TokenWallet, AssetRecord, DeployResult } from '@owneraio/finp2p-ethereum-ownera';
+export { TokenStandard, TokenWallet, AssetRecord, DeployResult } from '@owneraio/finp2p-ethereum-adapter-contract';

--- a/src/services/direct/token-standards/registry.ts
+++ b/src/services/direct/token-standards/registry.ts
@@ -1,4 +1,4 @@
-import { TokenStandard } from '@owneraio/finp2p-ethereum-ownera';
+import { TokenStandard } from '@owneraio/finp2p-ethereum-adapter-contract';
 
 /**
  * Registry for token standard implementations in direct mode.

--- a/src/services/direct/token-standards/whitelisting.ts
+++ b/src/services/direct/token-standards/whitelisting.ts
@@ -1,9 +1,9 @@
 // The InvestorWhitelisting capability was upstreamed into
-// @owneraio/finp2p-ethereum-ownera (0.28.4) verbatim; re-exported here so
+// @owneraio/finp2p-ethereum-adapter-contract (0.28.4) verbatim; re-exported here so
 // existing adapter imports keep working with the single upstream definition.
 export {
   WhitelistParty,
   WhitelistPartyRole,
   InvestorWhitelisting,
   supportsWhitelisting,
-} from "@owneraio/finp2p-ethereum-ownera";
+} from "@owneraio/finp2p-ethereum-adapter-contract";

--- a/src/services/direct/token-whitelisting-option.ts
+++ b/src/services/direct/token-whitelisting-option.ts
@@ -1,5 +1,5 @@
 import { logger, rejectedPlan } from "@owneraio/finp2p-nodejs-skeleton-adapter";
-import { AssetRecord, Logger as TokenLogger } from "@owneraio/finp2p-ethereum-ownera";
+import { AssetRecord, Logger as TokenLogger } from "@owneraio/finp2p-ethereum-adapter-contract";
 import { PlanApprovalOption, IntrospectedPlan, IntrospectedInstruction } from "../plan-approval";
 import { AccountMappingService, AssetStore } from "./account-mapping";
 import { CustodyProvider } from "./custody-provider";

--- a/tests/operation-context.test.ts
+++ b/tests/operation-context.test.ts
@@ -1,4 +1,4 @@
-import { PrimaryType, LegType } from "@owneraio/finp2p-ethereum-ownera";
+import { PrimaryType, LegType } from "@owneraio/finp2p-ethereum-adapter-contract";
 import { buildOperationContext } from "../src/services/direct/operation-context";
 
 const ASSET = { assetId: "bank-us:102:asset-1", assetType: "finp2p" } as any;


### PR DESCRIPTION
Follow-up to #326, step 3 of the #325 sequence — now that `@owneraio/finp2p-ethereum-adapter-contract@0.28.0` is published (dedicated tag on the #326 merge commit, CI-published, sole version in the registry):

- All `src/` and `tests/` SPI imports move from `@owneraio/finp2p-ethereum-ownera` to `@owneraio/finp2p-ethereum-adapter-contract` (pin `^0.28.0`; lockfile resolves the real `0.28.0`).
- The ownera dependency **stays** for the old-plugin compatibility window (plugins still peer on it); ownera-typed plugin instances keep registering via structural typing — the suite exercises the real plugin classes against the contract-typed registry.
- README updated (interface owned by the adapter, no more follow-up caveat).
- Zero runtime changes.

Verification: tsc clean, eslint clean, 51 unit + 19 plan-approval tests green; the `spi` CI job additionally compiles this code against the locally packed SPI.

Remaining #325 work is tools-repo side: plugin peer switch to the SPI, dtcc + collateral off the deprecated package (TS + Solidity), ownera deprecation notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)