### PR TITLE
Whitelisting: whitelist business parties only, drop the instruction-endpoint map

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -128,7 +128,7 @@ function registerDirectServices(
     // recipients must exist (Hedera auto-create) before whitelisting can
     // reference them; whitelisting gates (and can veto) before gas is spent
     new WalletActivationOption(custodyProvider, accountMapping, walletActivationAmount),
-    new TokenWhitelistingOption(assetStore, accountMapping, custodyProvider),
+    new TokenWhitelistingOption(assetStore, accountMapping),
     new GasPrefundingOption(custodyProvider, accountMapping),
   ];
   const planApprovalService = new ConfigurablePlanApprovalService(

--- a/src/services/direct/token-whitelisting-option.ts
+++ b/src/services/direct/token-whitelisting-option.ts
@@ -2,27 +2,14 @@ import { logger, rejectedPlan } from "@owneraio/finp2p-nodejs-skeleton-adapter";
 import { AssetRecord, Logger as TokenLogger } from "@owneraio/finp2p-ethereum-adapter-contract";
 import { PlanApprovalOption, IntrospectedPlan, IntrospectedInstruction } from "../plan-approval";
 import { AccountMappingService, AssetStore } from "./account-mapping";
-import { CustodyProvider } from "./custody-provider";
 import { tokenStandardRegistry } from "./token-standards/registry";
-import { InvestorWhitelisting, supportsWhitelisting, WhitelistParty, WhitelistPartyRole } from "./token-standards/whitelisting";
+import { InvestorWhitelisting, supportsWhitelisting, WhitelistParty } from "./token-standards/whitelisting";
 
 const tokenLogger: TokenLogger = {
   info: (m, ...a) => logger.info(m, ...a),
   warn: (m, ...a) => logger.warning(m, ...a),
   error: (m, ...a) => logger.error(m, ...a),
   debug: (m, ...a) => logger.debug(m, ...a),
-};
-
-// which parties each instruction type actually moves tokens between — holds
-// transfer source → escrow, releases escrow → destination; a hold's business
-// destination is not a transfer endpoint until the release names it
-const INSTRUCTION_ENDPOINTS: Record<string, WhitelistPartyRole[]> = {
-  issue: ["destination"],
-  transfer: ["source", "destination"],
-  hold: ["source", "escrow"],
-  release: ["escrow", "destination"],
-  revertHoldInstruction: ["escrow", "destination"],
-  redeem: ["source", "escrow"],
 };
 
 type AssetWork = {
@@ -35,20 +22,18 @@ type AssetWork = {
 
 /**
  * Plan-approval option that runs token-standard-specific investor
- * whitelisting for every asset of the plan this adapter is responsible for —
- * both legs when both assets are kept here, or just the one that is.
+ * whitelisting for every asset of the plan this adapter is responsible for.
  *
  * Responsibility test: the instruction executes on this ledger AND the asset
- * is registered in this adapter's asset store. The asset's standard is
- * resolved first; only standards with the whitelisting capability have their
- * parties collected, so plain ERC20 plans are never vetoed over an account
- * that whitelisting alone would need. Parties are the actual transfer
- * endpoints of each instruction type (including the escrow custody wallet for
- * hold/release paths), resolved with execution's exact rules: account mapping
- * everywhere, with the instruction's explicit ledger address as fallback only
- * where execution accepts one — transfer/release destinations. Resolved
- * parties are handed to ensureWhitelisted sequentially, since standards sign
- * with pooled agent keys.
+ * is registered in this adapter's asset store. For each such asset the
+ * business parties named on its instructions — the source and destination
+ * finIds — are resolved to addresses and handed to the standard's
+ * ensureWhitelisted, sequentially. How the standard actually moves tokens
+ * (escrow accounts, hold/release routing, etc.) is the standard's own concern;
+ * the adapter passes the investors involved and lets the standard decide what
+ * "whitelisted" requires. ensureWhitelisted is idempotent, so covering every
+ * party is safe. Standards without the whitelisting capability (plain ERC20)
+ * are skipped.
  *
  * Gating: a party that cannot be whitelisted (or resolved) means the plan
  * will fail at execution — reject at approval instead.
@@ -61,14 +46,11 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
   constructor(
     private readonly assetStore: AssetStore,
     private readonly accountMapping: AccountMappingService,
-    private readonly custodyProvider: CustodyProvider,
   ) {}
 
   async apply(plan: IntrospectedPlan): Promise<ReturnType<typeof rejectedPlan> | void> {
     const work = new Map<string, AssetWork>();
     const foreignAssets = new Set<string>();
-    let escrowAddress: string | undefined;
-    let escrowResolved = false;
 
     for (const instruction of plan.instructions) {
       if (!instruction.local || !instruction.assetId) continue;
@@ -107,24 +89,9 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
       }
       if (!entry.whitelisting) continue; // e.g. plain ERC20 — nothing to resolve
 
-      for (const role of INSTRUCTION_ENDPOINTS[instruction.type ?? ""] ?? []) {
-        if (role === "escrow") {
-          if (!escrowResolved) {
-            escrowAddress = await this.tryResolveEscrowAddress(plan.planId);
-            escrowResolved = true;
-          }
-          if (!escrowAddress) {
-            // hold/release execution needs this wallet — approving without
-            // whitelisting the actual endpoint would just defer the failure
-            logger.warning(`Plan ${plan.planId}: escrow wallet address is unavailable but asset ${entry.assetId} needs its escrow endpoint whitelisted — rejecting`);
-            return rejectedPlan(1, `Plan ${plan.planId}: escrow wallet address is unavailable; cannot whitelist the escrow endpoint of asset ${entry.assetId}`);
-          }
-          entry.parties.set(`escrow|${escrowAddress}`, { address: escrowAddress, role: "escrow" });
-          continue;
-        }
-        const veto = await this.addParty(entry, instruction, role, plan.planId);
-        if (veto) return veto;
-      }
+      const veto = await this.addParty(entry, instruction, "source", plan.planId)
+        ?? await this.addParty(entry, instruction, "destination", plan.planId);
+      if (veto) return veto;
     }
 
     for (const { assetId, asset, whitelisting, parties } of work.values()) {
@@ -145,11 +112,9 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
     entry: AssetWork, instruction: IntrospectedInstruction, role: "source" | "destination", planId: string
   ): Promise<ReturnType<typeof rejectedPlan> | undefined> {
     const finId = role === "source" ? instruction.sourceFinId : instruction.destinationFinId;
-    // execution accepts an explicit ledger address only for transfer/release
-    // destinations; sources always require a mapped custody wallet
-    const explicitAddress = role === "destination" && (instruction.type === "transfer" || instruction.type === "release")
-      ? instruction.destinationAddress
-      : undefined;
+    // execution accepts an explicit ledger address only for a destination; a
+    // source always resolves through the account mapping
+    const explicitAddress = role === "destination" ? instruction.destinationAddress : undefined;
     if (!finId && !explicitAddress) return undefined;
 
     const key = `${finId ?? explicitAddress}|${role}`;
@@ -163,25 +128,5 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
     }
     entry.parties.set(key, { finId, address, role });
     return undefined;
-  }
-
-  /**
-   * The escrow custody wallet is a transfer endpoint of hold/release paths and
-   * may need whitelisting itself. An unresolvable address (e.g. an
-   * unconfigured Fireblocks placeholder vault with no getAddress()) makes the
-   * caller veto: hold/release execution needs that wallet anyway.
-   */
-  private async tryResolveEscrowAddress(planId: string): Promise<string | undefined> {
-    try {
-      const signer = this.custodyProvider.escrow?.signer as { getAddress?: () => Promise<string> } | undefined;
-      if (!signer || typeof signer.getAddress !== "function") {
-        logger.warning(`Token whitelisting: escrow wallet has no resolvable address (placeholder?) for plan ${planId}`);
-        return undefined;
-      }
-      return await signer.getAddress();
-    } catch (e) {
-      logger.warning(`Token whitelisting: resolving escrow wallet address for plan ${planId} failed: ${e}`);
-      return undefined;
-    }
   }
 }

--- a/tests/token-whitelisting.test.ts
+++ b/tests/token-whitelisting.test.ts
@@ -14,7 +14,6 @@ const ADDR: Record<string, string> = {
   [ALICE]: "0x1111111111111111111111111111111111111111",
   [BOB]: "0x2222222222222222222222222222222222222222"
 };
-const ESCROW_ADDR = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const EXPLICIT_ADDR = "0x3333333333333333333333333333333333333333";
 
 type Call = { assetId: string; parties: WhitelistParty[] };
@@ -30,21 +29,14 @@ function whitelistingStandard(calls: Call[], failWith?: string) {
 
 const plainStandard = {} as any;
 
-const escrowProvider = (address?: string) => ({
-  escrow: { signer: address ? { getAddress: async () => address } : {} }
-}) as any;
-
-function buildOption(
-  assets: Record<string, string>, mapped: Record<string, string> = ADDR,
-  custodyProvider = escrowProvider(ESCROW_ADDR)
-) {
+function buildOption(assets: Record<string, string>, mapped: Record<string, string> = ADDR) {
   const assetStore = {
     getAsset: async (id: string) => assets[id]
       ? { contract_address: `0xtoken-${id}`, decimals: 2, token_standard: assets[id], id }
       : undefined
   } as any;
   const accountMapping = { resolveAccount: async (finId: string) => mapped[finId] } as any;
-  return new TokenWhitelistingOption(assetStore, accountMapping, custodyProvider);
+  return new TokenWhitelistingOption(assetStore, accountMapping);
 }
 
 const instruction = (
@@ -68,21 +60,40 @@ describe("TokenWhitelistingOption", () => {
   });
   beforeEach(() => { calls.length = 0; });
 
-  test("whitelists the transfer endpoints of both assets when both are kept in this adapter", async () => {
+  test("whitelists the source+destination parties of each asset kept in this adapter", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST", [SETTLEMENT_ID]: "WL_TEST" });
     const veto = await option.apply(plan([
       instruction(SETTLEMENT_ID, ALICE, BOB, true, "hold"),
       instruction(ASSET_ID, BOB, ALICE),
-      instruction(SETTLEMENT_ID, ALICE, BOB, true, "release")
     ]));
     expect(veto).toBeUndefined();
     expect(calls).toHaveLength(2);
     const byAsset = Object.fromEntries(calls.map(c => [c.assetId, c.parties]));
-    // hold moves ALICE → escrow, release moves escrow → BOB
     expect(partyKeys(byAsset[`0xtoken-${SETTLEMENT_ID}`]))
-      .toEqual([`${ALICE}:source`, `${BOB}:destination`, `${ESCROW_ADDR}:escrow`].sort());
+      .toEqual([`${ALICE}:source`, `${BOB}:destination`].sort());
     expect(partyKeys(byAsset[`0xtoken-${ASSET_ID}`]))
       .toEqual([`${BOB}:source`, `${ALICE}:destination`].sort());
+  });
+
+  test("an escrow party (no finId) is never whitelisted — escrow is preconfigured outside the adapter", async () => {
+    // a hold whose destination is the escrow carries no destinationFinId
+    const option = buildOption({ [ASSET_ID]: "WL_TEST" });
+    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, undefined, true, "hold")]));
+    expect(veto).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(partyKeys(calls[0].parties)).toEqual([`${ALICE}:source`]);
+  });
+
+  test("collects both roles across an asset's instructions, deduped by finId+role", async () => {
+    const option = buildOption({ [ASSET_ID]: "WL_TEST" });
+    await option.apply(plan([
+      instruction(ASSET_ID, ALICE, BOB, true, "hold"),
+      instruction(ASSET_ID, ALICE, BOB, true, "release"),
+      instruction(ASSET_ID, BOB, ALICE, true, "transfer"),
+    ]));
+    expect(calls).toHaveLength(1);
+    expect(partyKeys(calls[0].parties))
+      .toEqual([`${ALICE}:source`, `${ALICE}:destination`, `${BOB}:source`, `${BOB}:destination`].sort());
   });
 
   test("only the asset kept in this adapter is whitelisted", async () => {
@@ -96,33 +107,15 @@ describe("TokenWhitelistingOption", () => {
     expect(calls[0].assetId).toBe(`0xtoken-${ASSET_ID}`);
   });
 
-  test("a hold's business destination is not a transfer endpoint — no veto when it is unmapped", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [ALICE]: ADDR[ALICE] }); // BOB unmapped
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB, true, "hold")]));
-    expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(1);
-    expect(partyKeys(calls[0].parties)).toEqual([`${ALICE}:source`, `${ESCROW_ADDR}:escrow`].sort());
-  });
-
-  test("parties are deduplicated across instructions of the same asset", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" });
-    await option.apply(plan([
-      instruction(ASSET_ID, ALICE, BOB),
-      instruction(ASSET_ID, ALICE, BOB)
-    ]));
-    expect(calls).toHaveLength(1);
-    expect(calls[0].parties).toHaveLength(2);
-  });
-
   test("standards without the whitelisting capability are skipped before any party resolution", async () => {
     expect(supportsWhitelisting(plainStandard)).toBe(false);
     const option = buildOption({ [ASSET_ID]: "WL_PLAIN" }, {}); // nothing mapped at all
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB, true, "hold")]));
+    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB)]));
     expect(veto).toBeUndefined();
     expect(calls).toHaveLength(0);
   });
 
