### PR TITLE
Bump hedera-plugin to ^0.28.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.8",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.9",
         "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
-      "version": "0.28.8",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.8/966239952c9bee33f47e0393cc89b116e1da46ee",
-      "integrity": "sha512-n6YqnfpkpawmdauwhhY6CqWQt0wAX2nkB/EljwzgPhqx9hGvBOzPwoPHKckvZOIyXlQeQhpstsJZWVkwCjGZ8A==",
+      "version": "0.28.9",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.9/17b62e486a7c80badbdadb602798a123efc9a13d",
+      "integrity": "sha512-hdbA1kPLKROuMI0U9TfguzsqPUZrbsBLtJUOmfGy6fGMrk/nCf84/iqRMvmhUyZ2iqwl25DSHlXmIxrQHpqnPw==",
       "dependencies": {
         "ethers": "^6.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.8",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.9",
     "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",


### PR DESCRIPTION
Updates `@owneraio/finp2p-ethereum-hedera-plugin` `^0.28.8` → `^0.28.9`.

Constructor and SPI surface unchanged (`(provider, issuer | undefined, controller, allowlister?)`, `decimals()` present). `tsc` clean, build OK, all unit suites green (24/14/46/9/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)