### PR TITLE
Pin hedera-plugin 0.28.45-rc.0 for integration testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
         "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
         "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-        "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.44",
+        "@owneraio/finp2p-ethereum-hedera-plugin": "0.28.45-rc.0",
         "@owneraio/finp2p-ethereum-orchestrator": "^0.28.27",
         "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
         "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.27",
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@owneraio/finp2p-ethereum-hedera-plugin": {
-      "version": "0.28.44",
-      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.44/8dc323f9296f6af04a22ecd804573d877db0242f",
-      "integrity": "sha512-lK3e6JONazaaar2cf/vraqDijt++ZNwJTf8G4g1JLpy/0cLNHFWLdITXxTVGRfEKILGmxl21AkAVUqmL1Oqdbw==",
+      "version": "0.28.45-rc.0",
+      "resolved": "https://npm.pkg.github.com/download/@owneraio/finp2p-ethereum-hedera-plugin/0.28.45-rc.0/df7a1b33ef8a6b724a00097404632bcdb5143cc8",
+      "integrity": "sha512-sniySx1A8WtQ12LrOxET6xDIIVzZcx5g+ed0komO2d7wfHGADe7o5slmpL3VSkdV/O/4l/nas0kVStakDzgPkQ==",
       "dependencies": {
         "ethers": "^6.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@owneraio/finp2p-ethereum-collateral": "^0.28.27",
     "@owneraio/finp2p-ethereum-dtcc-plugin": "^0.28.12",
     "@owneraio/finp2p-ethereum-erc20-plugin": "^0.28.6",
-    "@owneraio/finp2p-ethereum-hedera-plugin": "^0.28.44",
+    "@owneraio/finp2p-ethereum-hedera-plugin": "0.28.45-rc.0",
     "@owneraio/finp2p-ethereum-orchestrator": "^0.28.27",
     "@owneraio/finp2p-ethereum-trex-plugin": "^0.28.10",
     "@owneraio/finp2p-nodejs-skeleton-adapter": "^0.28.27",


### PR DESCRIPTION
Exact pin of the rc (prereleases don't match caret ranges). Split whitelisting interface and `WhitelistingMechanism` values verified unchanged against the installed package. Widen to `^0.28.45` when the final ships — merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)