### PR TITLE
Promote adapter-contract to 0.28.11; drop ephemeral issuer placeholder

### DIFF
--- a/adapter-contract/package.json
+++ b/adapter-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owneraio/finp2p-ethereum-adapter-contract",
-  "version": "0.28.11-rc.0",
+  "version": "0.28.11",
   "description": "The FinP2P Ethereum adapter's plugin SPI: the interfaces and runtime values token-standard plugins implement. Owned and released from the adapter repository; shares the platform's major.minor line with an independent patch version.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/integrations/token-standards/register.ts
+++ b/src/integrations/token-standards/register.ts
@@ -39,18 +39,22 @@ export function registerTokenStandards(ctx: IntegrationContext): void {
   const issuerKey = process.env.ASSET_ISSUER_PRIVATE_KEY;
   const controllerKey = process.env.ASSET_CONTROLLER_PRIVATE_KEY;
   const allowlisterKey = process.env.ASSET_WHITELIST_PRIVATE_KEY;
-  if (!issuerKey || !controllerKey) {
-    logger.warn(`Ethereum token standards: no ASSET_ISSUER_PRIVATE_KEY/ASSET_CONTROLLER_PRIVATE_KEY — using an ephemeral signer; reads and whitelist checks work but issuance/administration will not persist (set the keys to enable)`);
+  if (!issuerKey) {
+    logger.warn(`Ethereum token standards: ASSET_ISSUER_PRIVATE_KEY is not set — issuance is disabled (reads and whitelist checks still work; set the key to enable)`);
   }
 
   const provider = pooledProvider(rpcUrl);
-  // TODO: pass `undefined` for a missing issuer/controller once the plugins
-  // accept an optional signer (issuer?: Signer). Until then an ephemeral signer
-  // stands in so registration stays unconditional — a required-arg placeholder,
-  // not a working signer (on-chain writes with it do not persist across restart).
-  const ephemeral = Wallet.createRandom().connect(provider);
-  const issuer = issuerKey ? pooledSigner(rpcUrl, issuerKey) : ephemeral;
-  const controller = controllerKey ? pooledSigner(rpcUrl, controllerKey) : ephemeral;
+  // The issuer is optional on every standard now: pass undefined when the key is
+  // absent (issuance stays disabled) rather than a throwaway signer.
+  const issuer = issuerKey ? pooledSigner(rpcUrl, issuerKey) : undefined;
+  // The controller is still a required constructor arg (TREX/CMTAT/BENJI/HEDERA).
+  // Until it too becomes optional, stand in an ephemeral signer when the key is
+  // absent — a required-arg placeholder, not a working signer (on-chain admin
+  // writes with it do not persist across restart).
+  if (!controllerKey) {
+    logger.warn(`Ethereum token standards: ASSET_CONTROLLER_PRIVATE_KEY is not set — using an ephemeral controller; administration will not persist (set the key to enable)`);
+  }
+  const controller = controllerKey ? pooledSigner(rpcUrl, controllerKey) : Wallet.createRandom().connect(provider);
   const allowlister = allowlisterKey ? pooledSigner(rpcUrl, allowlisterKey) : undefined;
 
   const registered = [

--- a/tests/ethereum-standards.test.ts
+++ b/tests/ethereum-standards.test.ts
@@ -39,14 +39,16 @@ describe("registerTokenStandards (real plugin standards)", () => {
     for (const name of ALL) expect(tokenStandardRegistry.has(name)).toBe(false);
   });
 
-  test("without issuer/controller keys: registers all five with an ephemeral signer and warns", () => {
-    // TODO: revert to fail-closed / undefined issuer once the plugins accept an
-    // optional signer; today an ephemeral placeholder keeps registration on.
+  test("without issuer/controller keys: registers all five; issuer disabled, controller ephemeral", () => {
+    // Issuer is optional on every standard now → undefined (issuance disabled) when
+    // the key is absent. Controller is still a required constructor arg, so an
+    // ephemeral placeholder stands in. Two distinct warnings, one per key.
     warnings.length = 0;
     registerTokenStandards({ logger: warningLogger, rpcUrl: RPC } as any);
 
-    expect(warnings.length).toBe(1);
-    expect(warnings[0]).toContain("ephemeral");
+    expect(warnings.length).toBe(2);
+    expect(warnings.some(w => /ASSET_ISSUER_PRIVATE_KEY.*issuance is disabled/.test(w))).toBe(true);
+    expect(warnings.some(w => /ASSET_CONTROLLER_PRIVATE_KEY.*ephemeral controller/.test(w))).toBe(true);
     for (const name of ALL) expect(tokenStandardRegistry.has(name)).toBe(true);
   });
 


### PR DESCRIPTION
Finalizes the mandatory-`decimals()` SPI work (#347) and cleans up the issuer wiring.

## Changes
- **adapter-contract `0.28.11-rc.0` → `0.28.11`** (final). Published to `latest` via the `adapter-contract-v0.28.11` tag after merge. This unblocks the token-standard plugin **finals**, which build against `0.28.11`.
- **`register.ts`: drop the ephemeral issuer placeholder.** Every standard now accepts an optional issuer (erc20 `issuer?: Signer`, the rest `issuer: Signer | undefined`), so a missing `ASSET_ISSUER_PRIVATE_KEY` now passes `undefined` (issuance disabled) instead of a throwaway signer. The controller is still required on TREX/CMTAT/BENJI/HEDERA, so its ephemeral stand-in remains until it too goes optional; per-key warnings split accordingly.

## Follow-up (separate PR)
Once the plugin finals are published (they depend on adapter-contract `0.28.11`), bump the adapter's deps from the `-rc.0` pins to the finals (adapter-contract `0.28.11`, erc20 `0.28.5`, cmtat/trex `0.28.9`, benji/hedera `0.28.8`, dtcc `0.28.11`, collateral `0.28.27`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)