### PR TITLE
Custodial-account onboarding: resolve custody account ids, mirror the account mapping

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,6 @@ import {
   PaymentsServiceImpl,
   AccountMappingServiceImpl,
   NetworkAccountService,
-  NetworkAccountServiceImpl,
   workflows,
   storage as storageModule,
 } from "@owneraio/finp2p-nodejs-skeleton-adapter";
@@ -24,6 +23,7 @@ import {
   CustodyProvider,
   CustodyWallet,
   CustodyTokenService,
+  CustodyNetworkAccountService,
   custodyRegistry,
 } from "./services/custody";
 import { createWalletResolver } from "./integrations/wallet-resolver";
@@ -204,16 +204,6 @@ async function createApp(
   const assetStore = new storageModule.PgAssetStore(dbPool, ledgerSchema);
   const workflowStorage = new workflows.WorkflowStorage(dbPool, ledgerSchema);
 
-  // Investor network-account onboarding (sync trust model, no ownership
-  // challenge) — the successor of the finId->wallet mapping API. Direct mode
-  // records bindings in the Postgres store only (the wallet reaches the token
-  // services per operation on the instruction legs); on-chain mode additionally
-  // registers generated wallets in the operator contract's credentials registry.
-  const networkAccountStore = new storageModule.PgNetworkAccountStore(dbPool, ledgerSchema);
-  const networkAccountService: NetworkAccountService = appConfig.type === 'finp2p-contract'
-    ? new OnChainNetworkAccountService(networkAccountStore, (appConfig as FinP2PContractAppConfig).finP2PContract, new EvmNetworkAccountValidator())
-    : new NetworkAccountServiceImpl(networkAccountStore, new EvmNetworkAccountValidator());
-
   let custodyProvider: CustodyProvider | undefined;
   if (custodyRegistry.has(appConfig.type)) {
     logger.info(`Activating custody provider: ${appConfig.type} (available: ${custodyRegistry.availableProviders.join(', ')})`);
@@ -275,6 +265,17 @@ async function createApp(
   // EVM addresses resolve to the same record.
   const accountMappingService = new AccountMappingServiceImpl(accountMappingStore, { caseSensitive: false });
   const accountMapping: AccountResolver = new DbAccountResolver(accountMappingService);
+
+  // Investor network-account onboarding (sync trust model, no ownership
+  // challenge) — the successor of the finId->wallet mapping API. Custody modes
+  // record the binding (a custody account id in place of the address is
+  // resolved via the provider) and mirror it into the account-mapping store;
+  // on-chain mode registers generated wallets in the operator contract's
+  // credentials registry.
+  const networkAccountStore = new storageModule.PgNetworkAccountStore(dbPool, ledgerSchema);
+  const networkAccountService: NetworkAccountService = appConfig.type === 'finp2p-contract'
+    ? new OnChainNetworkAccountService(networkAccountStore, (appConfig as FinP2PContractAppConfig).finP2PContract, new EvmNetworkAccountValidator())
+    : new CustodyNetworkAccountService(networkAccountStore, custodyProvider, accountMappingService, logger, new EvmNetworkAccountValidator());
 
   let omnibusCtx: OmnibusContext | undefined;
   if (appConfig.accountModel === 'omnibus' && custodyProvider) {

--- a/src/services/custody/index.ts
+++ b/src/services/custody/index.ts
@@ -1,3 +1,4 @@
 export * from './custody-provider'
 export * from './custody-registry'
 export * from './token-service'
+export * from './network-account-service'

--- a/src/services/custody/network-account-service.ts
+++ b/src/services/custody/network-account-service.ts
@@ -1,0 +1,79 @@
+import winston from 'winston';
+import {
+  AccountInvalidShapeError,
+  AccountMappingServiceImpl,
+  AccountOperation,
+  BindInfo,
+  NetworkAccountServiceImpl,
+  NetworkAccountValidator,
+  storage,
+} from '@owneraio/finp2p-nodejs-skeleton-adapter';
+import { FIELD_CUSTODY_ACCOUNT_ID, FIELD_LEDGER_ACCOUNT_ID } from '../accounts/mapping-validator';
+import { CustodyProvider } from './custody-provider';
+
+const ETH_ADDRESS_FORMAT = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * Investor onboarding for custody modes.
+ *
+ * A custodialAccount bind carries the custody account id (e.g. a Fireblocks
+ * vault account id) explicitly and is resolved to its wallet address via the
+ * custody provider; a walletAccount address in EVM format binds as-is, and a
+ * walletAccount address in any other format is treated as a custody account
+ * id too — a temporary overload kept until routers send custodialAccount.
+ * Every binding is normalized to the resolved walletAccount and mirrored into
+ * the account-mapping store, which is what every operational resolver reads
+ * (token services, plan approval, deposits); the custody account id is kept
+ * on the mapping so per-operation signing skips the vault scan. The mapping
+ * is per finId and shared across the investor's asset bindings, so unbinding
+ * one asset leaves it in place.
+ */
+export class CustodyNetworkAccountService extends NetworkAccountServiceImpl {
+
+  constructor(
+    store: storage.NetworkAccountStore,
+    private readonly custodyProvider: CustodyProvider | undefined,
+    private readonly mappingService: AccountMappingServiceImpl,
+    private readonly logger: winston.Logger,
+    validator?: NetworkAccountValidator,
+  ) {
+    super(store, validator);
+  }
+
+  async createAccount(idempotencyKey: string, organizationId: string, assetId: string, finId: string, bindInfo: BindInfo | undefined): Promise<AccountOperation> {
+    let effectiveBind = bindInfo;
+    let custodyAccountId: string | undefined;
+    if (bindInfo?.account.type === 'custodialAccount') {
+      custodyAccountId = bindInfo.account.vaultAccountId;
+      const address = await this.resolveCustodyAddress(custodyAccountId);
+      this.logger.info(`onboarding: custodial account ${custodyAccountId} (provider '${bindInfo.account.provider}') resolved to ${address}`);
+      effectiveBind = { ...bindInfo, account: { type: 'walletAccount', address } };
+    } else if (bindInfo?.account.type === 'walletAccount' && !ETH_ADDRESS_FORMAT.test(bindInfo.account.address)) {
+      custodyAccountId = bindInfo.account.address;
+      const address = await this.resolveCustodyAddress(custodyAccountId);
+      this.logger.info(`onboarding: '${custodyAccountId}' taken as a custody account id, resolved to ${address}`);
+      effectiveBind = { ...bindInfo, account: { type: 'walletAccount', address } };
+    }
+
+    const op = await super.createAccount(idempotencyKey, organizationId, assetId, finId, effectiveBind);
+    if (op.type !== 'success' || op.record.account.type !== 'walletAccount') return op;
+    const address = op.record.account.address;
+
+    await this.mappingService.saveAccount(finId, custodyAccountId
+      ? { [FIELD_LEDGER_ACCOUNT_ID]: address, [FIELD_CUSTODY_ACCOUNT_ID]: custodyAccountId }
+      : { [FIELD_LEDGER_ACCOUNT_ID]: address });
+
+    return op;
+  }
+
+  private async resolveCustodyAddress(custodyAccountId: string): Promise<string> {
+    if (!this.custodyProvider?.resolveAddressFromCustodyId) {
+      throw new AccountInvalidShapeError(`'${custodyAccountId}' is not an EVM address and the custody provider cannot resolve custody account ids`);
+    }
+    try {
+      return await this.custodyProvider.resolveAddressFromCustodyId(custodyAccountId);
+    } catch (e) {
+      throw new AccountInvalidShapeError(`cannot resolve custody account '${custodyAccountId}' to a wallet address: ${(e as Error).message}`);
+    }
+  }
+}

--- a/tests/network-accounts.test.ts
+++ b/tests/network-accounts.test.ts
@@ -2,6 +2,7 @@ import { AccountInvalidShapeError, storage } from "@owneraio/finp2p-nodejs-skele
 import { EvmNetworkAccountValidator } from "../src/services/accounts";
 import { finIdToAddress } from "@owneraio/finp2p-ethereum-orchestrator";
 import { OnChainTokenService, OnChainNetworkAccountService } from "../src/services/onchain";
+import { CustodyNetworkAccountService } from "../src/services/custody";
 
 const ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
@@ -102,5 +103,81 @@ describe("OnChainNetworkAccountService onboarding", () => {
       .rejects.toThrow(AccountInvalidShapeError);
     expect(contract.addCredential).not.toHaveBeenCalled();
     expect(store.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe("CustodyNetworkAccountService onboarding", () => {
+
+  const FIN_ID = "02b3e7cbe9b2e91832ea4a11a17a2e30d3cf52dae486ec1e1e3d0741e1f77210ab";
+  const VAULT_ID = "85";
+  const logger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any;
+
+  const storeMock = (): jest.Mocked<storage.NetworkAccountStore> => ({
+    insert: jest.fn().mockImplementation(async (row) => row),
+    getByFinId: jest.fn().mockResolvedValue(undefined),
+    remove: jest.fn().mockResolvedValue(undefined),
+  });
+
+  const custodyProvider = {
+    resolveAddressFromCustodyId: jest.fn().mockImplementation(async (id: string) => {
+      if (id !== VAULT_ID) throw new Error(`No deposit address found for vault ${id}`);
+      return ADDRESS;
+    }),
+  } as any;
+  const mappingService = { saveAccount: jest.fn().mockResolvedValue(undefined) } as any;
+  beforeEach(() => { custodyProvider.resolveAddressFromCustodyId.mockClear(); mappingService.saveAccount.mockClear(); });
+
+  const build = (store: storage.NetworkAccountStore) =>
+    new CustodyNetworkAccountService(store, custodyProvider, mappingService, logger, new EvmNetworkAccountValidator());
+
+  test("EVM wallet bind: recorded as-is and mirrored into the account mapping", async () => {
+    const store = storeMock();
+    const op = await build(store).createAccount("ik", "org", "asset", FIN_ID, { account: { type: "walletAccount", address: ADDRESS } });
+    expect(op.type).toBe("success");
+    expect(store.insert).toHaveBeenCalledTimes(1);
+    expect(mappingService.saveAccount).toHaveBeenCalledWith(FIN_ID, { ledgerAccountId: ADDRESS });
+  });
+
+  test("custodialAccount bind: vault id resolved via the provider, mirrored with both fields", async () => {
+    const store = storeMock();
+    const op = await build(store).createAccount("ik", "org", "asset", FIN_ID,
+      { account: { type: "custodialAccount", provider: "fireblocks", vaultAccountId: VAULT_ID } });
+    expect(op.type).toBe("success");
+    expect((op as any).record.account).toEqual({ type: "walletAccount", address: ADDRESS });
+    expect(custodyProvider.resolveAddressFromCustodyId).toHaveBeenCalledWith(VAULT_ID);
+    expect(store.insert).toHaveBeenCalledWith(expect.objectContaining({ account: { type: "walletAccount", address: ADDRESS } }));
+    expect(mappingService.saveAccount).toHaveBeenCalledWith(FIN_ID, { ledgerAccountId: ADDRESS, custodyAccountId: VAULT_ID });
+  });
+
+  test("non-EVM walletAccount address binds as a custody account id (temporary overload)", async () => {
+    const store = storeMock();
+    const op = await build(store).createAccount("ik", "org", "asset", FIN_ID, { account: { type: "walletAccount", address: VAULT_ID } });
+    expect(op.type).toBe("success");
+    expect((op as any).record.account).toEqual({ type: "walletAccount", address: ADDRESS });
+    expect(mappingService.saveAccount).toHaveBeenCalledWith(FIN_ID, { ledgerAccountId: ADDRESS, custodyAccountId: VAULT_ID });
+  });
+
+  test("unresolvable custody account id is rejected before any persistence", async () => {
+    const store = storeMock();
+    await expect(build(store).createAccount("ik", "org", "asset", FIN_ID, { account: { type: "walletAccount", address: "no-such-vault" } }))
+      .rejects.toThrow(AccountInvalidShapeError);
+    expect(store.insert).not.toHaveBeenCalled();
+    expect(mappingService.saveAccount).not.toHaveBeenCalled();
+  });
+
+  test("custody-id bind without a resolving provider is rejected", async () => {
+    const store = storeMock();
+    const service = new CustodyNetworkAccountService(store, undefined, mappingService, logger, new EvmNetworkAccountValidator());
+    await expect(service.createAccount("ik", "org", "asset", FIN_ID, { account: { type: "custodialAccount", provider: "fireblocks", vaultAccountId: VAULT_ID } }))
+      .rejects.toThrow(AccountInvalidShapeError);
+    expect(store.insert).not.toHaveBeenCalled();
+  });
+
+  test("remove unbinds without touching the shared account mapping", async () => {
+    const store = storeMock();
+    const op = await build(store).removeAccount("ik", "acc-1");
+    expect(op.type).toBe("success");
+    expect(store.remove).toHaveBeenCalledWith("acc-1");
+    expect(mappingService.saveAccount).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Split out of #365 so the custodial-account binding lands before the whitelisting step.

`CustodyNetworkAccountService` replaces the plain skeleton impl in custody modes:

- **custodialAccount binds** (skeleton 0.28.26 variant): `vaultAccountId` resolved to the wallet address via the provider's `resolveAddressFromCustodyId` (same call the internal `/mapping/owners` validator uses); binding normalized to the resolved `walletAccount`. Unresolvable ids / providers without the capability reject with 400 before anything persists.
- **Temporary overload**: a `walletAccount` address not matching `^0x[0-9a-fA-F]{40}$` is treated as a custody account id too — kept until routers actually send `custodialAccount`.
- **Account-mapping mirror**: every binding also writes `account_mappings` (`ledgerAccountId`, plus `custodyAccountId` for custody-id binds). All operational resolution — token services, plan approval, deposits — reads that store, so without the mirror an official-API-onboarded investor cannot transact; with the custody id stored, Fireblocks signing takes the vault-scoped fast path with no workspace scan. The mapping is per finId and shared across the investor's asset bindings, so unbinding one asset leaves it in place.

Six tests in `tests/network-accounts.test.ts`. #365 rebases on top with the whitelist-on-onboard/dewhitelist-on-offboard step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)