### PR TITLE
Orchestrator 0.28.26: drive on-chain mapping by the wallet resolution mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.37",
-        "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
+        "@owneraio/finp2p-ethereum-orchestrator": "^0.28.26",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.27",
         "@owneraio/finp2p-vanilla-service": "^0.28.7-onboard.1",
@@ -1853,9 +1853,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-orchestrator": {
-      "version": "0.28.24",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-orchestrator/0.28.24/b7d86f791937be2ce2eb2c4666038101c3302bf1",
-      "integrity": "sha512-tFwF3A3si76zs6M9hej6yAkhi4Rln9Sb8nMOz8YrwB2xIgzwuxqtTpEw0A7RrbG3bNmDyAhNwyXsIAHzuQJvNg==",
+      "version": "0.28.26",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-orchestrator/0.28.26/7f055466530bcfe3057d67ae1a3367c0a7fdaf15",
+      "integrity": "sha512-u19ru+C6PWyAcNLOSrRwKx3OJqhAr0nkO0D1Y8ojR5S8AnUYARWVc9ztcxvQSXHe7owT/+o6P0icuM4MHYtxKQ==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
         "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.37",
-        "@owneraio/finp2p-ethereum-orchestrator": "^0.28.26",
+        "@owneraio/finp2p-ethereum-orchestrator": "^0.28.27",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.27",
         "@owneraio/finp2p-vanilla-service": "^0.28.7-onboard.1",
@@ -1853,9 +1853,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-orchestrator": {
-      "version": "0.28.26",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-orchestrator/0.28.26/7f055466530bcfe3057d67ae1a3367c0a7fdaf15",
-      "integrity": "sha512-u19ru+C6PWyAcNLOSrRwKx3OJqhAr0nkO0D1Y8ojR5S8AnUYARWVc9ztcxvQSXHe7owT/+o6P0icuM4MHYtxKQ==",
+      "version": "0.28.27",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-orchestrator/0.28.27/62fac34db577a73d817c103e64d5d808b46da306",
+      "integrity": "sha512-LeI8IDeRemGUrrDGBhfGNjJeltFt96ZTYG1bZi778zmFGVHh5zz5IjPhDXHIdknnNP28gRMVAIEziQqvme91Xw==",
       "license": "TBD",
       "dependencies": {
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.37",
-    "@owneraio/finp2p-ethereum-orchestrator": "^0.28.24",
+    "@owneraio/finp2p-ethereum-orchestrator": "^0.28.26",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.27",
     "@owneraio/finp2p-vanilla-service": "^0.28.7-onboard.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
     "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.37",
-    "@owneraio/finp2p-ethereum-orchestrator": "^0.28.26",
+    "@owneraio/finp2p-ethereum-orchestrator": "^0.28.27",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.27",
     "@owneraio/finp2p-vanilla-service": "^0.28.7-onboard.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import {
   OnChainTokenService,
   OnChainNetworkAccountService,
 } from "./services/onchain";
