### PR TITLE
Don't warn when TOKENY envs are absent

### DIFF
--- a/src/integrations/ethereum-standards/index.ts
+++ b/src/integrations/ethereum-standards/index.ts
@@ -28,8 +28,9 @@ import { pooledProvider, pooledSigner } from "../signer-pool";
  * constructor arguments — an optional whitelisting signer
  * (TOKEN_STANDARD_ALLOWLISTER_PRIVATE_KEY) where the constructor accepts one
  * (CMTAT, HEDERA_ATS), and an optional TREX investor qualifier built from
- * TOKENY_API_URL + TOKENY_EMAIL + TOKENY_PASSWORD. What each argument
- * authorizes, and the behavior when it is absent, is the plugin's contract.
+ * TOKENY_API_URL + TOKENY_EMAIL + TOKENY_PASSWORD when those are set. What
+ * each argument authorizes, and the behavior when it is absent, is the
+ * plugin's contract.
  *
  * Missing agent keys degrade to validate-only, not to unregistered:
  * provider-backed reads (balanceOf, whitelist checks — ensureWhitelisted
@@ -65,8 +66,6 @@ export function registerEthereumTokenStandards(ctx: IntegrationContext): void {
   if (tokenyUrl && tokenyEmail && tokenyPassword) {
     trexQualifier = createTokenyQualifier(new TokenyClient(tokenyUrl, tokenyEmail, tokenyPassword), finP2PClient as any, provider, controller);
     logger.info("TREX investor qualifier enabled via the Tokeny API");
-  } else {
-    logger.warn("TREX investor qualifier disabled (set TOKENY_API_URL + TOKENY_EMAIL + TOKENY_PASSWORD to enable Tokeny onboarding); ensureWhitelisted fails closed for unverified investors");
   }
 
   const standards: Array<[string, TokenStandard]> = [

--- a/tests/ethereum-standards.test.ts
+++ b/tests/ethereum-standards.test.ts
@@ -53,10 +53,9 @@ describe("registerEthereumTokenStandards (real plugin standards)", () => {
     process.env.OPERATOR_PRIVATE_KEY = OPERATOR_KEY;
 
     registerEthereumTokenStandards({ logger: warningLogger, rpcUrl: RPC } as any);
-    // fully keyed — no degraded-mode warning; the TREX qualifier warn is
-    // expected while the TOKENY_* envs are absent
-    expect(warnings.some(w => w.includes("validate-only"))).toBe(false);
-    expect(warnings.some(w => w.includes("TREX investor qualifier disabled"))).toBe(true);
+    // fully keyed — no warnings at all; absent TOKENY_* envs are silent
+    // (TREX qualifier stays off without noise)
+    expect(warnings).toEqual([]);
 
     const expected: Array<[string, any]> = [
       ["TREX", TrexTokenStandard],


### PR DESCRIPTION
The `registerEthereumTokenStandards` wiring warned on every boot when the `TOKENY_*` envs were unset:

> TREX investor qualifier disabled (set TOKENY_API_URL + TOKENY_EMAIL + TOKENY_PASSWORD …); ensureWhitelisted fails closed for unverified investors

Absent Tokeny credentials is the **normal, intended** state for any deployment that doesn't use TREX onboarding — observed firing on the pure-ERC20/HTS Hedera adapters (`hashsphereerc20`, `testneterc20`) where it's irrelevant and its "fails closed for unverified investors" phrasing is needlessly alarming.

Change: drop the `else` warn branch. The `info` line stays when the qualifier is actually enabled (TOKENY_* present); otherwise startup is silent. No behavior change — the qualifier is still `undefined` when unconfigured, exactly as before.

Test updated: the fully-keyed registration path now asserts no warnings at all.

tsc + eslint clean; 51 unit tests green.

_Note: the deeper coupling — the adapter constructing Tokeny at all — is tracked separately as a boundary concern (Tokeny is a TREX-plugin internal); this PR only removes the noise._

🤖 Generated with [Claude Code](https://claude.com/claude-code)