### PR TITLE
Validate the caip10 network against the adapter's chain

### DIFF
--- a/src/services/accounts/account-resolver.ts
+++ b/src/services/accounts/account-resolver.ts
@@ -5,13 +5,21 @@ export type AccountMappingStore = storage.AccountStore;
 export type AssetStore = InstanceType<typeof storage.PgAssetStore>;
 
 /** Address carried by an instruction-leg account, if its variant has one
- *  (custodialAccount doesn't — those resolve via the account mapping). */
-export function ledgerAccountAddress(account: LedgerAccount | undefined): string | undefined {
+ *  (custodialAccount doesn't — those resolve via the account mapping).
+ *  A caip10Account is only usable when it names this adapter's chain; a
+ *  mismatch throws rather than settling on the wrong network. */
+export function ledgerAccountAddress(account: LedgerAccount | undefined, chainId: bigint): string | undefined {
   if (!account) return undefined;
   switch (account.type) {
     case 'walletAccount':
-    case 'caip10Account':
       return account.address;
+    case 'caip10Account': {
+      const eip155 = /^eip155:(\d+)$/.exec(account.network);
+      if (!eip155 || BigInt(eip155[1]) !== chainId) {
+        throw new Error(`caip10 account network '${account.network}' does not match this adapter's chain eip155:${chainId}`);
+      }
+      return account.address;
+    }
     default:
       return undefined;
   }

--- a/src/services/custody/token-service.ts
+++ b/src/services/custody/token-service.ts
@@ -215,7 +215,7 @@ export class CustodyTokenService implements TokenService, EscrowService, HealthS
       const wallet = this.issuerWallet;
       if (!wallet) return failedReceiptOperation(1, 'ASSET_ISSUER_PRIVATE_KEY is not set — issuance is disabled');
       const address = await this.accountMapping.resolveAccount(destination.finId)
-        ?? ledgerAccountAddress(destination.account);
+        ?? ledgerAccountAddress(destination.account, (await this.readProvider.getNetwork()).chainId);
       if (!address) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
       const amount = parseUnits(quantity, asset.decimals);
 
@@ -241,7 +241,7 @@ export class CustodyTokenService implements TokenService, EscrowService, HealthS
       const amount = parseUnits(quantity, asset.decimals);
 
       const destinationAddress = await this.accountMapping.resolveAccount(destination.finId)
-        ?? ledgerAccountAddress(destination.account);
+        ?? ledgerAccountAddress(destination.account, (await this.readProvider.getNetwork()).chainId);
       if (!destinationAddress) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
       const opCtx = buildOperationContext(ast, signature, exCtx);
       const result = await standard.transfer(wallet, asset, destinationAddress, amount, this.logger, opCtx);
@@ -313,7 +313,7 @@ export class CustodyTokenService implements TokenService, EscrowService, HealthS
       const asset = await this.assetRecord(ast.assetId);
       const standard = tokenStandardRegistry.resolve(asset.tokenStandard);
       const destinationAddress = await this.accountMapping.resolveAccount(destination.finId)
-        ?? ledgerAccountAddress(destination.account);
+        ?? ledgerAccountAddress(destination.account, (await this.readProvider.getNetwork()).chainId);
       if (!destinationAddress) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
       const escrowWallet = this.escrowWallet;
       const amount = parseUnits(quantity, asset.decimals);

--- a/src/services/omnibus/omnibus-delegate.ts
+++ b/src/services/omnibus/omnibus-delegate.ts
@@ -70,7 +70,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
   ): Promise<DelegateResult> {
     const dbAsset = await this.assetRecord(asset.assetId);
     const destinationAddress = await this.accountMapping.resolveAccount(destination.finId)
-      ?? ledgerAccountAddress(destination.account);
+      ?? ledgerAccountAddress(destination.account, (await this.readProvider.getNetwork()).chainId);
     if (!destinationAddress) throw new Error(`Cannot resolve address for finId: ${destination.finId}`);
 
     const amount = parseUnits(quantity, dbAsset.decimals);
@@ -209,7 +209,7 @@ export class OmnibusDelegate implements TransferDelegate, AssetDelegate, EscrowD
     // counterparty's on-chain address via `destination.account.address`; deliver
     // there directly so funds physically leave this org.
     const localAddress = await this.accountMapping.resolveAccount(destination.finId);
-    const externalAddress = ledgerAccountAddress(destination.account);
+    const externalAddress = ledgerAccountAddress(destination.account, (await this.readProvider.getNetwork()).chainId);
     if (!localAddress && !externalAddress) {
       return { success: false, error: `Cannot resolve release destination for finId: ${destination.finId}` };
     }

--- a/tests/account-resolver.test.ts
+++ b/tests/account-resolver.test.ts
@@ -2,6 +2,7 @@ import { finIdToAddress, privateKeyToFinId } from '@owneraio/finp2p-ethereum-orc
 import {
   AccountResolver,
   DbAccountResolver,
+  ledgerAccountAddress,
   AccountMappingStore,
 } from '../src/services/accounts/account-resolver';
 import { FIELD_LEDGER_ACCOUNT_ID } from '../src/services/accounts/mapping-validator';
@@ -153,5 +154,36 @@ describe('DbAccountResolver', () => {
     const mappings = await accountStore.getByFieldValue(FIELD_LEDGER_ACCOUNT_ID, TEST_ADDRESS);
     expect(mappings.length).toBeGreaterThan(0);
     expect(mappings[0].finId).toBe(TEST_FIN_ID);
+  });
+});
+
+describe('ledgerAccountAddress', () => {
+  const CHAIN = 11155111n;
+  const ADDR = '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18';
+
+  test('walletAccount address passes through', () => {
+    expect(ledgerAccountAddress({ type: 'walletAccount', address: ADDR }, CHAIN)).toBe(ADDR);
+  });
+
+  test('caip10Account on this chain resolves', () => {
+    expect(ledgerAccountAddress({ type: 'caip10Account', network: 'eip155:11155111', address: ADDR }, CHAIN)).toBe(ADDR);
+  });
+
+  test('caip10Account on another chain throws instead of settling here', () => {
+    expect(() => ledgerAccountAddress({ type: 'caip10Account', network: 'eip155:1', address: ADDR }, CHAIN))
+      .toThrow(/does not match this adapter's chain/);
+  });
+
+  test('non-eip155 caip10 network throws', () => {
+    expect(() => ledgerAccountAddress({ type: 'caip10Account', network: 'cosmos:cosmoshub-4', address: ADDR }, CHAIN))
+      .toThrow(/does not match this adapter's chain/);
+  });
+
+  test('custodialAccount carries no address', () => {
+    expect(ledgerAccountAddress({ type: 'custodialAccount', provider: 'fireblocks', vaultAccountId: '85' }, CHAIN)).toBeUndefined();
+  });
+
+  test('absent account is undefined', () => {
+    expect(ledgerAccountAddress(undefined, CHAIN)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Review follow-up to #366 (P1): `ledgerAccountAddress` returned a `caip10Account` address unconditionally, discarding `account.network` — a destination leg pinned to `eip155:1` could be executed by an adapter connected to a different chain, settling on the wrong network.

Callers (custody token-service issue/transfer/hold-release destinations, omnibus-delegate outbound/release) now pass the read provider's `chainId` (ethers caches `getNetwork()`, so no extra RPC per call), and the helper throws on a network mismatch or a non-eip155 namespace instead of resolving. `walletAccount` stays network-less by definition (this-chain), `custodialAccount` still resolves via the account mapping.

Six unit tests over the helper in `tests/account-resolver.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)