### PR TITLE
Bump hedera-plugin to ^0.28.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.17",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.18",
         "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
-      "version": "0.28.17",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.17/d07b4bb50149b26fab8f4552a90592a942a3a24c",
-      "integrity": "sha512-v+YgKnTG7p8FBJf1PYrD/0JEwL0BQQZongv6SUHabnY+4du3QTesqVvNRiYSk/Np4ERankSxXzaSWlkKvcof3g==",
+      "version": "0.28.18",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.18/76a3899f31e9750a7ca91396e1a9724f4162fe41",
+      "integrity": "sha512-yxcQw3egk7eZcQ3E8vb7fj6n9wQqD3iiBQFcQHucakvebQTmvQVnuAh063WoyOQSyDIrZlLxTE9Hmt1Yvcj9lg==",
       "dependencies": {
         "ethers": "^6.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.17",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.18",
     "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.9",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.24",


### PR DESCRIPTION
Updates `@owneraio/finp2p-ethereum-hedera-plugin` `^0.28.17` → `^0.28.18`.

`0.28.18` adds an optional 5th constructor param on `AtsTokenStandard` — `formerControllers?: string[]` (controller-rotation support). Backward compatible; the adapter's registration is unchanged (not wired — would need an env for former controller addresses, a separate decision if rotation is needed).

`tsc` clean, build OK, all unit suites green (24/14/46/9/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)