### PR TITLE
Bump hedera-plugin to ^0.28.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.11",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
-      "version": "0.28.11",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.11/3500ba68b5c63967d3450ae709a67bfafbcf27ad",
-      "integrity": "sha512-uCLF5F9xVNK4DDA73p1E5+3BZq88Ujzy1bmobZLbCuEU5k8NOmO5Pz4Wr1l4eHjOKii7Tr3ecaHnIHeDEl/Png==",
+      "version": "0.28.12",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.12/ad505753c2fddf60cc2acf637c5f2a8c990d8cf5",
+      "integrity": "sha512-pfYGHtQWuTzC9UeoPRk+k2yHEy3QpgWy2/Q9B0CqUM93kqe+gISnfeyxRA3lNi8o/TcNjL8CzvMNNbm5jpehvA==",
       "dependencies": {
         "ethers": "^6.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.11",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",


### PR DESCRIPTION
Updates `@owneraio/finp2p-ethereum-hedera-plugin` `^0.28.11` → `^0.28.12`.

Constructor and SPI surface unchanged (`(provider, issuer | undefined, controller, allowlister?)`). `tsc` clean, build OK, all unit suites green (24/14/46/9/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)