### PR TITLE
Bump hedera-plugin to ^0.28.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.13",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.16",
         "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
-      "version": "0.28.13",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.13/e50c012cba45ecd6bf36bc2e5b9d159c17f55880",
-      "integrity": "sha512-1esS2GydSDCeboYbdN5UmmjTXDJfd1aqHQTtlQhXyYduVimhhWVr7SGI38vJnBGD0j4KYF/JOfmmSbQ6/GUzpg==",
+      "version": "0.28.16",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.16/96196f5b56ca0e0ea3b738876f2ad5f75672780a",
+      "integrity": "sha512-LcY+X/CstzbXod5NZS/+gopMDbJQG4iRB6hvadM6ZTsIwayyAkkerElkdhZDnZal0eH96FmMxfKWgUIUOGb1zQ==",
       "dependencies": {
         "ethers": "^6.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.13",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.16",
     "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",


### PR DESCRIPTION
Updates `@owneraio/finp2p-ethereum-hedera-plugin` `^0.28.13` → `^0.28.16`.

Constructor and SPI surface unchanged (`(provider, issuer | undefined, controller, allowlister?)`). `tsc` clean, build OK, all unit suites green (24/14/46/9/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)