### PR TITLE
Ephemeral signer instead of VoidSigner when agent keys are absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The base `TokenStandard` interface is owned by the adapter and published as [`@o
 | `OWNERA_COLLATERAL_REGISTRY` | `@owneraio/finp2p-ethereum-collateral` | `COLLATERAL_REGISTRY_ADDRESS` + `COLLATERAL_AGENT_PRIVATE_KEY` |
 | `DTCC_COLLATERAL_ACCOUNT` | `@owneraio/finp2p-ethereum-dtcc-plugin` | `DTCC_PLUGIN_ENABLED=true` |
 
-¹ Signers default to `OPERATOR_PRIVATE_KEY`; override per role with `TOKEN_STANDARD_ISSUER_PRIVATE_KEY` / `TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY`. Standards whose constructors accept a whitelisting signer receive `TOKEN_STANDARD_ALLOWLISTER_PRIVATE_KEY`; TREX accepts an investor qualifier built from `TOKENY_API_URL` + `TOKENY_EMAIL` + `TOKENY_PASSWORD`. Optional-argument semantics are each plugin's contract. Without keys the standards register in validate-only mode — reads and whitelist checks work, agent writes fail per operation. Skipped entirely only when `NETWORK_HOST` is unset.
+¹ Signers default to `OPERATOR_PRIVATE_KEY`; override per role with `TOKEN_STANDARD_ISSUER_PRIVATE_KEY` / `TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY`. Standards whose constructors accept a whitelisting signer receive `TOKEN_STANDARD_ALLOWLISTER_PRIVATE_KEY`; TREX accepts an investor qualifier built from `TOKENY_API_URL` + `TOKENY_EMAIL` + `TOKENY_PASSWORD`. Optional-argument semantics are each plugin's contract. Without an issuer/controller key the standards register with an ephemeral signer — reads and whitelist checks work; on-chain agent writes need a configured, authorized key. Skipped entirely only when `NETWORK_HOST` is unset.
 
 ## Documentation
 

--- a/src/integrations/ethereum-standards/index.ts
+++ b/src/integrations/ethereum-standards/index.ts
@@ -1,4 +1,4 @@
-import { VoidSigner, ZeroAddress } from "ethers";
+import { Wallet } from "ethers";
 import { TokenStandard } from "@owneraio/finp2p-ethereum-adapter-contract";
 import { TrexTokenStandard, TokenStandardName as TREX_STANDARD, TokenyClient, createTokenyQualifier, TrexInvestorQualifier } from "@owneraio/finp2p-ethereum-trex-plugin";
 import { CmtatTokenStandard, TokenStandardName as CMTAT_STANDARD } from "@owneraio/finp2p-ethereum-cmtat-plugin";
@@ -32,10 +32,12 @@ import { pooledProvider, pooledSigner } from "../signer-pool";
  * each argument authorizes, and the behavior when it is absent, is the
  * plugin's contract.
  *
- * Missing agent keys degrade to validate-only, not to unregistered:
- * provider-backed reads (balanceOf, whitelist checks — ensureWhitelisted
- * succeeds for already-whitelisted investors) keep working, and only the
- * agent writes (deploy/mint/whitelist additions) fail per-operation.
+ * A missing issuer/controller key is not a real secret for deployments that
+ * don't use these standards for agent writes (plain ERC20 signs via custody
+ * wallets): an ephemeral signer stands in, so provider-backed reads and
+ * whitelist checks work with a valid address. Unauthorized/unfunded writes
+ * still fail on-chain per operation — nothing is lost versus a configured key
+ * for such deployments, and deployments that DO issue set the explicit keys.
  */
 export function registerEthereumTokenStandards(ctx: IntegrationContext): void {
   const { logger, rpcUrl, finP2PClient } = ctx;
@@ -51,12 +53,15 @@ export function registerEthereumTokenStandards(ctx: IntegrationContext): void {
   }
 
   const provider = pooledProvider(rpcUrl);
-  const readOnlySigner = new VoidSigner(ZeroAddress, provider);
-  if (!issuerKey || !controllerKey) {
-    logger.warn(`Ethereum token standards (${names.join(", ")}) registered in validate-only mode: reads and whitelist checks work, agent writes (deploy/mint/whitelist additions) fail until OPERATOR_PRIVATE_KEY or TOKEN_STANDARD_ISSUER/CONTROLLER_PRIVATE_KEY is configured`);
+  // Absent role keys get one shared ephemeral signer (valid address, can sign
+  // locally; on-chain writes fail unless the address is actually authorized).
+  // Deployments issuing through these standards set the explicit keys.
+  const ephemeral = !issuerKey || !controllerKey ? Wallet.createRandom().connect(provider) : undefined;
+  if (ephemeral) {
+    logger.info(`Ethereum token standards (${names.join(", ")}): no issuer/controller key configured — using an ephemeral signer (reads and whitelist checks work; set TOKEN_STANDARD_ISSUER_PRIVATE_KEY to issue)`);
   }
-  const issuer = issuerKey ? pooledSigner(rpcUrl, issuerKey) : readOnlySigner;
-  const controller = controllerKey ? pooledSigner(rpcUrl, controllerKey) : readOnlySigner;
+  const issuer = issuerKey ? pooledSigner(rpcUrl, issuerKey) : ephemeral!;
+  const controller = controllerKey ? pooledSigner(rpcUrl, controllerKey) : ephemeral!;
   const allowlister = allowlisterKey ? pooledSigner(rpcUrl, allowlisterKey) : undefined;
 
   const tokenyUrl = process.env.TOKENY_API_URL;

--- a/tests/ethereum-standards.test.ts
+++ b/tests/ethereum-standards.test.ts
@@ -35,11 +35,11 @@ describe("registerEthereumTokenStandards (real plugin standards)", () => {
     }
   });
 
-  test("without agent keys: registers all four in validate-only mode instead of skipping", () => {
+  test("without agent keys: registers all four with an ephemeral signer, no warning", () => {
     warnings.length = 0;
     registerEthereumTokenStandards({ logger: warningLogger, rpcUrl: RPC } as any);
 
-    expect(warnings.some(w => w.includes("validate-only"))).toBe(true);
+    expect(warnings).toEqual([]); // ephemeral signer is a normal state, not a warning
     for (const name of ["TREX", "CMTAT", "BENJI", "HEDERA_ATS"]) {
       expect(tokenStandardRegistry.has(name)).toBe(true);
     }


### PR DESCRIPTION
Follow-up to the template trim (owneraio/template-catalog#307) and #331. `OPERATOR_PRIVATE_KEY`/controller is effectively a read key for custody deployments — plain ERC20 signs via custody wallets, so the plugin-standard signers it feeds are never exercised.

## Change
In `registerEthereumTokenStandards`, a missing issuer/controller key now yields a **shared ephemeral signer** (`Wallet.createRandom().connect(provider)`) instead of `VoidSigner(ZeroAddress)`:
- valid non-zero address → provider reads and whitelist checks work cleanly, can sign locally, no `getAddress()`→`0x0` surprises;
- on-chain agent writes still fail unless the address is authorized/funded — identical outcome for deployments that don't use these standards; issuers set `TOKEN_STANDARD_ISSUER_PRIVATE_KEY`.

The `warn`-level "validate-only mode" line becomes a concise `info` — an ephemeral signer is a normal state, not a warning. Combined with #331 (TOKENY-absent silence), a stock ERC20/HTS custody adapter now boots without spurious token-standard warnings.

_(Supersedes #332, which was auto-closed when its stacked base branch was deleted on #331 merge; rebased onto master, redundant tokeny-removal commit dropped.)_

## Tests
`ethereum-standards.test.ts` no-keys path asserts all four register with no warning. tsc + eslint clean; 51 unit tests green. README footnote updated (validate-only → ephemeral).

> Note: broader "plugin standards only, no fallbacks" removal of custody issuance is tracked in #333; this PR only fixes the no-key signer/logging.