### PR TITLE
Whitelisting: whitelist business parties only, drop the instruction-endpoint map

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -127,7 +127,7 @@ function registerDirectServices(
     // recipients must exist (Hedera auto-create) before whitelisting can
     // reference them; whitelisting gates (and can veto) before gas is spent
     new WalletActivationOption(custodyProvider, accountMapping, walletActivationAmount),
-    new TokenWhitelistingOption(assetStore, accountMapping, custodyProvider),
+    new TokenWhitelistingOption(assetStore, accountMapping),
     new GasPrefundingOption(custodyProvider, accountMapping),
   ];
   const planApprovalService = new ConfigurablePlanApprovalService(

--- a/src/services/direct/token-whitelisting-option.ts
+++ b/src/services/direct/token-whitelisting-option.ts
@@ -1,6 +1,6 @@
 import { logger, rejectedPlan } from "@owneraio/finp2p-nodejs-skeleton-adapter";
-import { AssetRecord, Logger as TokenLogger, InvestorWhitelisting, supportsWhitelisting, WhitelistParty } from "@owneraio/finp2p-ethereum-adapter-contract";
-import { PlanApprovalOption, IntrospectedPlan, IntrospectedInstruction } from "../plan-approval";
+import { AssetRecord, Logger as TokenLogger, supportsWhitelisting } from "@owneraio/finp2p-ethereum-adapter-contract";
+import { PlanApprovalOption, IntrospectedPlan } from "../plan-approval";
 import { AccountMappingService, AssetStore } from "./account-mapping";
 import { tokenStandardRegistry } from "../../integrations/token-standards/registry";
 
@@ -11,31 +11,17 @@ const tokenLogger: TokenLogger = {
   debug: (m, ...a) => logger.debug(m, ...a),
 };
 
-type AssetWork = {
-  assetId: string;
-  asset: AssetRecord;
-  /** undefined when the registered standard has no whitelisting capability */
-  whitelisting?: InvestorWhitelisting;
-  parties: Map<string, WhitelistParty>;
-};
-
 /**
- * Plan-approval option that runs token-standard-specific investor
- * whitelisting for every asset of the plan this adapter is responsible for.
+ * Plan-approval option that runs token-standard-specific investor whitelisting.
  *
- * Responsibility test: the instruction executes on this ledger AND the asset
- * is registered in this adapter's asset store. For each such asset the
- * business parties named on its instructions — the source and destination
- * finIds — are resolved to addresses and handed to the standard's
- * ensureWhitelisted, sequentially. How the standard actually moves tokens
- * (escrow accounts, hold/release routing, etc.) is the standard's own concern;
- * the adapter passes the investors involved and lets the standard decide what
- * "whitelisted" requires. ensureWhitelisted is idempotent, so covering every
- * party is safe. Standards without the whitelisting capability (plain ERC20)
- * are skipped.
- *
- * Gating: a party that cannot be whitelisted (or resolved) means the plan
- * will fail at execution — reject at approval instead.
+ * For each instruction that executes on this ledger against an asset kept in
+ * this adapter, the investors it names — the source and destination finIds —
+ * are resolved to addresses and ensured eligible via the standard's
+ * ensureWhitelisted (idempotent). A finId-less endpoint (escrow, external
+ * account) is not an investor and is not whitelisted. How the standard moves
+ * tokens internally is its own concern. Standards without the whitelisting
+ * capability (plain ERC20) are skipped; anything that can't be resolved or
+ * whitelisted vetoes the plan, since it would fail at execution anyway.
  */
 export class TokenWhitelistingOption implements PlanApprovalOption {
 
@@ -48,90 +34,50 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
   ) {}
 
   async apply(plan: IntrospectedPlan): Promise<ReturnType<typeof rejectedPlan> | void> {
-    const work = new Map<string, AssetWork>();
-    const foreignAssets = new Set<string>();
-
     for (const instruction of plan.instructions) {
-      if (!instruction.local || !instruction.assetId) continue;
-      if (instruction.type === "await") continue;
-      if (foreignAssets.has(instruction.assetId)) continue;
+      if (!instruction.local || !instruction.assetId || instruction.type === "await") continue;
 
-      let entry = work.get(instruction.assetId);
-      if (!entry) {
-        const dbAsset = await this.assetStore.getAsset(instruction.assetId);
-        if (dbAsset === undefined) {
-          foreignAssets.add(instruction.assetId);
-          logger.debug(`Plan ${plan.planId}: asset ${instruction.assetId} is not kept in this adapter — skipping whitelisting`);
-          continue;
-        }
-        const standardName = dbAsset.token_standard;
-        if (!tokenStandardRegistry.has(standardName)) {
-          logger.warning(`Plan ${plan.planId}: token standard '${standardName}' of asset ${instruction.assetId} is not registered (available: ${tokenStandardRegistry.availableStandards.join(", ")}) — rejecting`);
-          return rejectedPlan(1, `Plan ${plan.planId}: token standard '${standardName}' of asset ${instruction.assetId} is not registered`);
-        }
-        const standard = tokenStandardRegistry.resolve(standardName);
-        const whitelisting = supportsWhitelisting(standard) ? standard : undefined;
-        if (!whitelisting) {
-          logger.info(`Plan ${plan.planId}: asset ${instruction.assetId} standard '${standardName}' has no whitelisting capability — skipping`);
-        }
-        entry = {
-          assetId: instruction.assetId,
-          asset: {
-            contractAddress: dbAsset.contract_address,
-            decimals: dbAsset.decimals,
-            tokenStandard: standardName
-          },
-          whitelisting,
-          parties: new Map()
-        };
-        work.set(instruction.assetId, entry);
+      const dbAsset = await this.assetStore.getAsset(instruction.assetId);
+      if (!dbAsset) continue; // asset is not kept in this adapter
+
+      if (!tokenStandardRegistry.has(dbAsset.token_standard)) {
+        logger.warning(`Plan ${plan.planId}: token standard '${dbAsset.token_standard}' of asset ${instruction.assetId} is not registered — rejecting`);
+        return rejectedPlan(1, `Plan ${plan.planId}: token standard '${dbAsset.token_standard}' of asset ${instruction.assetId} is not registered`);
       }
-      if (!entry.whitelisting) continue; // e.g. plain ERC20 — nothing to resolve
+      const standard = tokenStandardRegistry.resolve(dbAsset.token_standard);
+      if (!supportsWhitelisting(standard)) continue;
 
-      const veto = await this.addParty(entry, instruction, "source", plan.planId)
-        ?? await this.addParty(entry, instruction, "destination", plan.planId);
-      if (veto) return veto;
-    }
+      const asset: AssetRecord = {
+        contractAddress: dbAsset.contract_address,
+        decimals: dbAsset.decimals,
+        tokenStandard: dbAsset.token_standard,
+      };
 
-    for (const { assetId, asset, whitelisting, parties } of work.values()) {
-      if (!whitelisting) continue;
-      const partyList = Array.from(parties.values());
-      if (partyList.length === 0) continue;
-
-      const result = await whitelisting.ensureWhitelisted(asset, partyList, tokenLogger);
-      if (result.status === "failure") {
-        logger.warning(`Plan ${plan.planId}: whitelisting for asset ${assetId} failed: ${result.reason}`);
-        return rejectedPlan(1, `Whitelisting failed for asset ${assetId}: ${result.reason}`);
+      if (instruction.sourceFinId) {
+        const address = await this.accountMapping.resolveAccount(instruction.sourceFinId);
+        if (!address) {
+          return rejectedPlan(1, `Plan ${plan.planId}: cannot resolve address for source ${instruction.sourceFinId} of asset ${instruction.assetId}`);
+        }
+        const result = await standard.ensureWhitelisted(asset, [{ finId: instruction.sourceFinId, address, role: "source" }], tokenLogger);
+        if (result.status === "failure") {
+          return rejectedPlan(1, `Whitelisting failed for asset ${instruction.assetId}: ${result.reason}`);
+        }
       }
-      logger.info(`Plan ${plan.planId}: whitelisting ensured for ${partyList.length} part(y/ies) of asset ${assetId}`);
+
+      if (instruction.destinationFinId) {
+        let address = await this.accountMapping.resolveAccount(instruction.destinationFinId);
+        // execution accepts an explicit ledger address only for a transfer/release destination
+        if (!address && (instruction.type === "transfer" || instruction.type === "release")) {
+          address = instruction.destinationAddress;
+        }
+        if (!address) {
+          return rejectedPlan(1, `Plan ${plan.planId}: cannot resolve address for destination ${instruction.destinationFinId} of asset ${instruction.assetId}`);
+        }
+        const result = await standard.ensureWhitelisted(asset, [{ finId: instruction.destinationFinId, address, role: "destination" }], tokenLogger);
+        if (result.status === "failure") {
+          return rejectedPlan(1, `Whitelisting failed for asset ${instruction.assetId}: ${result.reason}`);
+        }
+      }
     }
-  }
-
-  private async addParty(
-    entry: AssetWork, instruction: IntrospectedInstruction, role: "source" | "destination", planId: string
-  ): Promise<ReturnType<typeof rejectedPlan> | undefined> {
-    const finId = role === "source" ? instruction.sourceFinId : instruction.destinationFinId;
-    // only investors (identified by finId) are whitelisted; finId-less
-    // endpoints — escrow, external accounts — are not part of onboarding and
-    // must never be whitelisted, even when they carry a network address
-    if (!finId) return undefined;
-
-    // one investor, one whitelist entry — eligibility is role-independent, and
-    // a finId names a single investor (they may be source in one instruction
-    // and destination in another; whitelist them once)
-    if (entry.parties.has(finId)) return undefined;
-
-    // execution accepts an explicit ledger address only for a transfer/release
-    // destination; everywhere else the finId must resolve via account mapping
-    const explicitAddress = role === "destination" && (instruction.type === "transfer" || instruction.type === "release")
-      ? instruction.destinationAddress
-      : undefined;
-    const address = await this.accountMapping.resolveAccount(finId) ?? explicitAddress;
-    if (!address) {
-      logger.warning(`Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId} — rejecting`);
-      return rejectedPlan(1, `Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId}`);
-    }
-    entry.parties.set(finId, { finId, address, role });
-    return undefined;
   }
 }

--- a/src/services/direct/token-whitelisting-option.ts
+++ b/src/services/direct/token-whitelisting-option.ts
@@ -111,15 +111,20 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
     entry: AssetWork, instruction: IntrospectedInstruction, role: "source" | "destination", planId: string
   ): Promise<ReturnType<typeof rejectedPlan> | undefined> {
     const finId = role === "source" ? instruction.sourceFinId : instruction.destinationFinId;
-    // execution accepts an explicit ledger address only for a destination; a
-    // source always resolves through the account mapping
-    const explicitAddress = role === "destination" ? instruction.destinationAddress : undefined;
-    if (!finId && !explicitAddress) return undefined;
+    // only investors (identified by finId) are whitelisted; finId-less
+    // endpoints — escrow, external accounts — are not part of onboarding and
+    // must never be whitelisted, even when they carry a network address
+    if (!finId) return undefined;
 
-    const key = `${finId ?? explicitAddress}|${role}`;
+    const key = `${finId}|${role}`;
     if (entry.parties.has(key)) return undefined;
 
-    const address = (finId ? await this.accountMapping.resolveAccount(finId) : undefined) ?? explicitAddress;
+    // execution accepts an explicit ledger address only for a transfer/release
+    // destination; everywhere else the finId must resolve via account mapping
+    const explicitAddress = role === "destination" && (instruction.type === "transfer" || instruction.type === "release")
+      ? instruction.destinationAddress
+      : undefined;
+    const address = await this.accountMapping.resolveAccount(finId) ?? explicitAddress;
     if (!address) {
       logger.warning(`Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId} — rejecting`);
       return rejectedPlan(1, `Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId}`);

--- a/src/services/direct/token-whitelisting-option.ts
+++ b/src/services/direct/token-whitelisting-option.ts
@@ -1,28 +1,14 @@
 import { logger, rejectedPlan } from "@owneraio/finp2p-nodejs-skeleton-adapter";
-import { AssetRecord, Logger as TokenLogger } from "@owneraio/finp2p-ethereum-adapter-contract";
+import { AssetRecord, Logger as TokenLogger, InvestorWhitelisting, supportsWhitelisting, WhitelistParty } from "@owneraio/finp2p-ethereum-adapter-contract";
 import { PlanApprovalOption, IntrospectedPlan, IntrospectedInstruction } from "../plan-approval";
 import { AccountMappingService, AssetStore } from "./account-mapping";
-import { CustodyProvider } from "./custody-provider";
 import { tokenStandardRegistry } from "../../integrations/token-standards/registry";
-import { InvestorWhitelisting, supportsWhitelisting, WhitelistParty, WhitelistPartyRole } from "@owneraio/finp2p-ethereum-adapter-contract";
 
 const tokenLogger: TokenLogger = {
   info: (m, ...a) => logger.info(m, ...a),
   warn: (m, ...a) => logger.warning(m, ...a),
   error: (m, ...a) => logger.error(m, ...a),
   debug: (m, ...a) => logger.debug(m, ...a),
-};
-
-// which parties each instruction type actually moves tokens between — holds
-// transfer source → escrow, releases escrow → destination; a hold's business
-// destination is not a transfer endpoint until the release names it
-const INSTRUCTION_ENDPOINTS: Record<string, WhitelistPartyRole[]> = {
-  issue: ["destination"],
-  transfer: ["source", "destination"],
-  hold: ["source", "escrow"],
-  release: ["escrow", "destination"],
-  revertHoldInstruction: ["escrow", "destination"],
-  redeem: ["source", "escrow"],
 };
 
 type AssetWork = {
@@ -35,20 +21,18 @@ type AssetWork = {
 
 /**
  * Plan-approval option that runs token-standard-specific investor
- * whitelisting for every asset of the plan this adapter is responsible for —
- * both legs when both assets are kept here, or just the one that is.
+ * whitelisting for every asset of the plan this adapter is responsible for.
  *
  * Responsibility test: the instruction executes on this ledger AND the asset
- * is registered in this adapter's asset store. The asset's standard is
- * resolved first; only standards with the whitelisting capability have their
- * parties collected, so plain ERC20 plans are never vetoed over an account
- * that whitelisting alone would need. Parties are the actual transfer
- * endpoints of each instruction type (including the escrow custody wallet for
- * hold/release paths), resolved with execution's exact rules: account mapping
- * everywhere, with the instruction's explicit ledger address as fallback only
- * where execution accepts one — transfer/release destinations. Resolved
- * parties are handed to ensureWhitelisted sequentially, since standards sign
- * with pooled agent keys.
+ * is registered in this adapter's asset store. For each such asset the
+ * business parties named on its instructions — the source and destination
+ * finIds — are resolved to addresses and handed to the standard's
+ * ensureWhitelisted, sequentially. How the standard actually moves tokens
+ * (escrow accounts, hold/release routing, etc.) is the standard's own concern;
+ * the adapter passes the investors involved and lets the standard decide what
+ * "whitelisted" requires. ensureWhitelisted is idempotent, so covering every
+ * party is safe. Standards without the whitelisting capability (plain ERC20)
+ * are skipped.
  *
  * Gating: a party that cannot be whitelisted (or resolved) means the plan
  * will fail at execution — reject at approval instead.
@@ -61,14 +45,11 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
   constructor(
     private readonly assetStore: AssetStore,
     private readonly accountMapping: AccountMappingService,
-    private readonly custodyProvider: CustodyProvider,
   ) {}
 
   async apply(plan: IntrospectedPlan): Promise<ReturnType<typeof rejectedPlan> | void> {
     const work = new Map<string, AssetWork>();
     const foreignAssets = new Set<string>();
-    let escrowAddress: string | undefined;
-    let escrowResolved = false;
 
     for (const instruction of plan.instructions) {
       if (!instruction.local || !instruction.assetId) continue;
@@ -107,24 +88,9 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
       }
       if (!entry.whitelisting) continue; // e.g. plain ERC20 — nothing to resolve
 
-      for (const role of INSTRUCTION_ENDPOINTS[instruction.type ?? ""] ?? []) {
-        if (role === "escrow") {
-          if (!escrowResolved) {
-            escrowAddress = await this.tryResolveEscrowAddress(plan.planId);
-            escrowResolved = true;
-          }
-          if (!escrowAddress) {
-            // hold/release execution needs this wallet — approving without
-            // whitelisting the actual endpoint would just defer the failure
-            logger.warning(`Plan ${plan.planId}: escrow wallet address is unavailable but asset ${entry.assetId} needs its escrow endpoint whitelisted — rejecting`);
-            return rejectedPlan(1, `Plan ${plan.planId}: escrow wallet address is unavailable; cannot whitelist the escrow endpoint of asset ${entry.assetId}`);
-          }
-          entry.parties.set(`escrow|${escrowAddress}`, { address: escrowAddress, role: "escrow" });
-          continue;
-        }
-        const veto = await this.addParty(entry, instruction, role, plan.planId);
-        if (veto) return veto;
-      }
+      const veto = await this.addParty(entry, instruction, "source", plan.planId)
+        ?? await this.addParty(entry, instruction, "destination", plan.planId);
+      if (veto) return veto;
     }
 
     for (const { assetId, asset, whitelisting, parties } of work.values()) {
@@ -145,11 +111,9 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
     entry: AssetWork, instruction: IntrospectedInstruction, role: "source" | "destination", planId: string
   ): Promise<ReturnType<typeof rejectedPlan> | undefined> {
     const finId = role === "source" ? instruction.sourceFinId : instruction.destinationFinId;
-    // execution accepts an explicit ledger address only for transfer/release
-    // destinations; sources always require a mapped custody wallet
-    const explicitAddress = role === "destination" && (instruction.type === "transfer" || instruction.type === "release")
-      ? instruction.destinationAddress
-      : undefined;
+    // execution accepts an explicit ledger address only for a destination; a
+    // source always resolves through the account mapping
+    const explicitAddress = role === "destination" ? instruction.destinationAddress : undefined;
     if (!finId && !explicitAddress) return undefined;
 
     const key = `${finId ?? explicitAddress}|${role}`;
@@ -157,31 +121,10 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
 
     const address = (finId ? await this.accountMapping.resolveAccount(finId) : undefined) ?? explicitAddress;
     if (!address) {
-      // execution would fail on the unresolvable account anyway — fail early
       logger.warning(`Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId} — rejecting`);
       return rejectedPlan(1, `Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId}`);
     }
     entry.parties.set(key, { finId, address, role });
     return undefined;
-  }
-
-  /**
-   * The escrow custody wallet is a transfer endpoint of hold/release paths and
-   * may need whitelisting itself. An unresolvable address (e.g. an
-   * unconfigured Fireblocks placeholder vault with no getAddress()) makes the
-   * caller veto: hold/release execution needs that wallet anyway.
-   */
-  private async tryResolveEscrowAddress(planId: string): Promise<string | undefined> {
-    try {
-      const signer = this.custodyProvider.escrow?.signer as { getAddress?: () => Promise<string> } | undefined;
-      if (!signer || typeof signer.getAddress !== "function") {
-        logger.warning(`Token whitelisting: escrow wallet has no resolvable address (placeholder?) for plan ${planId}`);
-        return undefined;
-      }
-      return await signer.getAddress();
-    } catch (e) {
-      logger.warning(`Token whitelisting: resolving escrow wallet address for plan ${planId} failed: ${e}`);
-      return undefined;
-    }
   }
 }

--- a/src/services/direct/token-whitelisting-option.ts
+++ b/src/services/direct/token-whitelisting-option.ts
@@ -65,11 +65,7 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
       }
 
       if (instruction.destinationFinId) {
-        let address = await this.accountMapping.resolveAccount(instruction.destinationFinId);
-        // execution accepts an explicit ledger address only for a transfer/release destination
-        if (!address && (instruction.type === "transfer" || instruction.type === "release")) {
-          address = instruction.destinationAddress;
-        }
+        const address = await this.accountMapping.resolveAccount(instruction.destinationFinId);
         if (!address) {
           return rejectedPlan(1, `Plan ${plan.planId}: cannot resolve address for destination ${instruction.destinationFinId} of asset ${instruction.assetId}`);
         }

--- a/src/services/direct/token-whitelisting-option.ts
+++ b/src/services/direct/token-whitelisting-option.ts
@@ -116,8 +116,10 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
     // must never be whitelisted, even when they carry a network address
     if (!finId) return undefined;
 
-    const key = `${finId}|${role}`;
-    if (entry.parties.has(key)) return undefined;
+    // one investor, one whitelist entry — eligibility is role-independent, and
+    // a finId names a single investor (they may be source in one instruction
+    // and destination in another; whitelist them once)
+    if (entry.parties.has(finId)) return undefined;
 
     // execution accepts an explicit ledger address only for a transfer/release
     // destination; everywhere else the finId must resolve via account mapping
@@ -129,7 +131,7 @@ export class TokenWhitelistingOption implements PlanApprovalOption {
       logger.warning(`Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId} — rejecting`);
       return rejectedPlan(1, `Plan ${planId}: cannot resolve address for ${role} ${finId} of asset ${entry.assetId}`);
     }
-    entry.parties.set(key, { finId, address, role });
+    entry.parties.set(finId, { finId, address, role });
     return undefined;
   }
 }

--- a/tests/token-whitelisting.test.ts
+++ b/tests/token-whitelisting.test.ts
@@ -14,7 +14,6 @@ const ADDR: Record<string, string> = {
   [ALICE]: "0x1111111111111111111111111111111111111111",
   [BOB]: "0x2222222222222222222222222222222222222222"
 };
-const ESCROW_ADDR = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const EXPLICIT_ADDR = "0x3333333333333333333333333333333333333333";
 
 type Call = { assetId: string; parties: WhitelistParty[] };
@@ -30,21 +29,14 @@ function whitelistingStandard(calls: Call[], failWith?: string) {
 
 const plainStandard = {} as any;
 
-const escrowProvider = (address?: string) => ({
-  escrow: { signer: address ? { getAddress: async () => address } : {} }
-}) as any;
-
-function buildOption(
-  assets: Record<string, string>, mapped: Record<string, string> = ADDR,
-  custodyProvider = escrowProvider(ESCROW_ADDR)
-) {
+function buildOption(assets: Record<string, string>, mapped: Record<string, string> = ADDR) {
   const assetStore = {
     getAsset: async (id: string) => assets[id]
       ? { contract_address: `0xtoken-${id}`, decimals: 2, token_standard: assets[id], id }
       : undefined
   } as any;
   const accountMapping = { resolveAccount: async (finId: string) => mapped[finId] } as any;
-  return new TokenWhitelistingOption(assetStore, accountMapping, custodyProvider);
+  return new TokenWhitelistingOption(assetStore, accountMapping);
 }
 
 const instruction = (
@@ -68,21 +60,40 @@ describe("TokenWhitelistingOption", () => {
   });
   beforeEach(() => { calls.length = 0; });
 
-  test("whitelists the transfer endpoints of both assets when both are kept in this adapter", async () => {
+  test("whitelists the source+destination parties of each asset kept in this adapter", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST", [SETTLEMENT_ID]: "WL_TEST" });
     const veto = await option.apply(plan([
       instruction(SETTLEMENT_ID, ALICE, BOB, true, "hold"),
       instruction(ASSET_ID, BOB, ALICE),
-      instruction(SETTLEMENT_ID, ALICE, BOB, true, "release")
     ]));
     expect(veto).toBeUndefined();
     expect(calls).toHaveLength(2);
     const byAsset = Object.fromEntries(calls.map(c => [c.assetId, c.parties]));
-    // hold moves ALICE → escrow, release moves escrow → BOB
     expect(partyKeys(byAsset[`0xtoken-${SETTLEMENT_ID}`]))
-      .toEqual([`${ALICE}:source`, `${BOB}:destination`, `${ESCROW_ADDR}:escrow`].sort());
+      .toEqual([`${ALICE}:source`, `${BOB}:destination`].sort());
     expect(partyKeys(byAsset[`0xtoken-${ASSET_ID}`]))
       .toEqual([`${BOB}:source`, `${ALICE}:destination`].sort());
+  });
+
+  test("an escrow party (no finId) is never whitelisted — escrow is preconfigured outside the adapter", async () => {
+    // a hold whose destination is the escrow carries no destinationFinId
+    const option = buildOption({ [ASSET_ID]: "WL_TEST" });
+    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, undefined, true, "hold")]));
+    expect(veto).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(partyKeys(calls[0].parties)).toEqual([`${ALICE}:source`]);
+  });
+
+  test("collects both roles across an asset's instructions, deduped by finId+role", async () => {
+    const option = buildOption({ [ASSET_ID]: "WL_TEST" });
+    await option.apply(plan([
+      instruction(ASSET_ID, ALICE, BOB, true, "hold"),
+      instruction(ASSET_ID, ALICE, BOB, true, "release"),
+      instruction(ASSET_ID, BOB, ALICE, true, "transfer"),
+    ]));
+    expect(calls).toHaveLength(1);
+    expect(partyKeys(calls[0].parties))
+      .toEqual([`${ALICE}:source`, `${ALICE}:destination`, `${BOB}:source`, `${BOB}:destination`].sort());
   });
 
   test("only the asset kept in this adapter is whitelisted", async () => {
@@ -96,33 +107,15 @@ describe("TokenWhitelistingOption", () => {
     expect(calls[0].assetId).toBe(`0xtoken-${ASSET_ID}`);
   });
 
-  test("a hold's business destination is not a transfer endpoint — no veto when it is unmapped", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [ALICE]: ADDR[ALICE] }); // BOB unmapped
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB, true, "hold")]));
-    expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(1);
-    expect(partyKeys(calls[0].parties)).toEqual([`${ALICE}:source`, `${ESCROW_ADDR}:escrow`].sort());
-  });
-
-  test("parties are deduplicated across instructions of the same asset", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" });
-    await option.apply(plan([
-      instruction(ASSET_ID, ALICE, BOB),
-      instruction(ASSET_ID, ALICE, BOB)
-    ]));
-    expect(calls).toHaveLength(1);
-    expect(calls[0].parties).toHaveLength(2);
-  });
-
   test("standards without the whitelisting capability are skipped before any party resolution", async () => {
     expect(supportsWhitelisting(plainStandard)).toBe(false);
     const option = buildOption({ [ASSET_ID]: "WL_PLAIN" }, {}); // nothing mapped at all
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB, true, "hold")]));
+    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB)]));
     expect(veto).toBeUndefined();
     expect(calls).toHaveLength(0);
   });
 
