### PR TITLE
Bump hedera-plugin to ^0.28.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.37",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.44",
         "@owneraio/finp2p-ethereum-orchestrator": "^0.28.27",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.27",
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
-      "version": "0.28.37",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.37/1403fbd5b119aadabf85e6f506db76a7bb9151eb",
-      "integrity": "sha512-bzy1aOCjRUKoa34/K4RfwOuzDYqPGYhOT3m3cvJRvfHhZEIjKgrzHDGBqmTUAr727z8x9FJChUaAyQMbMr5JUA==",
+      "version": "0.28.44",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.44/8dc323f9296f6af04a22ecd804573d877db0242f",
+      "integrity": "sha512-lK3e6JONazaaar2cf/vraqDijt++ZNwJTf8G4g1JLpy/0cLNHFWLdITXxTVGRfEKILGmxl21AkAVUqmL1Oqdbw==",
       "dependencies": {
         "ethers": "^6.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.37",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.44",
     "@owneraio/finp2p-ethereum-orchestrator": "^0.28.27",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.27",

--- a/src/services/gas-station/wallet-activation.ts
+++ b/src/services/gas-station/wallet-activation.ts
@@ -22,31 +22,33 @@ export class WalletActivator {
     private readonly amount: string,
   ) {}
 
-  /** @returns true when an activation transfer was sent, false when the address was already active */
-  async ensureActivated(address: string): Promise<boolean> {
+  /** @returns the activation transaction hash, or undefined when the address was already active */
+  async ensureActivated(address: string): Promise<string | undefined> {
     let balance = await this.fundingWallet.provider.getBalance(address);
     if (balance > 0n) {
       logger.info(`Wallet activation: ${address} already active (balance ${balance}), skipping`);
-      return false;
+      return undefined;
     }
 
-    logger.info(`Wallet activation: ${address} has zero balance, sending ${this.amount} to activate`);
+    const from = await this.fundingWallet.signer.getAddress();
+    logger.info(`Wallet activation: ${address} has zero balance, sending ${this.amount} from gas station ${from}`);
+    const started = Date.now();
     const tx = await this.fundingWallet.signer.sendTransaction({
       to: address,
       value: parseEther(this.amount),
     });
-    logger.info(`Wallet activation: activation tx ${tx.hash} submitted for ${address}, polling for on-chain balance`);
+    logger.info(`Wallet activation: tx ${tx.hash} (${from} -> ${address}, ${this.amount}) submitted, polling for on-chain balance`);
 
-    const deadline = Date.now() + GAS_FUNDING_TIMEOUT_MS;
+    const deadline = started + GAS_FUNDING_TIMEOUT_MS;
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, GAS_FUNDING_POLL_INTERVAL_MS));
       balance = await this.fundingWallet.provider.getBalance(address);
       if (balance > 0n) {
-        logger.info(`Wallet activation: ${address} confirmed active on-chain (balance ${balance})`);
-        return true;
+        logger.info(`Wallet activation: tx ${tx.hash} confirmed — ${address} active with balance ${balance} after ${Date.now() - started}ms`);
+        return tx.hash;
       }
     }
-    throw new Error(`Activation transfer to ${address} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms`);
+    throw new Error(`Activation tx ${tx.hash} to ${address} did not reflect on-chain after ${GAS_FUNDING_TIMEOUT_MS}ms`);
   }
 }
 

--- a/src/services/plan-approval/options/wallet-activation-option.ts
+++ b/src/services/plan-approval/options/wallet-activation-option.ts
@@ -37,21 +37,26 @@ export class WalletActivationOption implements PlanApprovalOption {
           instruction.type !== "release") continue;
       if (!instruction.destinationFinId) continue;
 
+      const finId = instruction.destinationFinId;
       let address: string | undefined;
       try {
-        address = await this.accountMapping.resolveAccount(instruction.destinationFinId);
+        address = await this.accountMapping.resolveAccount(finId);
       } catch (e) {
-        logger.warning(`Wallet activation: resolving destination ${instruction.destinationFinId} of plan ${plan.planId} instruction ${instruction.sequence} failed, skipping: ${e}`);
+        logger.warning(`Wallet activation: resolving destination ${finId} of plan ${plan.planId} instruction ${instruction.sequence} failed, skipping: ${e}`);
         continue;
       }
-      if (!address) continue;
+      if (!address) {
+        logger.info(`Wallet activation: destination ${finId} of plan ${plan.planId} instruction ${instruction.sequence} has no mapped address, skipping`);
+        continue;
+      }
 
       try {
-        if (await activator.ensureActivated(address)) {
-          logger.info(`Wallet activation: sent ${this.activationAmount} to ${address} (plan ${plan.planId})`);
+        const txHash = await activator.ensureActivated(address);
+        if (txHash) {
+          logger.info(`Wallet activation: investor ${finId} (${address}) activated with ${this.activationAmount} by tx ${txHash} (plan ${plan.planId}, instruction ${instruction.sequence} ${instruction.type})`);
         }
       } catch (e) {
-        logger.warning(`Wallet activation: touch of ${address} for plan ${plan.planId} instruction ${instruction.sequence} failed: ${e}`);
+        logger.warning(`Wallet activation: activating investor ${finId} (${address}) for plan ${plan.planId} instruction ${instruction.sequence} failed: ${e}`);
       }
     }
   }

--- a/tests/wallet-activation.test.ts
+++ b/tests/wallet-activation.test.ts
@@ -75,6 +75,7 @@ describe("WalletActivationOption", () => {
 
     const provider = { getBalance: async (address: string) => balances[address] ?? 0n };
     const signer = {
+      getAddress: async () => "0xGAS0000000000000000000000000000000000000",
       sendTransaction: async (tx: { to: string; value: bigint }) => {
         if (opts.failFor === tx.to) throw new Error("funding wallet out of funds");
         touches.push(tx);


### PR DESCRIPTION
hedera-plugin 0.28.37 → 0.28.44. The split whitelisting interface, the `WhitelistingMechanism` enum values behind `HEDERA_ATS_WHITELISTING_MECHANISMS`, and `NO_WHITELISTING` are all unchanged (verified against the installed package), so the six-argument construction, the policy env parsing, and the `/investor/whitelist` flows work as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)