### PR TITLE
Drop global npm/yarn from the release image (fixes tar CVE-2026-59873)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,17 @@ FROM base AS release
 LABEL org.opencontainers.image.source=https://github.com/owneraio/finp2p-ethereum-adapter
 ENV NODE_ENV=production
 
+# The runtime invokes `node` directly (see CMD), never `npm`/`npx`. The base
+# image's globally-bundled npm ships its own copy of `tar`, which carries
+# CVE-2026-59873 (node-tar DoS) and is the only CRITICAL the image scan finds.
+# Remove the global npm/npx (and yarn/corepack) so that dead build-time tooling
+# is not in the shipped image or its attack surface.
+RUN rm -rf \
+      /usr/local/lib/node_modules/npm \
+      /usr/local/lib/node_modules/corepack \
+      /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+      /opt/yarn-* /usr/local/bin/yarn /usr/local/bin/yarnpkg
+
 COPY --from=dependencies /usr/app/node_modules ./node_modules
 COPY --from=build /usr/app/dist ./dist
 COPY --from=migrator /go/bin/goose /usr/bin/goose


### PR DESCRIPTION
## Problem

The image Trivy scan started failing with a single CRITICAL:

```
usr/local/lib/node_modules/npm/node_modules/tar/package.json   node-pkg
tar 6.2.1 → CVE-2026-59873 (node-tar: DoS via crafted gzip bomb, fixed 7.5.19)
```

This is **not an application dependency** — every `usr/app/node_modules/*` target scans clean. It's the `tar` copy **bundled inside the base image's global npm** (`node:20-alpine`). The failure appeared without any code change because the CVE was disclosed today and Trivy pulls the latest vuln DB at scan time — a re-run of `master` fails identically.

## Fix

The runtime invokes `node` directly (`CMD ["node", ...]`) and never uses npm/npx/yarn. That global tooling is dead weight in the shipped image, so the release stage now removes the global `npm`/`npx`/`corepack`/`yarn`. The finding is genuinely eliminated (not suppressed via `.trivyignore`) and the runtime attack surface shrinks.

## Testing

- The `docker`/`build` CI jobs rebuild the image and re-run the Trivy scan — this PR is validated by that scan going green.
- No source or dependency changes; `node_modules`, `dist`, and `goose` are copied exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)