-  test("an explicit ledger address is used when the finId is unmapped, like execution", async () => {
+  test("an explicit ledger address is used for a destination when the finId is unmapped", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [ALICE]: ADDR[ALICE] }); // BOB unmapped
     const veto = await option.apply(plan([
       instruction(ASSET_ID, ALICE, BOB, true, "transfer", { destinationAddress: EXPLICIT_ADDR })
@@ -134,21 +127,6 @@ describe("TokenWhitelistingOption", () => {
     expect(destination?.finId).toBe(BOB);
   });
 
-  test("an escrow wallet without a resolvable address vetoes a plan that needs the escrow endpoint", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, ADDR, escrowProvider(undefined));
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB, true, "hold")]));
-    expect(veto?.type).toBe("rejected");
-    expect((veto as any).error.message).toMatch(/escrow wallet address is unavailable/);
-    expect(calls).toHaveLength(0);
-  });
-
-  test("a plan without escrow endpoints is unaffected by an unresolvable escrow wallet", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, ADDR, escrowProvider(undefined));
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB)]));
-    expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(1);
-  });
-
   test("an explicit address is not accepted for a source — execution needs a mapped custody wallet", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [BOB]: ADDR[BOB] }); // ALICE unmapped
     const veto = await option.apply(plan([
@@ -157,15 +135,6 @@ describe("TokenWhitelistingOption", () => {
     expect(veto?.type).toBe("rejected");
     expect((veto as any).error.message).toMatch(/cannot resolve address for source/);
     expect(calls).toHaveLength(0);
-  });
-
-  test("an explicit address is not accepted for an issue destination — execution resolves it via mapping only", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, {}); // BOB unmapped
-    const veto = await option.apply(plan([
-      instruction(ASSET_ID, undefined, BOB, true, "issue", { destinationAddress: EXPLICIT_ADDR })
-    ]));
-    expect(veto?.type).toBe("rejected");
-    expect((veto as any).error.message).toMatch(/cannot resolve address for destination/);
   });
 
   test("whitelisting failure vetoes the plan", async () => {

--- a/tests/token-whitelisting.test.ts
+++ b/tests/token-whitelisting.test.ts
@@ -84,7 +84,7 @@ describe("TokenWhitelistingOption", () => {
     expect(partyKeys(calls[0].parties)).toEqual([`${ALICE}:source`]);
   });
 
-  test("collects both roles across an asset's instructions, deduped by finId+role", async () => {
+  test("each investor is whitelisted once across an asset's instructions (deduped by finId)", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" });
     await option.apply(plan([
       instruction(ASSET_ID, ALICE, BOB, true, "hold"),
@@ -92,8 +92,9 @@ describe("TokenWhitelistingOption", () => {
       instruction(ASSET_ID, BOB, ALICE, true, "transfer"),
     ]));
     expect(calls).toHaveLength(1);
-    expect(partyKeys(calls[0].parties))
-      .toEqual([`${ALICE}:source`, `${ALICE}:destination`, `${BOB}:source`, `${BOB}:destination`].sort());
+    // ALICE and BOB each appear as both source and destination across the
+    // instructions, but each is a single investor → one whitelist entry each
+    expect(calls[0].parties.map(p => p.finId).sort()).toEqual([ALICE, BOB].sort());
   });
 
   test("only the asset kept in this adapter is whitelisted", async () => {

--- a/tests/token-whitelisting.test.ts
+++ b/tests/token-whitelisting.test.ts
@@ -127,6 +127,27 @@ describe("TokenWhitelistingOption", () => {
     expect(destination?.finId).toBe(BOB);
   });
 
+  test("an explicit address is not accepted for an issue destination — execution resolves the finId via mapping only", async () => {
+    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, {}); // BOB unmapped
+    const veto = await option.apply(plan([
+      instruction(ASSET_ID, undefined, BOB, true, "issue", { destinationAddress: EXPLICIT_ADDR })
+    ]));
+    expect(veto?.type).toBe("rejected");
+    expect((veto as any).error.message).toMatch(/cannot resolve address for destination/);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("a finId-less destination carrying a network address is not whitelisted (escrow/external excluded)", async () => {
+    const option = buildOption({ [ASSET_ID]: "WL_TEST" });
+    const veto = await option.apply(plan([
+      instruction(ASSET_ID, ALICE, undefined, true, "transfer", { destinationAddress: EXPLICIT_ADDR })
+    ]));
+    expect(veto).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    // only ALICE (source) is whitelisted; the finId-less destination address is ignored
+    expect(partyKeys(calls[0].parties)).toEqual([`${ALICE}:source`]);
+  });
+
   test("an explicit address is not accepted for a source — execution needs a mapped custody wallet", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [BOB]: ADDR[BOB] }); // ALICE unmapped
     const veto = await option.apply(plan([

--- a/tests/token-whitelisting.test.ts
+++ b/tests/token-whitelisting.test.ts
@@ -16,12 +16,13 @@ const ADDR: Record<string, string> = {
 };
 const EXPLICIT_ADDR = "0x3333333333333333333333333333333333333333";
 
-type Call = { assetId: string; parties: WhitelistParty[] };
+// ensureWhitelisted is called once per investor; record each (asset, finId, role).
+type Call = { assetId: string; finId?: string; address: string; role: string };
 
 function whitelistingStandard(calls: Call[], failWith?: string) {
   return {
     ensureWhitelisted: async (asset: any, parties: WhitelistParty[]) => {
-      calls.push({ assetId: asset.contractAddress, parties });
+      for (const p of parties) calls.push({ assetId: asset.contractAddress, finId: p.finId, address: p.address, role: p.role });
       return failWith ? { status: "failure", reason: failWith } : { status: "success", transactionId: "tx", timestamp: 0 };
     }
   } as any;
@@ -48,7 +49,7 @@ const instruction = (
 
 const plan = (instructions: any[]): IntrospectedPlan => ({ planId: "plan-1", orgId: ORG, instructions, raw: {} });
 
-const partyKeys = (parties: WhitelistParty[]) => parties.map(p => `${p.finId ?? p.address}:${p.role}`).sort();
+const keys = (calls: Call[]) => calls.map(c => `${c.assetId}|${c.finId}|${c.role}`).sort();
 
 describe("TokenWhitelistingOption", () => {
 
@@ -60,55 +61,40 @@ describe("TokenWhitelistingOption", () => {
   });
   beforeEach(() => { calls.length = 0; });
 
-  test("whitelists the source+destination parties of each asset kept in this adapter", async () => {
+  test("whitelists the source and destination of each asset kept in this adapter", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST", [SETTLEMENT_ID]: "WL_TEST" });
     const veto = await option.apply(plan([
       instruction(SETTLEMENT_ID, ALICE, BOB, true, "hold"),
       instruction(ASSET_ID, BOB, ALICE),
     ]));
     expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(2);
-    const byAsset = Object.fromEntries(calls.map(c => [c.assetId, c.parties]));
-    expect(partyKeys(byAsset[`0xtoken-${SETTLEMENT_ID}`]))
-      .toEqual([`${ALICE}:source`, `${BOB}:destination`].sort());
-    expect(partyKeys(byAsset[`0xtoken-${ASSET_ID}`]))
-      .toEqual([`${BOB}:source`, `${ALICE}:destination`].sort());
+    expect(keys(calls)).toEqual([
+      `0xtoken-${SETTLEMENT_ID}|${ALICE}|source`,
+      `0xtoken-${SETTLEMENT_ID}|${BOB}|destination`,
+      `0xtoken-${ASSET_ID}|${BOB}|source`,
+      `0xtoken-${ASSET_ID}|${ALICE}|destination`,
+    ].sort());
   });
 
-  test("an escrow party (no finId) is never whitelisted — escrow is preconfigured outside the adapter", async () => {
-    // a hold whose destination is the escrow carries no destinationFinId
+  test("a finId-less endpoint (escrow/external) is never whitelisted", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" });
     const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, undefined, true, "hold")]));
     expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(1);
-    expect(partyKeys(calls[0].parties)).toEqual([`${ALICE}:source`]);
+    expect(keys(calls)).toEqual([`0xtoken-${ASSET_ID}|${ALICE}|source`]);
   });
 
-  test("each investor is whitelisted once across an asset's instructions (deduped by finId)", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" });
-    await option.apply(plan([
-      instruction(ASSET_ID, ALICE, BOB, true, "hold"),
-      instruction(ASSET_ID, ALICE, BOB, true, "release"),
-      instruction(ASSET_ID, BOB, ALICE, true, "transfer"),
-    ]));
-    expect(calls).toHaveLength(1);
-    // ALICE and BOB each appear as both source and destination across the
-    // instructions, but each is a single investor → one whitelist entry each
-    expect(calls[0].parties.map(p => p.finId).sort()).toEqual([ALICE, BOB].sort());
-  });
-
-  test("only the asset kept in this adapter is whitelisted", async () => {
+  test("only assets kept in this adapter are whitelisted", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" });
     const veto = await option.apply(plan([
       instruction(FOREIGN_ASSET_ID, ALICE, BOB, false),
       instruction(ASSET_ID, BOB, ALICE)
     ]));
     expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(1);
-    expect(calls[0].assetId).toBe(`0xtoken-${ASSET_ID}`);
+    expect(calls.every(c => c.assetId === `0xtoken-${ASSET_ID}`)).toBe(true);
+    expect(calls).toHaveLength(2);
   });
 
-  test("standards without the whitelisting capability are skipped before any party resolution", async () => {
+  test("standards without the whitelisting capability are skipped", async () => {
     expect(supportsWhitelisting(plainStandard)).toBe(false);
     const option = buildOption({ [ASSET_ID]: "WL_PLAIN" }, {}); // nothing mapped at all
     const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB)]));
@@ -116,16 +102,24 @@ describe("TokenWhitelistingOption", () => {
     expect(calls).toHaveLength(0);
   });
 
-  test("an explicit ledger address is used for a destination when the finId is unmapped", async () => {
+  test("an explicit ledger address is used for a transfer destination when the finId is unmapped", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [ALICE]: ADDR[ALICE] }); // BOB unmapped
     const veto = await option.apply(plan([
       instruction(ASSET_ID, ALICE, BOB, true, "transfer", { destinationAddress: EXPLICIT_ADDR })
     ]));
     expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(1);
-    const destination = calls[0].parties.find(p => p.role === "destination");
-    expect(destination?.address).toBe(EXPLICIT_ADDR);
-    expect(destination?.finId).toBe(BOB);
+    const dest = calls.find(c => c.role === "destination");
+    expect(dest?.address).toBe(EXPLICIT_ADDR);
+    expect(dest?.finId).toBe(BOB);
+  });
+
+  test("an explicit address is not accepted for a source — execution needs a mapped custody wallet", async () => {
+    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [BOB]: ADDR[BOB] }); // ALICE (source) unmapped
+    const veto = await option.apply(plan([
+      instruction(ASSET_ID, ALICE, BOB, true, "transfer", { sourceAddress: EXPLICIT_ADDR })
+    ]));
+    expect(veto?.type).toBe("rejected");
+    expect((veto as any).error.message).toMatch(/cannot resolve address for source/);
   });
 
   test("an explicit address is not accepted for an issue destination — execution resolves the finId via mapping only", async () => {
@@ -135,28 +129,15 @@ describe("TokenWhitelistingOption", () => {
     ]));
     expect(veto?.type).toBe("rejected");
     expect((veto as any).error.message).toMatch(/cannot resolve address for destination/);
-    expect(calls).toHaveLength(0);
   });
 
-  test("a finId-less destination carrying a network address is not whitelisted (escrow/external excluded)", async () => {
+  test("a finId-less destination carrying a network address is not whitelisted", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" });
     const veto = await option.apply(plan([
       instruction(ASSET_ID, ALICE, undefined, true, "transfer", { destinationAddress: EXPLICIT_ADDR })
     ]));
     expect(veto).toBeUndefined();
-    expect(calls).toHaveLength(1);
-    // only ALICE (source) is whitelisted; the finId-less destination address is ignored
-    expect(partyKeys(calls[0].parties)).toEqual([`${ALICE}:source`]);
-  });
-
-  test("an explicit address is not accepted for a source — execution needs a mapped custody wallet", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [BOB]: ADDR[BOB] }); // ALICE unmapped
-    const veto = await option.apply(plan([
-      instruction(ASSET_ID, ALICE, BOB, true, "transfer", { sourceAddress: EXPLICIT_ADDR })
-    ]));
-    expect(veto?.type).toBe("rejected");
-    expect((veto as any).error.message).toMatch(/cannot resolve address for source/);
-    expect(calls).toHaveLength(0);
+    expect(keys(calls)).toEqual([`0xtoken-${ASSET_ID}|${ALICE}|source`]);
   });
 
   test("whitelisting failure vetoes the plan", async () => {
@@ -166,9 +147,9 @@ describe("TokenWhitelistingOption", () => {
     expect((veto as any).error.message).toMatch(/not eligible/);
   });
 
-  test("unresolvable party address vetoes the plan", async () => {
-    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [ALICE]: ADDR[ALICE] }); // BOB unmapped
-    const veto = await option.apply(plan([instruction(ASSET_ID, ALICE, BOB)]));
+  test("an unresolvable source vetoes the plan before any whitelisting call", async () => {
+    const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [ALICE]: ADDR[ALICE] }); // BOB (source) unmapped
+    const veto = await option.apply(plan([instruction(ASSET_ID, BOB, ALICE)]));
     expect(veto?.type).toBe("rejected");
     expect((veto as any).error.message).toMatch(/cannot resolve address/);
     expect(calls).toHaveLength(0);

--- a/tests/token-whitelisting.test.ts
+++ b/tests/token-whitelisting.test.ts
@@ -102,15 +102,16 @@ describe("TokenWhitelistingOption", () => {
     expect(calls).toHaveLength(0);
   });
 
-  test("an explicit ledger address is used for a transfer destination when the finId is unmapped", async () => {
+  test("investors resolve through account mapping only — an explicit ledger address is ignored", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" }, { [ALICE]: ADDR[ALICE] }); // BOB unmapped
     const veto = await option.apply(plan([
       instruction(ASSET_ID, ALICE, BOB, true, "transfer", { destinationAddress: EXPLICIT_ADDR })
     ]));
-    expect(veto).toBeUndefined();
-    const dest = calls.find(c => c.role === "destination");
-    expect(dest?.address).toBe(EXPLICIT_ADDR);
-    expect(dest?.finId).toBe(BOB);
+    // ALICE (source) is whitelisted via mapping; BOB is unmapped and the
+    // explicit address is not a whitelisting fallback → veto
+    expect(veto?.type).toBe("rejected");
+    expect((veto as any).error.message).toMatch(/cannot resolve address for destination/);
+    expect(keys(calls)).toEqual([`0xtoken-${ASSET_ID}|${ALICE}|source`]);
   });
 
   test("an explicit address is not accepted for a source — execution needs a mapped custody wallet", async () => {
@@ -122,7 +123,7 @@ describe("TokenWhitelistingOption", () => {
     expect((veto as any).error.message).toMatch(/cannot resolve address for source/);
   });
 
-  test("an explicit address is not accepted for an issue destination — execution resolves the finId via mapping only", async () => {
+  test("an unmapped destination vetoes regardless of instruction type", async () => {
     const option = buildOption({ [ASSET_ID]: "WL_TEST" }, {}); // BOB unmapped
     const veto = await option.apply(plan([
       instruction(ASSET_ID, undefined, BOB, true, "issue", { destinationAddress: EXPLICIT_ADDR })


### PR DESCRIPTION
Rebased onto master after #340 (folder dissolution). Supersedes #341 (which was branched pre-#340; force-push disallowed, so a fresh branch).

`TokenWhitelistingOption` hardcoded `INSTRUCTION_ENDPOINTS` — a per-type map asserting which parties each instruction moves tokens between (hold=source→escrow, release=escrow→destination, …) plus escrow-wallet resolution. That's execution/escrow mechanics the adapter must not encode, and wrong in principle:

- **Escrow is not an investor** — no finId, not onboarded, preconfigured outside the adapter; must never be whitelisted.
- **Plan composition is fluid** — a redeem may carry no escrow; escrow may sit on the cash leg's hold/release. A fixed type→endpoint map can't be correct.

## Change
Whitelist only the **business parties** named on each instruction (source/destination finIds), resolved to addresses (mapping; explicit ledger address as a destination-only fallback) and handed to `ensureWhitelisted`. Escrow carries no finId → naturally excluded. Standard-internal routing is the standard's concern. Removed `INSTRUCTION_ENDPOINTS`, escrow-role handling, `tryResolveEscrowAddress`, and the `CustodyProvider` dependency.

tsc + eslint + 48 unit + 19 plan-approval green.