### PR TITLE
Pin finp2p-contracts 0.28.21, drop ownera override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dfns/sdk-keysigner": "^0.8.11",
         "@fireblocks/fireblocks-web3-provider": "^1.3.12",
         "@owneraio/finp2p-client": "^0.28.22",
-        "@owneraio/finp2p-contracts": "^0.28.20",
+        "@owneraio/finp2p-contracts": "^0.28.21",
         "@owneraio/finp2p-ethereum-adapter-contract": "^0.28.0",
         "@owneraio/finp2p-ethereum-benji-plugin": "^0.28.4",
         "@owneraio/finp2p-ethereum-cmtat-plugin": "^0.28.5",
@@ -1737,12 +1737,11 @@
       }
     },
     "node_modules/@owneraio/finp2p-contracts": {
-      "version": "0.28.20",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.20/d5433662507b669d69f50834564e78b2d661f92d",
-      "integrity": "sha512-PkhPJfa1jr8b49k5NePVd/wj48j7LB+y6VQHt+OatDJqPrRKTGpUESApb4DnKBl2/YBPJjcV3+/WMRoekdbIXg==",
+      "version": "0.28.21",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-contracts/0.28.21/78d3f5bf48c9c9c46db95d08ac5b5574b5106783",
+      "integrity": "sha512-xF8fYMAtzsKhM0+qNIzjEtx9+TsFkgz5hulWrg0VO94cwuuLZeNOL00+VWm6EU4MnaCMxt+xq1Fhj3KrVcSHjg==",
       "license": "TBD",
       "dependencies": {
-        "@owneraio/finp2p-ethereum-token-standard": "^0.28.2",
         "ethers": "^6.11.1"
       },
       "bin": {
@@ -1836,16 +1835,6 @@
       "peerDependencies": {
         "@owneraio/finp2p-contracts": "^0.28.20",
         "@owneraio/finp2p-ethereum-adapter-contract": "^0.28.0"
-      }
-    },
-    "node_modules/@owneraio/finp2p-ethereum-token-standard": {
-      "name": "@owneraio/finp2p-ethereum-adapter-contract",
-      "version": "0.28.0",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-adapter-contract/0.28.0/b5a58b6574d2733c723d5f397e86664d3d0720c4",
-      "integrity": "sha512-LuQiJbMvt4NKOF7lbA2vzYrNqGfH78ALhppG+qNIQW07ZTagz6eOGY8+RzuNCWTM/Au8RM8Lm7gVyJWJRZ220w==",
-      "license": "TBD",
-      "dependencies": {
-        "ethers": "^6.9.0"
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-trex-plugin": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@dfns/sdk-keysigner": "^0.8.11",
     "@fireblocks/fireblocks-web3-provider": "^1.3.12",
     "@owneraio/finp2p-client": "^0.28.22",
-    "@owneraio/finp2p-contracts": "^0.28.20",
+    "@owneraio/finp2p-contracts": "^0.28.21",
     "@owneraio/finp2p-ethereum-adapter-contract": "^0.28.0",
     "@owneraio/finp2p-ethereum-benji-plugin": "^0.28.4",
     "@owneraio/finp2p-ethereum-cmtat-plugin": "^0.28.5",
@@ -85,8 +85,5 @@
     "prettier": "2.5.1",
     "testcontainers": "^11.8.0",
     "ts-jest": "^29.0.3"
-  },
-  "overrides": {
-    "@owneraio/finp2p-ethereum-token-standard": "npm:@owneraio/finp2p-ethereum-adapter-contract@^0.28.0"
   }
 }


### PR DESCRIPTION
Follow-up to #335. Now that `@owneraio/finp2p-contracts@0.28.21` is published (vendored base Solidity, no ownera dependency):

- Bump the adapter pin `^0.28.20 → ^0.28.21`.
- Remove the `overrides` redirect of the deprecated `finp2p-ethereum-token-standard` alias — 0.28.21 no longer declares it, so nothing resolves the removed `finp2p-ethereum-ownera` anymore. Clean end state, no override machinery.

Verified: clean `npm install` has zero `finp2p-ethereum-ownera` in the tree; tsc + eslint + 51 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)