+import { WalletResolutionMode } from "@owneraio/finp2p-ethereum-orchestrator";
 import {
   CustodyProvider,
   CustodyWallet,
@@ -153,6 +154,7 @@ function registerFinP2PContractServices(
   paymentsService: PaymentsServiceImpl, pluginManager: PluginManager,
   workflowStorage: workflows.WorkflowStorage, finP2PClient: FinP2PClient | undefined,
   networkAccountService: NetworkAccountService,
+  walletResolutionMode: WalletResolutionMode,
 ) {
   if (contractConfig.accountModel === 'omnibus') {
     throw new Error('Omnibus account model is not supported with finp2p-contract provider');
@@ -160,7 +162,7 @@ function registerFinP2PContractServices(
   const proxiedNetworkAccountService = wrapWithWorkflowProxy(networkAccountService, workflowStorage, finP2PClient, 'createAccount', 'removeAccount');
   let planApprovalService = new PlanApprovalServiceImpl(contractConfig.orgId, pluginManager, contractConfig.finP2PClient);
   const tokenService = new OnChainTokenService(contractConfig.finP2PContract, contractConfig.finP2PClient, contractConfig.execDetailsStore, contractConfig.proofProvider, pluginManager, contractConfig.defaultAssetStandard);
-  const mappingService = new CredentialsMappingService(contractConfig.finP2PContract);
+  const mappingService = new CredentialsMappingService(contractConfig.finP2PContract, walletResolutionMode);
   const mappingConfig = buildMappingConfig();
 
   const commonService = new DirectCommonServiceImpl(workflowStorage);
@@ -287,8 +289,17 @@ async function createApp(
   // approval only validates. On-chain mode registers generated wallets in the
   // operator contract's credentials registry.
   const networkAccountStore = new storageModule.PgNetworkAccountStore(dbPool, ledgerSchema);
+  // The contract's wallet resolution mode is read once at boot: under
+  // FinIdDerivation (demo mode) the credentials mapping is disabled and
+  // onboarding/mapping writes are no-ops.
+  const walletResolutionMode = appConfig.type === 'finp2p-contract'
+    ? await (appConfig as FinP2PContractAppConfig).finP2PContract.getWalletResolutionMode()
+    : undefined;
+  if (walletResolutionMode !== undefined) {
+    logger.info(`FinP2P contract wallet resolution mode: ${WalletResolutionMode[walletResolutionMode]}`);
+  }
   const networkAccountService: NetworkAccountService = appConfig.type === 'finp2p-contract'
-    ? new OnChainNetworkAccountService(networkAccountStore, (appConfig as FinP2PContractAppConfig).finP2PContract, new EvmNetworkAccountValidator())
+    ? new OnChainNetworkAccountService(networkAccountStore, (appConfig as FinP2PContractAppConfig).finP2PContract, walletResolutionMode!, new EvmNetworkAccountValidator())
     : new CustodyNetworkAccountService(networkAccountStore, custodyProvider, accountMappingService, logger, new EvmNetworkAccountValidator());
 
 
@@ -338,7 +349,7 @@ async function createApp(
   if (custodyProvider) {
     await registerCustodyServices(app, logger, custodyProvider, escrowWallet, readProvider, gasStation, appConfig, paymentsService, pluginManager, workflowStorage, finP2PClient, accountMappingStore, accountMappingService, assetStore, accountMapping, omnibusCtx, networkAccountService, whitelistService);
   } else if (appConfig.type === 'finp2p-contract') {
-    registerFinP2PContractServices(app, appConfig as FinP2PContractAppConfig, paymentsService, pluginManager, workflowStorage, finP2PClient, networkAccountService);
+    registerFinP2PContractServices(app, appConfig as FinP2PContractAppConfig, paymentsService, pluginManager, workflowStorage, finP2PClient, networkAccountService, walletResolutionMode!);
   } else {
     throw new Error(`Unknown provider type: '${appConfig.type}'. Available custody providers: ${custodyRegistry.availableProviders.join(', ')}`);
   }

--- a/src/services/onchain/mapping.ts
+++ b/src/services/onchain/mapping.ts
@@ -1,5 +1,5 @@
 import { AccountMappingService, AccountMapping, ReceiptOperation, Asset, ExecutionContext } from '@owneraio/finp2p-nodejs-skeleton-adapter';
-import { FinP2PContract, ReceiptOperation as ContractReceiptOperation } from '@owneraio/finp2p-ethereum-orchestrator';
+import { FinP2PContract, ReceiptOperation as ContractReceiptOperation, WalletResolutionMode } from '@owneraio/finp2p-ethereum-orchestrator';
 import { FIELD_LEDGER_ACCOUNT_ID } from '../accounts/mapping-validator';
 
 function mapAccount(acc: { finId: string; account?: string } | undefined) {
@@ -51,11 +51,16 @@ export function mapReceiptOperation(op: ContractReceiptOperation, asset?: Asset,
 
 /**
  * AccountMappingService backed by the on-chain credentials registry.
- * The contract is the source of truth — no DB persistence needed.
+ * The contract is the source of truth — no DB persistence needed. Under
+ * WalletResolutionMode.FinIdDerivation (demo mode) the registry is disabled
+ * (addCredential reverts), so writes are no-ops.
  */
 export class CredentialsMappingService implements AccountMappingService {
 
-  constructor(private readonly finP2PContract: FinP2PContract) {}
+  constructor(
+    private readonly finP2PContract: FinP2PContract,
+    private readonly resolutionMode: WalletResolutionMode,
+  ) {}
 
   async getAccounts(finIds?: string[]): Promise<AccountMapping[]> {
     if (!finIds || finIds.length === 0) return [];
@@ -77,6 +82,9 @@ export class CredentialsMappingService implements AccountMappingService {
   }
 
   async saveAccount(finId: string, fields: Record<string, string>): Promise<AccountMapping> {
+    if (this.resolutionMode === WalletResolutionMode.FinIdDerivation) {
+      return { finId, fields };
+    }
     const address = fields[FIELD_LEDGER_ACCOUNT_ID];
     if (!address) throw new Error(`Field '${FIELD_LEDGER_ACCOUNT_ID}' is required for on-chain credential mapping`);
     await this.finP2PContract.addCredential(finId, address);
@@ -84,6 +92,9 @@ export class CredentialsMappingService implements AccountMappingService {
   }
 
   async deleteAccount(finId: string, _fieldName?: string): Promise<void> {
+    if (this.resolutionMode === WalletResolutionMode.FinIdDerivation) {
+      return;
+    }
     await this.finP2PContract.removeCredential(finId);
   }
 }

--- a/src/services/onchain/network-account-service.ts
+++ b/src/services/onchain/network-account-service.ts
@@ -1,44 +1,60 @@
+import { randomUUID } from 'crypto';
 import {
   AccountOperation,
   BindInfo,
   NetworkAccountServiceImpl,
   NetworkAccountValidator,
   storage,
+  successfulAccountOperation,
 } from '@owneraio/finp2p-nodejs-skeleton-adapter';
-import { FinP2PContract, finIdToAddress } from '@owneraio/finp2p-ethereum-orchestrator';
+import { FinP2PContract, WalletResolutionMode } from '@owneraio/finp2p-ethereum-orchestrator';
 
 /**
- * Investor onboarding for the on-chain operator contract: an operation
- * referencing a finId with no entry in the contract's credentials registry
- * reverts, so onboarding is where the investor finId gets bound to a wallet
- * via addCredential.
+ * Investor onboarding for the on-chain operator contract, driven by the
+ * contract's wallet resolution mode (read once at service start):
+ *
+ * - WalletMapping: an operation referencing a finId with no entry in the
+ *   credentials registry reverts, so onboarding binds the investor's wallet
+ *   via addCredential. Create-new is not supported — the adapter never
+ *   derives a wallet from the finId off-chain.
+ * - FinIdDerivation (demo mode): the contract derives wallets from the
+ *   finId's compressed public key and the credentials mapping is disabled
+ *   (addCredential reverts), so onboarding is a no-op success — nothing to
+ *   register, nothing stored.
  */
 export class OnChainNetworkAccountService extends NetworkAccountServiceImpl {
 
   constructor(
     store: storage.NetworkAccountStore,
     private readonly finP2PContract: FinP2PContract,
+    private readonly resolutionMode: WalletResolutionMode,
     validator?: NetworkAccountValidator,
   ) {
     super(store, validator);
   }
 
   async createAccount(idempotencyKey: string, organizationId: string, assetId: string, finId: string, bindInfo: BindInfo | undefined): Promise<AccountOperation> {
-    if (!bindInfo) {
-      // create-new: the investor's wallet is the address derived from the
-      // finId itself (finId = compressed secp256k1 pubkey), so the investor's
-      // existing finId key signs for it — no LA-side key to generate or hold
-      const address = finIdToAddress(finId);
-      await this.finP2PContract.addCredential(finId, address);
-      return super.createAccount(idempotencyKey, organizationId, assetId, finId, { account: { type: 'walletAccount', address } });
+    if (this.resolutionMode === WalletResolutionMode.FinIdDerivation) {
+      if (bindInfo) await this.validator?.validate(bindInfo.account);
+      return successfulAccountOperation('', { id: randomUUID(), account: bindInfo?.account ?? { type: 'none' } });
     }
 
-    // bind-existing: validate the wallet shape before touching the chain
-    // (super validates again — cheap and keeps its invariants intact)
-    await this.validator?.validate(bindInfo.account);
-    if (bindInfo.account.type === 'walletAccount') {
-      await this.finP2PContract.addCredential(finId, bindInfo.account.address);
+    if (bindInfo) {
+      // bind-existing: validate the wallet shape before touching the chain
+      // (super validates again — cheap and keeps its invariants intact)
+      await this.validator?.validate(bindInfo.account);
+      if (bindInfo.account.type === 'walletAccount') {
+        await this.finP2PContract.addCredential(finId, bindInfo.account.address);
+      }
     }
+    // create-new (no bindInfo) falls through to the base NotSupported rejection
     return super.createAccount(idempotencyKey, organizationId, assetId, finId, bindInfo);
+  }
+
+  async removeAccount(idempotencyKey: string, accountId: string): Promise<AccountOperation> {
+    if (this.resolutionMode === WalletResolutionMode.FinIdDerivation) {
+      return successfulAccountOperation('', { id: accountId, account: { type: 'none' } });
+    }
+    return super.removeAccount(idempotencyKey, accountId);
   }
 }

--- a/tests/network-accounts.test.ts
+++ b/tests/network-accounts.test.ts
@@ -1,7 +1,7 @@
 import { AccountInvalidShapeError, storage } from "@owneraio/finp2p-nodejs-skeleton-adapter";
 import { InvestorWhitelistServiceImpl, EvmNetworkAccountValidator } from "../src/services/accounts";
-import { finIdToAddress } from "@owneraio/finp2p-ethereum-orchestrator";
-import { OnChainTokenService, OnChainNetworkAccountService } from "../src/services/onchain";
+import { WalletResolutionMode } from "@owneraio/finp2p-ethereum-orchestrator";
+import { OnChainTokenService, OnChainNetworkAccountService, CredentialsMappingService } from "../src/services/onchain";
 import { CustodyNetworkAccountService } from "../src/services/custody";
 import { ValidationError, WhitelistRefusedError } from "@owneraio/finp2p-nodejs-skeleton-adapter";
 import { tokenStandardRegistry } from "../src/integrations/token-standards/registry";
@@ -71,40 +71,81 @@ describe("OnChainNetworkAccountService onboarding", () => {
 
   const FIN_ID = "02b3e7cbe9b2e91832ea4a11a17a2e30d3cf52dae486ec1e1e3d0741e1f77210ab";
 
-  test("create-new: derives the wallet from the finId, registers and persists it", async () => {
+  const build = (store: storage.NetworkAccountStore, contract: any, mode: WalletResolutionMode) =>
+    new OnChainNetworkAccountService(store, contract, mode, new EvmNetworkAccountValidator());
+
+  test("wallet-mapping: bind-existing registers the wallet in the credentials registry", async () => {
     const store = storeMock();
     const contract = contractMock();
-    const service = new OnChainNetworkAccountService(store, contract as any, new EvmNetworkAccountValidator());
-
-    const op = await service.createAccount("ik-1", "org", "asset", FIN_ID, undefined);
-    expect(op.type).toBe("success");
-    const record = (op as any).record;
-    expect(record.account).toEqual({ type: "walletAccount", address: finIdToAddress(FIN_ID) });
-    expect(contract.addCredential).toHaveBeenCalledWith(FIN_ID, record.account.address);
-    expect(store.insert).toHaveBeenCalledWith(expect.objectContaining({ finId: FIN_ID, account: record.account }));
-  });
-
-  test("bind-existing: registers the supplied wallet under the investor finId", async () => {
-    const store = storeMock();
-    const contract = contractMock();
-    const service = new OnChainNetworkAccountService(store, contract as any, new EvmNetworkAccountValidator());
-
-    const op = await service.createAccount("ik-2", "org", "asset", FIN_ID, { account: { type: "walletAccount", address: ADDRESS } });
+    const op = await build(store, contract, WalletResolutionMode.WalletMapping)
+      .createAccount("ik-1", "org", "asset", FIN_ID, { account: { type: "walletAccount", address: ADDRESS } });
     expect(op.type).toBe("success");
     expect((op as any).record.account).toEqual({ type: "walletAccount", address: ADDRESS });
     expect(contract.addCredential).toHaveBeenCalledWith(FIN_ID, ADDRESS);
     expect(store.insert).toHaveBeenCalledTimes(1);
   });
 
-  test("bind-existing with invalid wallet: rejected before any chain call", async () => {
+  test("wallet-mapping: create-new is not supported — the adapter never derives a wallet off-chain", async () => {
     const store = storeMock();
     const contract = contractMock();
-    const service = new OnChainNetworkAccountService(store, contract as any, new EvmNetworkAccountValidator());
+    await expect(build(store, contract, WalletResolutionMode.WalletMapping).createAccount("ik-2", "org", "asset", FIN_ID, undefined))
+      .rejects.toThrow(/create-new account mode is not supported/);
+    expect(contract.addCredential).not.toHaveBeenCalled();
+    expect(store.insert).not.toHaveBeenCalled();
+  });
 
-    await expect(service.createAccount("ik-2b", "org", "asset", FIN_ID, { account: { type: "walletAccount", address: "0x1234" } as any }))
+  test("wallet-mapping: bind-existing with invalid wallet is rejected before any chain call", async () => {
+    const store = storeMock();
+    const contract = contractMock();
+    await expect(build(store, contract, WalletResolutionMode.WalletMapping)
+      .createAccount("ik-2b", "org", "asset", FIN_ID, { account: { type: "walletAccount", address: "0x1234" } as any }))
       .rejects.toThrow(AccountInvalidShapeError);
     expect(contract.addCredential).not.toHaveBeenCalled();
     expect(store.insert).not.toHaveBeenCalled();
+  });
+
+  test("finId-derivation (demo): onboarding is a no-op success — no registration, nothing stored", async () => {
+    const store = storeMock();
+    const contract = contractMock();
+    const service = build(store, contract, WalletResolutionMode.FinIdDerivation);
+    const op = await service.createAccount("ik-3", "org", "asset", FIN_ID, { account: { type: "walletAccount", address: ADDRESS } });
+    expect(op.type).toBe("success");
+    expect((op as any).record.account).toEqual({ type: "walletAccount", address: ADDRESS });
+    expect(contract.addCredential).not.toHaveBeenCalled();
+    expect(store.insert).not.toHaveBeenCalled();
+
+    const removed = await service.removeAccount("ik-4", "acc-1");
+    expect(removed.type).toBe("success");
+    expect(store.remove).not.toHaveBeenCalled();
+  });
+});
+
+describe("CredentialsMappingService wallet resolution modes", () => {
+
+  const FIN_ID = "02b3e7cbe9b2e91832ea4a11a17a2e30d3cf52dae486ec1e1e3d0741e1f77210ab";
+  const contractMock = () => ({
+    addCredential: jest.fn().mockResolvedValue({ hash: "0x0" }),
+    removeCredential: jest.fn().mockResolvedValue({ hash: "0x0" }),
+    getCredentialAddress: jest.fn().mockResolvedValue(ADDRESS),
+  });
+
+  test("wallet-mapping: writes reach the credentials registry", async () => {
+    const contract = contractMock();
+    const service = new CredentialsMappingService(contract as any, WalletResolutionMode.WalletMapping);
+    await service.saveAccount(FIN_ID, { ledgerAccountId: ADDRESS });
+    await service.deleteAccount(FIN_ID);
+    expect(contract.addCredential).toHaveBeenCalledWith(FIN_ID, ADDRESS);
+    expect(contract.removeCredential).toHaveBeenCalledWith(FIN_ID);
+  });
+
+  test("finId-derivation (demo): writes are no-ops — the registry is disabled", async () => {
+    const contract = contractMock();
+    const service = new CredentialsMappingService(contract as any, WalletResolutionMode.FinIdDerivation);
+    const saved = await service.saveAccount(FIN_ID, { ledgerAccountId: ADDRESS });
+    await service.deleteAccount(FIN_ID);
+    expect(saved).toEqual({ finId: FIN_ID, fields: { ledgerAccountId: ADDRESS } });
+    expect(contract.addCredential).not.toHaveBeenCalled();
+    expect(contract.removeCredential).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Bumps `@owneraio/finp2p-ethereum-orchestrator` to `^0.28.26` and adopts `getWalletResolutionMode()` — read **once at boot** (logged), never per mapping call.

| Mode | Onboarding (`/accounts/create`) | Credentials mapping (`/mapping/owners`) |
|---|---|---|
| `WalletMapping` | bind-existing → `addCredential` + store, as before | writes reach the registry, as before |
| `FinIdDerivation` (demo) | **no-op success** — the contract derives wallets from the finId pubkey; `addCredential` reverts, so nothing is registered or stored | **writes are no-ops**; reads still answer from the registry surface |

Also removed: the **off-chain `finIdToAddress` derivation** in create-new onboarding — dangerous, since only the contract's demo mode legitimately derives wallets. Create-new now rejects with the base NotSupported in `WalletMapping` mode (remaining `finIdToAddress` uses are test fixtures only).

Six mode-driven tests (operation-context 78/78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)