### PR TITLE
Bump hedera-plugin to ^0.28.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.9",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.10",
         "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
-      "version": "0.28.9",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.9/17b62e486a7c80badbdadb602798a123efc9a13d",
-      "integrity": "sha512-hdbA1kPLKROuMI0U9TfguzsqPUZrbsBLtJUOmfGy6fGMrk/nCf84/iqRMvmhUyZ2iqwl25DSHlXmIxrQHpqnPw==",
+      "version": "0.28.10",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.10/d147b50092193d4b7901e12d6845b3dd96ebf9c1",
+      "integrity": "sha512-DO1Qz+zXr/lh4EWpSN/lwaNobSZDFqP8jBNAHlOVQd57C0DGpbg5TV6C2NDMLroG4Vxh3c9zP2pdBB2rB8w7EQ==",
       "dependencies": {
         "ethers": "^6.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.9",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.10",
     "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",


### PR DESCRIPTION
Updates `@owneraio/finp2p-ethereum-hedera-plugin` `^0.28.9` → `^0.28.10`.

`0.28.10` adds an optional 5th constructor param on `AtsTokenStandard` — `identityOnboarding?: { registrar: Signer; resolveIdentity(party) }` — for registrar-driven identity onboarding during whitelisting. Backward compatible; the adapter's registration is unchanged (not wired yet — wiring it would need a registrar key + identity resolution source, a separate decision).

`tsc` clean, build OK, all unit suites green (24/14/46/9/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)