-  test("an explicit ledger address is used when the finId is unmapped, like execution", async () => {
+  test("an explicit ledger address is used for a destination when the finId is unmapped", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [ALICE]: ADDR[ALICE] }); // BOB unmapped
     const veto = await option.apply(plan([
       instruction(ASSET_ID, ALICE, BOB, true, "transfer", { destinationAddress: EXPLICIT_ADDR })
@@ -134,21 +127,6 @@ describe("TokenWhitelistingOption", () => {
     expect(destination?.finId).toBe(BOB);
   });
 
-  test("an escrow wallet without a resolvable address vetoes a plan that needs the escrow endpoint", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, ADDR, escrowProvider(undefined));
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB, true, "hold")]));
-    expect(veto?.type).toBe("rejected");
-    expect((veto as any).error.message).toMatch(/escrow wallet address is unavailable/);
-    expect(calls).toHaveLength(0);
-  });
-
-  test("a plan without escrow endpoints is unaffected by an unresolvable escrow wallet", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, ADDR, escrowProvider(undefined));
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB)]));
-    expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(1);
-  });
-
   test("an explicit address is not accepted for a source — execution needs a mapped custody wallet", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [BOB]: ADDR[BOB] }); // ALICE unmapped
     const veto = await option.apply(plan([
@@ -157,15 +135,6 @@ describe("TokenWhitelistingOption", () => {
     expect(veto?.type).toBe("rejected");
     expect((veto as any).error.message).toMatch(/cannot resolve address for source/);
     expect(calls).toHaveLength(0);
-  });
-
-  test("an explicit address is not accepted for an issue destination — execution resolves it via mapping only", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, {}); // BOB unmapped
-    const veto = await option.apply(plan([
-      instruction(ASSET_ID, undefined, BOB, true, "issue", { destinationAddress: EXPLICIT_ADDR })
-    ]));
-    expect(veto?.type).toBe("rejected");
-    expect((veto as any).error.message).toMatch(/cannot resolve address for destination/);
   });
 
   test("whitelisting failure vetoes the plan", async () => {


### PR DESCRIPTION
`TokenWhitelistingOption` hardcoded `INSTRUCTION_ENDPOINTS` — a per-instruction-type map asserting which parties each type moves tokens between (hold = source→escrow, release = escrow→destination, redeem = source→escrow, …) plus resolution of the escrow custody wallet. That's execution/escrow mechanics the adapter must not encode, and it's wrong in principle:

- **Escrow is not an investor.** It has no finId, isn't onboarded, isn't part of the FinP2P whitelisting flow, and is assumed preconfigured outside the adapter. It must never be whitelisted.
- **Plan composition is fluid.** The instruction set isn't rigid — a redeem may carry no escrow, while escrow may sit on the cash leg's hold/release. A fixed type→endpoint map can't be correct across compositions.

## Change
Whitelist only the **business parties** named on each instruction — the source and destination finIds — resolved to addresses (account mapping; explicit ledger address as a destination-only fallback, matching execution) and handed to `ensureWhitelisted`. Escrow accounts carry no finId, so they're naturally excluded. How a standard routes tokens internally (escrow, hold/release) is the standard's own concern.

Removed: `INSTRUCTION_ENDPOINTS`, the escrow role handling, `tryResolveEscrowAddress`, and the `CustodyProvider` constructor dependency (app.ts call site updated).

## Tests
Rewritten to the business-party model; added a test that an escrow party (finId-less) is never whitelisted. tsc + eslint + 48 unit + 19 plan-approval green.

_Touches the same file as #340 (folder dissolution); whichever merges second rebases._