### PR TITLE
Hotfix: bump hedera-plugin to ^0.28.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@owneraio/finp2p-ethereum-cmtat-plugin": "^0.28.5",
         "@owneraio/finp2p-ethereum-collateral": "^0.28.26",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.10",
-        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.5",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.5",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
         "@owneraio/finp2p-vanilla-service": "^0.28.6",
@@ -1826,9 +1826,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
-      "version": "0.28.5",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.5/1ae7065b76da0beb6b93c04d8f206aacd9048957",
-      "integrity": "sha512-J6DLMdwSQCRAgCirhhbL65W138ri1UdDOYEckwiEMkNn6htZTLm5kWz8HHKbvO14kSg3kbtq+dlCJboY22IY5A==",
+      "version": "0.28.6",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.6/7f461ef825890d37225b85531189c3d64b5d95d6",
+      "integrity": "sha512-AFTnh3ql3DpbtWdKUXqzkESQJU8Y88nOa9+33iN/2/dN10IDokO1KCL/DfqKhF2nJ6eWP+5YAcpXTz9LC/3caw==",
       "dependencies": {
         "ethers": "^6.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@owneraio/finp2p-ethereum-cmtat-plugin": "^0.28.5",
     "@owneraio/finp2p-ethereum-collateral": "^0.28.26",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.10",
-    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.5",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.5",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
     "@owneraio/finp2p-vanilla-service": "^0.28.6",


### PR DESCRIPTION
Hotfix bump of `@owneraio/finp2p-ethereum-hedera-plugin` `^0.28.5 → ^0.28.6`. Constructor unchanged (`provider, issuer, controller, allowlister?`) — no adapter wiring change. tsc + 51 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)