### PR TITLE
Rename token-standard agent key envs to ASSET_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The base `TokenStandard` interface is owned by the adapter and published as [`@o
 | `OWNERA_COLLATERAL_REGISTRY` | `@owneraio/finp2p-ethereum-collateral` | `COLLATERAL_REGISTRY_ADDRESS` + `COLLATERAL_AGENT_PRIVATE_KEY` |
 | `DTCC_COLLATERAL_ACCOUNT` | `@owneraio/finp2p-ethereum-dtcc-plugin` | `DTCC_PLUGIN_ENABLED=true` |
 
-¹ Signers default to `OPERATOR_PRIVATE_KEY`; override per role with `TOKEN_STANDARD_ISSUER_PRIVATE_KEY` / `TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY`. Standards whose constructors accept a whitelisting signer receive `TOKEN_STANDARD_ALLOWLISTER_PRIVATE_KEY` (TREX, CMTAT, HEDERA_ATS). Optional-argument semantics are each plugin's contract. Without an issuer/controller key the standards register with an ephemeral signer — reads and whitelist checks work; on-chain agent writes need a configured, authorized key. Skipped entirely only when `NETWORK_HOST` is unset.
+¹ Signers default to `OPERATOR_PRIVATE_KEY`; override per role with `ASSET_ISSUER_PRIVATE_KEY` / `ASSET_CONTROLLER_PRIVATE_KEY`. Standards whose constructors accept a whitelisting signer receive `ASSET_WHITELIST_PRIVATE_KEY` (TREX, CMTAT, HEDERA_ATS). Optional-argument semantics are each plugin's contract. Without an issuer/controller key the standards register with an ephemeral signer — reads and whitelist checks work; on-chain agent writes need a configured, authorized key. Skipped entirely only when `NETWORK_HOST` is unset.
 
 ## Documentation
 

--- a/src/integrations/token-standards/register.ts
+++ b/src/integrations/token-standards/register.ts
@@ -23,17 +23,17 @@ export function registerTokenStandards(ctx: IntegrationContext): void {
 
 /**
  * TREX/CMTAT/BENJI/HEDERA_ATS. issuer/controller default to
- * OPERATOR_PRIVATE_KEY (override per role via TOKEN_STANDARD_ISSUER/CONTROLLER
- * _PRIVATE_KEY); whitelisting writes use TOKEN_STANDARD_ALLOWLISTER_PRIVATE_KEY.
+ * OPERATOR_PRIVATE_KEY (override per role via ASSET_ISSUER_PRIVATE_KEY /
+ * ASSET_CONTROLLER_PRIVATE_KEY); whitelisting writes use ASSET_WHITELIST_PRIVATE_KEY.
  * Absent an issuer/controller key an ephemeral signer stands in — reads and
  * whitelist checks work; on-chain writes need a configured, authorized key.
  */
 export function registerEthereumTokenStandards(ctx: IntegrationContext): void {
   const { logger, rpcUrl } = ctx;
   const operatorKey = process.env.OPERATOR_PRIVATE_KEY;
-  const issuerKey = process.env.TOKEN_STANDARD_ISSUER_PRIVATE_KEY ?? operatorKey;
-  const controllerKey = process.env.TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY ?? operatorKey;
-  const allowlisterKey = process.env.TOKEN_STANDARD_ALLOWLISTER_PRIVATE_KEY;
+  const issuerKey = process.env.ASSET_ISSUER_PRIVATE_KEY ?? operatorKey;
+  const controllerKey = process.env.ASSET_CONTROLLER_PRIVATE_KEY ?? operatorKey;
+  const allowlisterKey = process.env.ASSET_WHITELIST_PRIVATE_KEY;
 
   const names = [TREX_STANDARD, CMTAT_STANDARD, BENJI_STANDARD, HEDERA_ATS_STANDARD];
   if (!rpcUrl) {
@@ -44,7 +44,7 @@ export function registerEthereumTokenStandards(ctx: IntegrationContext): void {
   const provider = pooledProvider(rpcUrl);
   const ephemeral = !issuerKey || !controllerKey ? Wallet.createRandom().connect(provider) : undefined;
   if (ephemeral) {
-    logger.info(`Ethereum token standards (${names.join(", ")}): no issuer/controller key configured — using an ephemeral signer (reads and whitelist checks work; set TOKEN_STANDARD_ISSUER_PRIVATE_KEY to issue)`);
+    logger.info(`Ethereum token standards (${names.join(", ")}): no issuer/controller key configured — using an ephemeral signer (reads and whitelist checks work; set ASSET_ISSUER_PRIVATE_KEY to issue)`);
   }
   const issuer = issuerKey ? pooledSigner(rpcUrl, issuerKey) : ephemeral!;
   const controller = controllerKey ? pooledSigner(rpcUrl, controllerKey) : ephemeral!;

--- a/tests/ethereum-standards.test.ts
+++ b/tests/ethereum-standards.test.ts
@@ -21,8 +21,8 @@ describe("registerEthereumTokenStandards (real plugin standards)", () => {
 
   test("without rpc: warns and registers nothing, does not throw", () => {
     delete process.env.OPERATOR_PRIVATE_KEY;
-    delete process.env.TOKEN_STANDARD_ISSUER_PRIVATE_KEY;
-    delete process.env.TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY;
+    delete process.env.ASSET_ISSUER_PRIVATE_KEY;
+    delete process.env.ASSET_CONTROLLER_PRIVATE_KEY;
     delete process.env.TOKENY_API_URL;
     delete process.env.TOKENY_EMAIL;
     delete process.env.TOKENY_PASSWORD;


### PR DESCRIPTION
Aligns the token-standard agent key env names under the `ASSET_` prefix, now that the custody `ASSET_ISSUER_CUSTODY_ACCOUNT_ID` is retired (template-catalog#307):

| Old | New |
|---|---|
| `TOKEN_STANDARD_ISSUER_PRIVATE_KEY` | `ASSET_ISSUER_PRIVATE_KEY` |
| `TOKEN_STANDARD_CONTROLLER_PRIVATE_KEY` | `ASSET_CONTROLLER_PRIVATE_KEY` |
| `TOKEN_STANDARD_ALLOWLISTER_PRIVATE_KEY` | `ASSET_WHITELIST_PRIVATE_KEY` |

`OPERATOR_PRIVATE_KEY` stays as the base these override. Not deployed under the old names yet (template not merged), so a clean rename — no back-compat aliasing.

Template counterpart: owneraio/template-catalog#307 updated to match.

tsc + eslint + 51 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)