### PR TITLE
Bump skeleton to ^0.28.26 (LedgerAccount variants) with union-compat fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.19",
         "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
-        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25",
+        "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.26",
         "@owneraio/finp2p-vanilla-service": "^0.28.7-onboard.1",
         "@types/node": "^24.10.1",
         "axios": "^1.1.3",
@@ -1891,9 +1891,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-nodejs-skeleton-adapter": {
-      "version": "0.28.25",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.25/8bb9d210f000090d732f1bae0e33644f42c058dd",
-      "integrity": "sha512-igQ2utaarj02OPaQXQhz56DaJlNnX4c+3u0G6es2Vh7d24EuMa/GSdl9qk4/RbLH9tozJ26aR3xjxILIEDbiDg==",
+      "version": "0.28.26",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-nodejs-skeleton-adapter/0.28.26/33f3738c742fd32028cf07b23f1659fa07307a07",
+      "integrity": "sha512-IQLnKj0P7BwlRfshMCk3JE22jXttCvjo6Qp0LqLk8AW9MYrOz4h2FEmtVUgqaP3yteSF7f8VOBhTmIarEuqiPw==",
       "license": "TBD",
       "dependencies": {
         "axios": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.19",
     "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
-    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.25",
+    "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.26",
     "@owneraio/finp2p-vanilla-service": "^0.28.7-onboard.1",
     "@types/node": "^24.10.1",
     "axios": "^1.1.3",

--- a/src/integrations/deposits/ota-deposit/plugin.ts
+++ b/src/integrations/deposits/ota-deposit/plugin.ts
@@ -88,7 +88,7 @@ export class OtaDepositPlugin implements PaymentsPlugin {
 
     return successfulDepositOperation({
       asset,
-      account: { finId: ownerFinId, account: { type: 'crypto', address: ephemeralAddress } },
+      account: { finId: ownerFinId, account: { type: 'walletAccount', address: ephemeralAddress } },
       description: `Send ${asset.assetId} to one-time address ${ephemeralAddress}; funds will be swept to ${sweepTarget}`,
       paymentOptions: [{
         description: 'One-time-address deposit',

--- a/src/integrations/deposits/pull-deposit/plugin.ts
+++ b/src/integrations/deposits/pull-deposit/plugin.ts
@@ -91,7 +91,7 @@ export class PullDepositPlugin implements PaymentsPlugin {
 
     return successfulDepositOperation({
       asset,
-      account: { finId: ownerFinId, account: { type: 'crypto', address: destinationAddress } },
+      account: { finId: ownerFinId, account: { type: 'walletAccount', address: destinationAddress } },
       description: `Approve ${operatorAddress} on the token contract to deposit into ${destinationAddress}`,
       paymentOptions: [{
         description: 'ERC20 approve + pull',

--- a/src/integrations/deposits/wallet-deposit/plugin.ts
+++ b/src/integrations/deposits/wallet-deposit/plugin.ts
@@ -86,7 +86,7 @@ class WalletDepositPlugin implements PaymentsPlugin {
     );
     return successfulDepositOperation({
       asset,
-      account: { finId: ownerFinId, account: { type: 'crypto', address: resolved.walletAddress } },
+      account: { finId: ownerFinId, account: { type: 'walletAccount', address: resolved.walletAddress } },
       description: 'Wallet deposit to investor address',
       paymentOptions: [{
         description: 'Crypto transfer',

--- a/src/services/accounts/account-resolver.ts
+++ b/src/services/accounts/account-resolver.ts
@@ -1,8 +1,21 @@
-import { storage } from '@owneraio/finp2p-nodejs-skeleton-adapter';
+import { LedgerAccount, storage } from '@owneraio/finp2p-nodejs-skeleton-adapter';
 import { FIELD_LEDGER_ACCOUNT_ID, FIELD_CUSTODY_ACCOUNT_ID } from './mapping-validator';
 
 export type AccountMappingStore = storage.AccountStore;
 export type AssetStore = InstanceType<typeof storage.PgAssetStore>;
+
+/** Address carried by an instruction-leg account, if its variant has one
+ *  (custodialAccount doesn't — those resolve via the account mapping). */
+export function ledgerAccountAddress(account: LedgerAccount | undefined): string | undefined {
+  if (!account) return undefined;
+  switch (account.type) {
+    case 'walletAccount':
+    case 'caip10Account':
+      return account.address;
+    default:
+      return undefined;
+  }
+}
 
 export interface ResolvedAccount {
   ledgerAccountId: string;

--- a/src/services/custody/token-service.ts
+++ b/src/services/custody/token-service.ts
@@ -8,7 +8,7 @@ import winston from 'winston';
 import { parseUnits, Provider, Signer, Wallet } from "ethers";
 import { AssetRecord, TokenOperationResult } from '@owneraio/finp2p-ethereum-adapter-contract';
 import { CustodyProvider, CustodyWallet } from './custody-provider';
-import { AccountResolver, AssetStore } from "../accounts";
+import { AccountResolver, AssetStore, ledgerAccountAddress } from "../accounts";
 import { tokenStandardRegistry } from '../../integrations/token-standards/registry';
 import { TokenStandardName as ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from '@owneraio/finp2p-ethereum-erc20-plugin';
 import { buildOperationContext } from "../operations";
@@ -215,7 +215,7 @@ export class CustodyTokenService implements TokenService, EscrowService, HealthS
       const wallet = this.issuerWallet;
       if (!wallet) return failedReceiptOperation(1, 'ASSET_ISSUER_PRIVATE_KEY is not set — issuance is disabled');
       const address = await this.accountMapping.resolveAccount(destination.finId)
-        ?? destination.account?.address;
+        ?? ledgerAccountAddress(destination.account);
       if (!address) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
       const amount = parseUnits(quantity, asset.decimals);
 
@@ -241,7 +241,7 @@ export class CustodyTokenService implements TokenService, EscrowService, HealthS
       const amount = parseUnits(quantity, asset.decimals);
 
       const destinationAddress = await this.accountMapping.resolveAccount(destination.finId)
-        ?? destination.account?.address;
+        ?? ledgerAccountAddress(destination.account);
       if (!destinationAddress) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
       const opCtx = buildOperationContext(ast, signature, exCtx);
       const result = await standard.transfer(wallet, asset, destinationAddress, amount, this.logger, opCtx);
@@ -313,7 +313,7 @@ export class CustodyTokenService implements TokenService, EscrowService, HealthS
       const asset = await this.assetRecord(ast.assetId);
       const standard = tokenStandardRegistry.resolve(asset.tokenStandard);
       const destinationAddress = await this.accountMapping.resolveAccount(destination.finId)
-        ?? destination.account?.address;
+        ?? ledgerAccountAddress(destination.account);
       if (!destinationAddress) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
       const escrowWallet = this.escrowWallet;
       const amount = parseUnits(quantity, asset.decimals);

--- a/src/services/omnibus/omnibus-delegate.ts
+++ b/src/services/omnibus/omnibus-delegate.ts
@@ -14,7 +14,7 @@ import { GasStation } from '../gas-station';
 import { tokenStandardRegistry } from "../../integrations/token-standards/registry";
 import { TokenStandardName as ERC20_TOKEN_STANDARD, DEFAULT_NEW_ERC20_DECIMALS } from "@owneraio/finp2p-ethereum-erc20-plugin";
 import { AssetRecord } from '@owneraio/finp2p-ethereum-adapter-contract';
-import { AccountResolver, AssetStore } from '../accounts/account-resolver';
+import { AccountResolver, AssetStore, ledgerAccountAddress } from '../accounts/account-resolver';
 
 export interface ReceiptPollingConfig {
   timeoutMs: number;
@@ -70,7 +70,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
   ): Promise<DelegateResult> {
     const dbAsset = await this.assetRecord(asset.assetId);
     const destinationAddress = await this.accountMapping.resolveAccount(destination.finId)
-      ?? destination.account?.address;
+      ?? ledgerAccountAddress(destination.account);
     if (!destinationAddress) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
 
     const amount = parseUnits(quantity, dbAsset.decimals);
@@ -209,7 +209,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     // counterparty's on-chain address via `destination.account.address`; deliver
     // there directly so funds physically leave this org.
     const localAddress = await this.accountMapping.resolveAccount(destination.finId);
-    const externalAddress = destination.account?.address;
+    const externalAddress = ledgerAccountAddress(destination.account);
     if (!localAddress && !externalAddress) {
       return { success: false, error: `Cannot resolve release destination for finId: ${destination.finId}` };
     }
@@ -279,7 +279,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
         // { type: 'finId', finId }; the depositor learns the on-chain address
         // from paymentOptions[].methodInstruction.walletAddress instead.
         account: {
-          type: 'crypto',
+          type: 'walletAccount',
           address: omnibusAddress,
         },
       },

--- a/tests/omnibus-delegate.test.ts
+++ b/tests/omnibus-delegate.test.ts
@@ -137,7 +137,7 @@ describe('OmnibusDelegate', () => {
       const result = await delegate.outboundTransfer(
         'idem-2',
         { finId: 'source-fin-id' } as any,
-        { finId: 'dest-fin-id', account: { type: 'crypto', address: '0xDIRECT_ADDR' } } as any,
+        { finId: 'dest-fin-id', account: { type: 'walletAccount', address: '0xDIRECT_ADDR' } } as any,
         TEST_ASSET,
         '2.0',
         undefined,
@@ -209,7 +209,7 @@ describe('OmnibusDelegate', () => {
       const result = await delegate.release(
         'idem-release-cross-org',
         {} as any,
-        { finId: 'remote-org-finId', account: { type: 'crypto', address: '0xREMOTE_ORG_OMNIBUS' } } as any,
+        { finId: 'remote-org-finId', account: { type: 'walletAccount', address: '0xREMOTE_ORG_OMNIBUS' } } as any,
         TEST_ASSET, '7.0', 'op-cross', undefined,
       );
 


### PR DESCRIPTION
Skeleton 0.28.26 widens `LedgerAccount` to the spec's full union (`walletAccount | caip10Account | custodialAccount`, with `NetworkAccount = LedgerAccount | 'none'`). Two compile-level consequences fixed here:

- Leg-account `.address` reads (custody token-service issue/transfer/hold destinations, omnibus-delegate outbound/release) can no longer assume the field exists — they go through a new `ledgerAccountAddress` helper; variants without an address (custodialAccount) fall back to account-mapping resolution as before.
- The deposit-instruction accounts were constructed with `type: 'crypto'`, which was never a spec variant — it only compiled against the old loose `{type: string}`. Now the real `walletAccount`. (The skeleton overwrites that inner shape anyway; value is cosmetic.)

No behavior change for walletAccount flows. Consuming custodialAccount in onboarding lands separately in #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)